### PR TITLE
added version command + api endpoint

### DIFF
--- a/src/API/HealthcheckController.php
+++ b/src/API/HealthcheckController.php
@@ -60,7 +60,8 @@ class HealthcheckController extends Controller
     {
         $version = [
             'version' => Constants::VERSION,
-            'status' => Constants::STATUS,
+            'candidate' => Constants::STATUS,
+            'semver' => Constants::VERSION . '-' . Constants::STATUS,
             'name' => Constants::NAME,
             'copyright' => 'Kimai 2 - ' . Constants::VERSION . ' ' . Constants::STATUS . ' (' . Constants::NAME . ') by Kevin Papst and contributors.',
         ];

--- a/src/API/HealthcheckController.php
+++ b/src/API/HealthcheckController.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace App\API;
 
+use App\Constants;
 use FOS\RestBundle\Controller\Annotations as Rest;
 use FOS\RestBundle\View\View;
 use FOS\RestBundle\View\ViewHandlerInterface;
@@ -45,5 +46,25 @@ class HealthcheckController extends Controller
         $view = new View(['message' => 'pong'], 200);
 
         return $this->viewHandler->handle($view);
+    }
+
+    /**
+     * @SWG\Response(
+     *     response=200,
+     *     description="Returns version information about the current release",
+     * )
+     *
+     * @Rest\Get(path="/version")
+     */
+    public function versionAction()
+    {
+        $version = [
+            'version' => Constants::VERSION,
+            'status' => Constants::STATUS,
+            'name' => Constants::NAME,
+            'copyright' => 'Kimai 2 - ' . Constants::VERSION . ' ' . Constants::STATUS . ' (' . Constants::NAME . ') by Kevin Papst and contributors.',
+        ];
+
+        return $this->viewHandler->handle(new View($version, 200));
     }
 }

--- a/src/Command/VersionCommand.php
+++ b/src/Command/VersionCommand.php
@@ -31,8 +31,9 @@ class VersionCommand extends Command
             ->setDescription('Receive version information')
             ->setHelp('This command allows you to fetch various version information about Kimai.')
             ->addOption('name', null, InputOption::VALUE_NONE, 'Display the major release name')
-            ->addOption('status', null, InputOption::VALUE_NONE, 'Display the current version status ("stable" or "dev")')
+            ->addOption('candidate', null, InputOption::VALUE_NONE, 'Display the current version candidate (e.g. "stable" or "dev")')
             ->addOption('short', null, InputOption::VALUE_NONE, 'Display the version only')
+            ->addOption('semver', null, InputOption::VALUE_NONE, 'Semantical versioning (SEMVER) compatible version string')
         ;
     }
 
@@ -42,6 +43,12 @@ class VersionCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $io = new SymfonyStyle($input, $output);
+
+        if ($input->getOption('semver')) {
+            $io->writeln(Constants::VERSION . '-' . Constants::STATUS);
+
+            return;
+        }
 
         if ($input->getOption('short')) {
             $io->writeln(Constants::VERSION);
@@ -55,7 +62,7 @@ class VersionCommand extends Command
             return;
         }
 
-        if ($input->getOption('status')) {
+        if ($input->getOption('candidate')) {
             $io->writeln(Constants::STATUS);
 
             return;

--- a/src/Command/VersionCommand.php
+++ b/src/Command/VersionCommand.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Command;
+
+use App\Constants;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Command used to fetch Kimai version information.
+ */
+class VersionCommand extends Command
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('kimai:version')
+            ->setDescription('Receive version information')
+            ->setHelp('This command allows you to fetch various version information about Kimai.')
+            ->addOption('name', null, InputOption::VALUE_NONE, 'Display the major release name')
+            ->addOption('status', null, InputOption::VALUE_NONE, 'Display the current version status ("stable" or "dev")')
+            ->addOption('short', null, InputOption::VALUE_NONE, 'Display the version only')
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        if ($input->getOption('short')) {
+            $io->writeln(Constants::VERSION);
+
+            return;
+        }
+
+        if ($input->getOption('name')) {
+            $io->writeln(Constants::NAME);
+
+            return;
+        }
+
+        if ($input->getOption('status')) {
+            $io->writeln(Constants::STATUS);
+
+            return;
+        }
+
+        $io->writeln('Kimai 2 - ' . Constants::VERSION . ' ' . Constants::STATUS . ' (' . Constants::NAME . ') by Kevin Papst and contributors.');
+    }
+}

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -17,7 +17,7 @@ class Constants
     /**
      * The current release version
      */
