### PR TITLE
preg_replace for md-file-extensions when rendering correct link…

### DIFF
--- a/src/Controller/HelpController.php
+++ b/src/Controller/HelpController.php
@@ -60,6 +60,8 @@ class HelpController extends AbstractController
 
         $content = file_get_contents($chapterFile);
 
+        $content = preg_replace('/\[(.+)\]\(([\w\-\/]+)(\.md)(\#[\w\-]+){0,1}\)/i', '[$1]($2$4)', $content);
+
         return $this->render('help/index.html.twig', [
             'breadcrumb' => $breadcrumb,
             'chapter' => $chapter,

--- a/templates/help/index.html.twig
+++ b/templates/help/index.html.twig
@@ -6,7 +6,6 @@
 {% block main %}
 
     {% set replacer = {
-        '.md"': '"',
         '<table>': '<table class="table">',
         'href="../../': 'target="_blank" href="'~github~'blob/master/',
         ('href="' ~ github): 'target="_blank" href="'~github


### PR DESCRIPTION
Contribution to #388

## Description

Adds the replacement-method for links to `.md` files with anchor (see https://github.com/kevinpapst/kimai2/issues/388#issuecomment-441400676).

This was not possible with the twig `replace()` function, detailed description in https://github.com/kevinpapst/kimai2/issues/388#issuecomment-441372534

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows the code style
- [x] All files have a license header 
- [x] All methods have a doc header with type declarations
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
