### PR TITLE
Update dockerfile for https in composer installer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ FROM php:7.2.9-apache-stretch
 
 WORKDIR /opt/kimai
 
-RUN php -r "readfile('http://getcomposer.org/installer');" | php -- --install-dir=/usr/bin/ --filename=composer && \
+RUN php -r "readfile('https://getcomposer.org/installer');" | php -- --install-dir=/usr/bin/ --filename=composer && \
     apt update && \
     apt install -y \
         git \


### PR DESCRIPTION
## Description
Composer is being installed from an http link. This should be changed to https, especially with the installer not being verified, to help prevent MITM issues.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