-    public const VERSION = '0.5';
+    public const VERSION = 0.5;
     /**
      * The release name
      */

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -15,9 +15,17 @@ namespace App;
 class Constants
 {
     /**
-     * Currently only used for informational purpose in the footer
+     * The current release version
      */
-    public const VERSION = '2.0 dev';
+    public const VERSION = '0.5';
+    /**
+     * The release name
+     */
+    public const NAME = 'Ayumi';
+    /**
+     * The current release status
+     */
+    public const STATUS = 'dev';
     /**
      * Used in multiple views
      */

--- a/src/Migrations/Version20180924111853.php
+++ b/src/Migrations/Version20180924111853.php
@@ -40,6 +40,7 @@ final class Version20180924111853 extends AbstractMigration
             $this->addSql('DROP TABLE __temp__' . $invoiceTemplates);
             $this->addSql('CREATE UNIQUE INDEX UNIQ_1626CFE95E237E06 ON ' . $invoiceTemplates . ' (name)');
         } else {
+            $this->addSql('UPDATE ' . $invoiceTemplates . ' SET name=SUBSTRING(name, 1, 60)');
             $this->addSql('ALTER TABLE ' . $invoiceTemplates . ' CHANGE name name VARCHAR(60) NOT NULL, CHANGE vat vat DOUBLE PRECISION DEFAULT 0');
         }
     }

--- a/templates/sidebar/home.html.twig
+++ b/templates/sidebar/home.html.twig
@@ -1,3 +1,4 @@
+{% set version = constant('App\\Constants::VERSION') ~ ' ' ~ constant('App\\Constants::STATUS') %}
 <ul class="control-sidebar-menu">
     <li>
         <a href="{{ path('help') }}">
@@ -11,9 +12,9 @@
     </li>
 </ul>
 
-<h3 class="control-sidebar-heading">{{ 'home.title'|trans({}, 'sidebar') }}</h3>
+<h3 class="control-sidebar-heading">{{ 'home.title'|trans({'%version%': version}, 'sidebar') }}</h3>
 <div class="form-group">
-    {{ 'home.betainfo'|trans({'%version%': constant('App\\Constants::VERSION'), '%url%': constant('App\\Constants::GITHUB')}, 'sidebar')|raw|nl2br }}
+    {{ 'home.betainfo'|trans({'%version%': version, '%url%': constant('App\\Constants::GITHUB')}, 'sidebar')|raw|nl2br }}
     <br>
     <a href="{{ constant('App\\Constants::GITHUB') }}graphs/contributors">{{ 'made.by.license'|trans({}, 'sidebar')|raw }}</a>
 </div>

--- a/tests/API/HealthcheckControllerTest.php
+++ b/tests/API/HealthcheckControllerTest.php
@@ -9,6 +9,7 @@
 
 namespace App\Tests\API;
 
