### PR TITLE
updated the documentation, reflecting the changes in #306

### DIFF
--- a/var/docs/developers.md
+++ b/var/docs/developers.md
@@ -186,6 +186,30 @@ otherwise they might get lost during an update.
 
 In the config `kimai.invoice.documents`, you can add a list of directories with the locations of your invoice document templates ([read more](invoices.md)).
 
+## Adding invoice calculator
+
+An invoice calculator is a class extending `App\Invoice\CalculatorInterface` and is responsible for calculating 
+invoice rates, taxes and taking care of all timesheet entries that should be displayed.   
+
+Every invoice calculator class will be picked up when refreshing the application cache by the [InvoiceServiceCompilerPass](https://github.com/kevinpapst/kimai2/blob/master/src/DependencyInjection/Compiler/InvoiceServiceCompilerPass.php):
+
+The ID of the calculator must be unique, please prefix it with your vendor or bundle name and make sure it only contains
+character as it will be stored in a database column.
+
+Translations are stored in the `invoice-calculator.xx.xliff`.
+
+## Adding invoice-number generator
+
+An invoice-number generator is a class extending `App\Invoice\NumberGeneratorInterface` and its only task is to generate 
+a number for the invoice. In most cases you do not want to mix multiple invoice-number generators throughout your invoices.   
+
+Every invoice number-generator class will be picked up when refreshing the application cache by the [InvoiceServiceCompilerPass](https://github.com/kevinpapst/kimai2/blob/master/src/DependencyInjection/Compiler/InvoiceServiceCompilerPass.php):
+
+The ID of the number generator must be unique, please prefix it with your vendor or bundle name and make sure it only contains
+character as it will be stored in a database column.
+
+Translations are stored in the `invoice-numbergenerator.xx.xliff`.
+
 ## Adding timesheet calculator
 
 A timesheet calculator will be called on stopped timesheet records. It can rewrite all values but will normally take care 

--- a/var/docs/developers.md
+++ b/var/docs/developers.md
@@ -182,56 +182,9 @@ Both follow the default naming syntax and you can link your bundle here instead 
 You should NOT add them in `config/packages/kimai.yaml` but in your own bundle or the `local.yaml` [config](configurations.md), 
 otherwise they might get lost during an update.
 
-## Adding invoice renderer (FIXME)
+## Adding documents for invoice rendering 
 
-An invoice renderer is a controller action that receives an instanceof `App\Model\InvoiceModel` and returns a HTML response.
-This HTML response is the preview inside for the invoice screen. 
-
-Adding invoice renderer can be achieved by adding keys to the configuration `kimai.invoice.renderer` like this:
-
-```
-kimai:
-    invoice:
-        renderer:
-            default: 'App\Controller\InvoiceController::invoiceAction'
-```
-
-The name of the renderer must be unique, please prefix it with your vendor or bundle name and make sure it only contains
-character as it will be stored in a database column.
-
-## Adding invoice calculator (FIXME)
-
-An invoice calculator is a class extending `App\Invoice\CalculatorInterface` and is responsible for calculating 
-invoice rates, taxes and such.   
-
-Adding invoice calculator can be achieved by adding keys to the configuration `kimai.invoice.calculator` like this:
-
-```
-kimai:
-    invoice:
-        calculator:
-            default: 'App\Invoice\DefaultCalculator'
-```
-
-The name of the calculator must be unique, please prefix it with your vendor or bundle name and make sure it only contains
-character as it will be stored in a database column.
-
-## Adding invoice-number generator (FIXME)
-
-An invoice-number generator is a class extending `App\Invoice\NumberGeneratorInterface` and its only task is to generate 
-a number for the invoice. In most cases you do not want to mix multiple invoice-number generators througout your invoice templates.   
-
-Adding invoice-number generator can be achieved by adding keys to the configuration `kimai.invoice.number_generator` like this:
-
-```
-kimai:
-    invoice:
-        number_generator:
-            default: 'App\Invoice\DateNumberGenerator'
-```
-
-The name of the number generator must be unique, please prefix it with your vendor or bundle name and make sure it only contains
-character as it will be stored in a database column.
+In the config `kimai.invoice.documents`, you can add a list of directories with the locations of your invoice document templates ([read more](invoices.md)).
 
 ## Adding timesheet calculator
 

--- a/var/docs/translations.md
+++ b/var/docs/translations.md
@@ -12,7 +12,10 @@ The files in `translations/` as a quick overview:
 - `messages` holds most of the visible application translations (like all the static UI elements and form translations)
 - `pagerfanta` includes the translations for the pagination component
 - `sidebar` holds all the translations of the right sidebar
-- `validators` only hold translations related to violations/validation of submitted form data (or API calls)
+- `validators` only holds translations related to violations/validation of submitted form data (or API calls)
+- `invoice-calculator` holds translations of calculator types (see `Adding invoice calculator` in [developers](developers.md)-section)
+- `invoice-numbergenerator` holds translations of the invoice calculator (see `Adding invoice-number generator ` in [developers](developers.md)-section)
+- `invoice-renderer` holds translations of all invoice templates ([read more](invoices.md))
 
 ## Adding a new language
 


### PR DESCRIPTION
## Description
Missing documentation updates in the developers-section about the `kimai.invoice.documens` and removed parts for `renderer`, `calculator` and `number_generator`

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My code follows the code style
- [ ] All files have a license header 
- [ ] All methods have a doc header with type declarations
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
