### PR TITLE
invoice VAT as float and database key length

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -39,6 +39,7 @@
             <directory suffix=".php">src/</directory>
             <directory suffix=".php">templates/</directory>
             <exclude>
+                <directory suffix=".php">src/Migrations/</directory>
                 <directory suffix=".php">assets/</directory>
                 <directory suffix=".php">bin/</directory>
                 <directory suffix=".php">config/</directory>

--- a/src/Entity/InvoiceTemplate.php
+++ b/src/Entity/InvoiceTemplate.php
@@ -37,8 +37,9 @@ class InvoiceTemplate
     /**
      * @var string
      *
-     * @ORM\Column(name="name", type="string", length=255, nullable=false)
+     * @ORM\Column(name="name", type="string", length=60, nullable=false)
      * @Assert\NotBlank()
+     * @Assert\Length(min=1, max=60)
      */
     private $name;
 
@@ -76,8 +77,8 @@ class InvoiceTemplate
     /**
      * @var float
      *
-     * @ORM\Column(name="vat", type="integer", length=2, nullable=true)
-     * @Assert\Range(min = 0, max = 99)
+     * @ORM\Column(name="vat", type="float", default=0, nullable=false)
+     * @Assert\Range(min = 0.0, max = 99.99)
      */
     private $vat = 0.00;
 

--- a/src/Entity/InvoiceTemplate.php
+++ b/src/Entity/InvoiceTemplate.php
@@ -77,7 +77,7 @@ class InvoiceTemplate
     /**
      * @var float
      *
-     * @ORM\Column(name="vat", type="float", default=0, nullable=false)
+     * @ORM\Column(name="vat", type="float", nullable=false)
      * @Assert\Range(min = 0.0, max = 99.99)
      */
     private $vat = 0.00;

--- a/src/Form/InvoiceTemplateForm.php
+++ b/src/Form/InvoiceTemplateForm.php
@@ -14,7 +14,7 @@ use App\Form\Type\InvoiceCalculatorType;
 use App\Form\Type\InvoiceNumberGeneratorType;
 use App\Form\Type\InvoiceRendererType;
 use Symfony\Component\Form\AbstractType;
-use Symfony\Component\Form\Extension\Core\Type\PercentType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -51,9 +51,9 @@ class InvoiceTemplateForm extends AbstractType
             ->add('dueDays', TextType::class, [
                 'label' => 'label.due_days',
             ])