+use App\Constants;
 use App\Entity\User;
 
 /**
@@ -30,5 +31,27 @@ class HealthcheckControllerTest extends APIControllerBaseTest
 
         $this->assertInternalType('array', $result);
         $this->assertEquals(['message' => 'pong'], $result);
+    }
+
+    public function testVersion()
+    {
+        $client = $this->getClientForAuthenticatedUser(User::ROLE_USER);
+        $this->assertAccessIsGranted($client, '/api/version');
+        $result = json_decode($client->getResponse()->getContent(), true);
+
+        $this->assertInternalType('array', $result);
+
+        $this->assertArrayHasKey('version', $result);
+        $this->assertArrayHasKey('status', $result);
+        $this->assertArrayHasKey('name', $result);
+        $this->assertArrayHasKey('copyright', $result);
+
+        $this->assertEquals(Constants::VERSION, $result['version']);
+        $this->assertEquals(Constants::STATUS, $result['status']);
+        $this->assertEquals(Constants::NAME, $result['name']);
+        $this->assertEquals(
+            'Kimai 2 - ' . Constants::VERSION . ' ' . Constants::STATUS . ' (' . Constants::NAME . ') by Kevin Papst and contributors.',
+            $result['copyright']
+        );
     }
 }

--- a/tests/API/HealthcheckControllerTest.php
+++ b/tests/API/HealthcheckControllerTest.php
@@ -42,12 +42,14 @@ class HealthcheckControllerTest extends APIControllerBaseTest
         $this->assertInternalType('array', $result);
 
         $this->assertArrayHasKey('version', $result);
-        $this->assertArrayHasKey('status', $result);
+        $this->assertArrayHasKey('candidate', $result);
+        $this->assertArrayHasKey('semver', $result);
         $this->assertArrayHasKey('name', $result);
         $this->assertArrayHasKey('copyright', $result);
 
-        $this->assertEquals(Constants::VERSION, $result['version']);
-        $this->assertEquals(Constants::STATUS, $result['status']);
+        $this->assertSame(Constants::VERSION, $result['version']);
+        $this->assertEquals(Constants::STATUS, $result['candidate']);
+        $this->assertEquals(Constants::VERSION . '-' . Constants::STATUS, $result['semver']);
         $this->assertEquals(Constants::NAME, $result['name']);
         $this->assertEquals(
             'Kimai 2 - ' . Constants::VERSION . ' ' . Constants::STATUS . ' (' . Constants::NAME . ') by Kevin Papst and contributors.',

--- a/tests/Command/VersionCommandTest.php
+++ b/tests/Command/VersionCommandTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Command;
+
+use App\Command\VersionCommand;
+use App\Constants;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * @coversDefaultClass \App\Command\VersionCommand
+ * @group integration
+ */
+class VersionCommandTest extends KernelTestCase
+{
+    /**
+     * @var Application
+     */
+    protected $application;
+
+    protected function setUp()
+    {
+        $kernel = self::bootKernel();
+        $this->application = new Application($kernel);
+
+        $this->application->add(new VersionCommand());
+    }
+
+    /**
+     * @dataProvider getTestData
+     */
+    public function testVersion(array $options, $result)
+    {
+        $commandTester = $this->getCommandTester($options);
+        $output = $commandTester->getDisplay();
+        $this->assertEquals($result . PHP_EOL, $output);
+    }
+
+    public function getTestData()
+    {
+        return [
+            [[], 'Kimai 2 - ' . Constants::VERSION . ' ' . Constants::STATUS . ' (' . Constants::NAME . ') by Kevin Papst and contributors.'],
+            [['--short' => true], Constants::VERSION],
+            [['--name' => true], Constants::NAME],
+            [['--status' => true], Constants::STATUS],
+        ];
+    }
+
+    protected function getCommandTester(array $options = [])
+    {
+        $command = $this->application->find('kimai:version');
+        $commandTester = new CommandTester($command);
+        $inputs = array_merge(['command' => $command->getName()], $options);
+        $commandTester->execute($inputs);
+
+        return $commandTester;
+    }
+}

--- a/tests/Command/VersionCommandTest.php
+++ b/tests/Command/VersionCommandTest.php
@@ -48,9 +48,10 @@ class VersionCommandTest extends KernelTestCase
     {
         return [
             [[], 'Kimai 2 - ' . Constants::VERSION . ' ' . Constants::STATUS . ' (' . Constants::NAME . ') by Kevin Papst and contributors.'],
-            [['--short' => true], Constants::VERSION],
             [['--name' => true], Constants::NAME],
-            [['--status' => true], Constants::STATUS],
+            [['--candidate' => true], Constants::STATUS],
+            [['--short' => true], Constants::VERSION],
+            [['--semver' => true], Constants::VERSION . '-' . Constants::STATUS],
         ];
     }
 

--- a/translations/sidebar.de.xliff
+++ b/translations/sidebar.de.xliff
@@ -4,13 +4,13 @@
         <body>
             <trans-unit id="home.title">
                 <source>home.title</source>
-                <target>Kimai v2 - Vorab Version</target>
+                <target>Kimai v2 - %version%</target>
             </trans-unit>
             <trans-unit id="home.betainfo">
                 <source>home.betainfo</source>
                 <target><![CDATA[Danke für die Nutzung der Open-Source Zeiterfassung <a href="%url%" target="_blank">Kimai</a>.
 
-                    Diese neue Version %version% ist aktuell noch in einer frühen Phase der Entwicklung und wurde vorab veröffentlicht, um frühzeitig Rückmeldungen ihrer Benutzer zu sammeln und deren Ideen in die weitere Planung zu integrieren.
+                    Diese neue Version ist aktuell noch in einer frühen Phase der Entwicklung und wurde vorab veröffentlicht, um frühzeitig Rückmeldungen ihrer Benutzer zu sammeln und deren Ideen in die weitere Planung zu integrieren.
 
                     Um bei der Verbesserung von <strong>Kimai</strong> zu helfen, schicken Sie mir bitte eine Nachricht auf der verlinkten Webseite. Egal ob Fragen, Fehlermeldungen oder Ideen für Erweiterungen, Ihr Feedback ist wertvoll!
                 ]]></target>

--- a/translations/sidebar.en.xliff
+++ b/translations/sidebar.en.xliff
@@ -4,13 +4,13 @@
         <body>
             <trans-unit id="home.title">
                 <source>home.title</source>
-                <target>Kimai v2 - Pre-Version</target>
+                <target>Kimai v2 - %version%</target>
             </trans-unit>
             <trans-unit id="home.betainfo">
                 <source>home.betainfo</source>
                 <target><![CDATA[Thank you for using the open source time-tracker <a href="%url%" target="_blank">Kimai</a>.
 
-                    This new version %version% is currently in an early stage of development and has been published in advance to collect feedback from its users and integrate their ideas into further planning.
+                    This new version is currently in an early stage of development and has been published in advance to collect feedback from its users and integrate their ideas into further planning.
 
                     To help me improve <strong>Kimai</strong>, please send your message on the linked website. Whether you have questions, error messages or ideas for enhancements, your feedback is valuable!
                 ]]></target>

--- a/translations/sidebar.es.xliff
+++ b/translations/sidebar.es.xliff
@@ -4,13 +4,13 @@
         <body>
             <trans-unit id="home.title">
                 <source>home.title</source>
-                <target>Kimai v2 - Pre-Version</target>
+                <target>Kimai v2 - %version%</target>
             </trans-unit>
             <trans-unit id="home.betainfo">
                 <source>home.betainfo</source>
                 <target><![CDATA[Gracias por usar el control de tiempo ppen source <a href="%url%" target="_blank">Kimai</a>.
 
-                    Esta nueva versión %version% se encuentra en una etapa inicial de desarrollo y ha sido publicada con la intención de recolectar feedback de los usuarios para incluir sus ideas en planes futuros..
+                    Esta nueva versión se encuentra en una etapa inicial de desarrollo y ha sido publicada con la intención de recolectar feedback de los usuarios para incluir sus ideas en planes futuros..
 
                     Para ayudar a mejorar <strong>Kimai</strong>, por favor enviar sus comentarios al sitio. Sus comentarios, ideas para mejorar o reportes de errores son valiosos y agradezco el tiempo para enviárnoslos!
                 ]]></target>

--- a/translations/sidebar.fr.xliff
+++ b/translations/sidebar.fr.xliff
@@ -4,13 +4,13 @@
         <body>
             <trans-unit id="home.title">
                 <source>home.title</source>
-                <target>Kimai v2 - Pré-version</target>
+                <target>Kimai v2 - %version%</target>
             </trans-unit>
             <trans-unit id="home.betainfo">
                 <source>home.betainfo</source>
                 <target><![CDATA[Merci d'utiliser ce logiciel libre de suivi de temps <a href="%url%" target="_blank">Kimai</a>.
 
-                    Cette nouvelle version %version% est actuellement à un stade précoce de développement et a été publié à l'avance afin de recueillir les commentaires de ses utilisateurs et d'intégrer leurs idées dans la planification à venir. 
+                    Cette nouvelle version est actuellement à un stade précoce de développement et a été publié à l'avance afin de recueillir les commentaires de ses utilisateurs et d'intégrer leurs idées dans la planification à venir.
 
                     Pour m'aider à améliorer<strong>Kimai</strong>, merci de poster votre message sur le site lié. Que vous ayez des questions, des messages ou des idées d'améliorations, vos retours sont précieux ! 
                 ]]></target>