-            ->add('vat', PercentType::class, [
+            ->add('vat', NumberType::class, [
                 'label' => 'label.vat',
-                'type' => 'integer',
+                'scale' => 2,
             ])
             ->add('renderer', InvoiceRendererType::class, [])
             ->add('calculator', InvoiceCalculatorType::class, [])

--- a/src/Migrations/Version20180924111853.php
+++ b/src/Migrations/Version20180924111853.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace DoctrineMigrations;
+
+use App\Doctrine\AbstractMigration;
+use Doctrine\DBAL\Schema\Schema;
+
+/**
+ * Changes the invoice templates table for:
+ * - shorter template name and proper index name
+ * - VAT supporting percentages
+ */
+final class Version20180924111853 extends AbstractMigration
+{
+    public function up(Schema $schema): void
+    {
+        $platform = $this->getPlatform();
+
+        if (!in_array($platform, ['sqlite', 'mysql'])) {
+            $this->abortIf(true, 'Unsupported database platform: ' . $platform);
+        }
+
+        $invoiceTemplates = $this->getTableName('invoice_templates');
+
+        if ($platform === 'sqlite') {
+            $this->addSql('DROP INDEX UNIQ_1626CFE95E237E06');
+            $this->addSql('CREATE TEMPORARY TABLE __temp__' . $invoiceTemplates . ' AS SELECT id, name, title, company, address, due_days, vat, calculator, number_generator, renderer, payment_terms FROM ' . $invoiceTemplates);
+            $this->addSql('DROP TABLE ' . $invoiceTemplates);
+            $this->addSql('CREATE TABLE ' . $invoiceTemplates . ' (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, title VARCHAR(255) NOT NULL COLLATE BINARY, company VARCHAR(255) NOT NULL COLLATE BINARY, address CLOB DEFAULT NULL COLLATE BINARY, due_days INTEGER NOT NULL, calculator VARCHAR(20) NOT NULL COLLATE BINARY, number_generator VARCHAR(20) NOT NULL COLLATE BINARY, renderer VARCHAR(20) NOT NULL COLLATE BINARY, payment_terms CLOB DEFAULT NULL COLLATE BINARY, name VARCHAR(60) NOT NULL, vat DOUBLE PRECISION DEFAULT 0)');
+            $this->addSql('INSERT INTO ' . $invoiceTemplates . ' (id, name, title, company, address, due_days, vat, calculator, number_generator, renderer, payment_terms) SELECT id, name, title, company, address, due_days, vat, calculator, number_generator, renderer, payment_terms FROM __temp__' . $invoiceTemplates);
+            $this->addSql('DROP TABLE __temp__' . $invoiceTemplates);
+            $this->addSql('CREATE UNIQUE INDEX UNIQ_1626CFE95E237E06 ON ' . $invoiceTemplates . ' (name)');
+        } else {
+            $this->addSql('ALTER TABLE ' . $invoiceTemplates . ' CHANGE name name VARCHAR(60) NOT NULL, CHANGE vat vat DOUBLE PRECISION DEFAULT 0');
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $platform = $this->getPlatform();
+
+        if (!in_array($platform, ['sqlite', 'mysql'])) {
+            $this->abortIf(true, 'Unsupported database platform: ' . $platform);
+        }
+
+        $invoiceTemplates = $this->getTableName('invoice_templates');
+
+        if ($platform === 'sqlite') {
+            $this->addSql('DROP INDEX UNIQ_1626CFE95E237E06');
+            $this->addSql('CREATE TEMPORARY TABLE __temp__' . $invoiceTemplates . ' AS SELECT id, name, title, company, address, due_days, vat, calculator, number_generator, renderer, payment_terms FROM ' . $invoiceTemplates);
+            $this->addSql('DROP TABLE ' . $invoiceTemplates);
+            $this->addSql('CREATE TABLE ' . $invoiceTemplates . ' (id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, title VARCHAR(255) NOT NULL, company VARCHAR(255) NOT NULL, address CLOB DEFAULT NULL, due_days INTEGER NOT NULL, calculator VARCHAR(20) NOT NULL, number_generator VARCHAR(20) NOT NULL, renderer VARCHAR(20) NOT NULL, payment_terms CLOB DEFAULT NULL, name VARCHAR(255) NOT NULL COLLATE BINARY, vat INTEGER DEFAULT NULL)');
+            $this->addSql('INSERT INTO ' . $invoiceTemplates . ' (id, name, title, company, address, due_days, vat, calculator, number_generator, renderer, payment_terms) SELECT id, name, title, company, address, due_days, vat, calculator, number_generator, renderer, payment_terms FROM __temp__' . $invoiceTemplates);
+            $this->addSql('DROP TABLE __temp__' . $invoiceTemplates);
+            $this->addSql('CREATE UNIQUE INDEX UNIQ_1626CFE95E237E06 ON ' . $invoiceTemplates . ' (name)');
+        } else {
+            $this->addSql('ALTER TABLE ' . $invoiceTemplates . ' CHANGE name name VARCHAR(255) NOT NULL COLLATE utf8mb4_unicode_ci, CHANGE vat vat INT DEFAULT NULL');
+        }
+    }
+}


### PR DESCRIPTION
Change VAT in InvoiceTemplate to a float, so we can use non-integer values as tax-rate.

Decrease InvoiceTemplate name from 255 to 60 characters. 
This should fix the `Specified key was too long; max key length is 767 bytes` error.

- was first reported in #285 
- fixes #322