--- a/translations/sidebar.it.xliff
+++ b/translations/sidebar.it.xliff
@@ -4,13 +4,13 @@
         <body>
             <trans-unit id="home.title">
                 <source>home.title</source>
-                <target>Kimai v2 - Pre-Version</target>
+                <target>Kimai v2 - %version%</target>
             </trans-unit>
             <trans-unit id="home.betainfo">
                 <source>home.betainfo</source>
                 <target><![CDATA[Thank you for using the open source time-tracker <a href="%url%" target="_blank">Kimai</a>.
 
-                    This new version %version% is currently in an early stage of development and has been published in advance to collect feedback from its users and integrate their ideas into further planning.
+                    This new version is currently in an early stage of development and has been published in advance to collect feedback from its users and integrate their ideas into further planning.
 
                     To help me improve <strong>Kimai</strong>, please send your message on the linked website. Whether you have questions, error messages or ideas for enhancements, your feedback is valuable!
                 ]]></target>

--- a/translations/sidebar.ru.xliff
+++ b/translations/sidebar.ru.xliff
@@ -4,7 +4,7 @@
         <body>
             <trans-unit id="home.title">
                 <source>home.title</source>
-                <target>Kimai v2 - Предварительная версия</target>
+                <target>Kimai v2 - %version%</target>
             </trans-unit>
             <trans-unit id="home.betainfo">
                 <source>home.betainfo</source>

--- a/var/docs/installation.md
+++ b/var/docs/installation.md
@@ -90,14 +90,14 @@ You just imported demo data, to test the application in its full beauty and with
 
 You can now login with these accounts:
 
-| Username | Password | Role |
-|---|:---:|---|
-| clara_customer | kitten | Customer |
-| john_user | kitten | User |
-| chris_user | kitten | User (deactivated) |
-| tony_teamlead | kitten | Teamlead |
-| anna_admin | kitten | Administrator |
-| susan_super | kitten | Super-Administrator |
+| Username | Password | API Key | Role |
+|---|:---:|:---:|---|
+| clara_customer| kitten | api_kitten |Customer |
+| john_user| kitten | api_kitten |User |
+| chris_user| kitten | api_kitten |User (deactivated) |
+| tony_teamlead| kitten | api_kitten |Teamlead |
+| anna_admin| kitten | api_kitten |Administrator |
+| susan_super| kitten | api_kitten |Super-Administrator |
 
 Demo data can always be deleted by dropping the schema and re-creating it.
 The `kimai:reset-dev` command can always be executed later on to reset your dev database and cache.

--- a/var/docs/internal.md
+++ b/var/docs/internal.md
@@ -6,8 +6,9 @@ Internal documentation for project maintainers
 
 - Prepare a GitHub release-draft
 - Change .github_changelog_generator config accordingly to new release tag (increase future release)
+- Change version constants in `src/Constants.php`
 - Create CHANGELOG.md with [github-changelog-generator](https://github.com/github-changelog-generator/github-changelog-generator]) by running `github_changelog_generator kevinpapst/kimai2`
-- Push a release branch and add it as last PR merge into master
+- Push a release branch and merge it as last PR into master
 - Edit the release-draft and add the "Full changelog" link + everything from CHANGELOG.md related to the new version 
 - Create the release
 - Post a new issue at [YunoHost tracker for Kimai 2](https://github.com/YunoHost-Apps/kimai2_ynh)


### PR DESCRIPTION
Fixes #320 

Adds new API endpoint `/api/version` with example output:
```json
{
    "version": 0.5,
    "candidate": "dev",
    "semver": "0.5-dev",
    "name": "version-name",
    "copyright": "Kimai 2 - 0.5 dev (version-name) by Kevin Papst and contributors."
}
``` 

Adds new command `bin/console kimai:version` with options:
- `--name`
- `--status`
- `--short`

With example outputs:
```bash
$ bin/console kimai:version
Kimai 2 - 0.5 dev (version-name) by Kevin Papst and contributors.

$ bin/console kimai:version --short
0.5

$ bin/console kimai:version --candidate
dev

$ bin/console kimai:version --semver
0.5-dev

$ bin/console kimai:version --name
version-name
```

ping @anmol26s / @bastilimbach maybe interesting for you?