### PR TITLE
validation for future and negative times

### DIFF
--- a/src/Entity/Timesheet.php
+++ b/src/Entity/Timesheet.php
@@ -25,6 +25,7 @@ use Symfony\Component\Validator\Context\ExecutionContextInterface;
  * )
  * @ORM\Entity(repositoryClass="App\Repository\TimesheetRepository")
  * @ORM\HasLifecycleCallbacks()
+ * @Assert\Callback("validate")
  */
 class Timesheet
 {
@@ -163,9 +164,9 @@ class Timesheet
     {
         $this->end = $end;
 
-        // FIXME test and then remove it, this should not be neccessary
         if (null === $end) {
             $this->duration = 0;
+            $this->rate = 0;
         }
 
         return $this;
@@ -345,12 +346,8 @@ class Timesheet
     }
 
     /**
-     * These validations are used in places, where we don't use a form yet (like the API).
-     *
      * @param ExecutionContextInterface $context
-     * @param mixed $payload
-     *
-     * @Assert\Callback
+     * @param $payload
      */
     public function validate(ExecutionContextInterface $context, $payload)
     {
@@ -411,5 +408,13 @@ class Timesheet
                 ->setTranslationDomain('validators')
                 ->addViolation();
         }
+
+        if (time() < $this->getBegin()->getTimestamp()) {
+            $context->buildViolation('The begin date cannot be in the future.')
+                ->atPath('begin')
+                ->setTranslationDomain('validators')
+                ->addViolation();
+        }
+
     }
 }

--- a/src/Timesheet/Calculator/RateCalculator.php
+++ b/src/Timesheet/Calculator/RateCalculator.php
@@ -38,6 +38,7 @@ class RateCalculator implements CalculatorInterface
     public function calculate(Timesheet $record)
     {
         if (null === $record->getEnd()) {
+            $record->setRate(0);
             return;
         }
 

--- a/src/Twig/Extensions.php
+++ b/src/Twig/Extensions.php
@@ -196,6 +196,10 @@ class Extensions extends \Twig_Extension
             }
         }
 
+        if ($seconds < 0) {
+            return '?';
+        }
+
         $locale = $this->getLocale();
         switch ($format) {
             case 'full':

--- a/tests/Invoice/Calculator/ActivityInvoiceCalculatorTest.php
+++ b/tests/Invoice/Calculator/ActivityInvoiceCalculatorTest.php
@@ -47,6 +47,8 @@ class ActivityInvoiceCalculatorTest extends AbstractCalculatorTest
 
         $timesheet = new Timesheet();
         $timesheet
+            ->setBegin(new \DateTime())
+            ->setEnd(new \DateTime())
             ->setDuration(3600)
             ->setRate(293.27)
             ->setUser($user)
@@ -55,6 +57,8 @@ class ActivityInvoiceCalculatorTest extends AbstractCalculatorTest
 
         $timesheet2 = new Timesheet();
         $timesheet2
+            ->setBegin(new \DateTime())
+            ->setEnd(new \DateTime())
             ->setDuration(400)
             ->setRate(84.75)
             ->setUser($user)
@@ -63,6 +67,8 @@ class ActivityInvoiceCalculatorTest extends AbstractCalculatorTest
 
         $timesheet3 = new Timesheet();
         $timesheet3
+            ->setBegin(new \DateTime())
+            ->setEnd(new \DateTime())
             ->setDuration(1800)
             ->setRate(111.11)
             ->setUser($user)
@@ -71,6 +77,8 @@ class ActivityInvoiceCalculatorTest extends AbstractCalculatorTest
 
         $timesheet4 = new Timesheet();
         $timesheet4
+            ->setBegin(new \DateTime())
+            ->setEnd(new \DateTime())
             ->setDuration(400)
             ->setRate(1947.99)
             ->setUser($user)
@@ -79,6 +87,8 @@ class ActivityInvoiceCalculatorTest extends AbstractCalculatorTest
 
         $timesheet5 = new Timesheet();
         $timesheet5
+            ->setBegin(new \DateTime())
+            ->setEnd(new \DateTime())
             ->setDuration(400)
             ->setRate(84)
             ->setUser(new User())

--- a/tests/Invoice/Calculator/UserInvoiceCalculatorTest.php
+++ b/tests/Invoice/Calculator/UserInvoiceCalculatorTest.php
@@ -47,6 +47,8 @@ class UserInvoiceCalculatorTest extends AbstractCalculatorTest
 
         $timesheet = new Timesheet();
         $timesheet
+            ->setBegin(new \DateTime())
+            ->setEnd(new \DateTime())
             ->setDuration(3600)
             ->setRate(293.27)
             ->setUser($user1)
@@ -55,6 +57,8 @@ class UserInvoiceCalculatorTest extends AbstractCalculatorTest
 
         $timesheet2 = new Timesheet();
         $timesheet2
+            ->setBegin(new \DateTime())
+            ->setEnd(new \DateTime())
             ->setDuration(400)
             ->setRate(84.75)
             ->setUser($user2)
@@ -63,6 +67,8 @@ class UserInvoiceCalculatorTest extends AbstractCalculatorTest
 
         $timesheet3 = new Timesheet();
         $timesheet3
+            ->setBegin(new \DateTime())
+            ->setEnd(new \DateTime())
             ->setDuration(1800)
             ->setRate(111.11)
             ->setUser($user1)
@@ -71,6 +77,8 @@ class UserInvoiceCalculatorTest extends AbstractCalculatorTest
 
         $timesheet4 = new Timesheet();
         $timesheet4
+            ->setBegin(new \DateTime())
+            ->setEnd(new \DateTime())
             ->setDuration(400)
             ->setRate(1947.99)
             ->setUser($user2)
@@ -79,6 +87,8 @@ class UserInvoiceCalculatorTest extends AbstractCalculatorTest
 
         $timesheet5 = new Timesheet();
         $timesheet5
+            ->setBegin(new \DateTime())
+            ->setEnd(new \DateTime())
             ->setDuration(400)
             ->setRate(84)
             ->setUser(new User())

--- a/tests/Twig/ExtensionsTest.php
+++ b/tests/Twig/ExtensionsTest.php
@@ -160,6 +160,14 @@ class ExtensionsTest extends TestCase
         // test fallback format
         $sut = $this->getSut($this->localeEn, 'XX');
         $this->assertEquals('02:37 h', $sut->duration($record->getDuration()));
+
+        // test negative duratiobn
+        $sut = $this->getSut($this->localeEn, 'XX');
+        $this->assertEquals('?', $sut->duration('-1'));
+
+        // test zero duration
+        $sut = $this->getSut($this->localeEn, 'XX');
+        $this->assertEquals('00:00 h', $sut->duration('0'));
     }
 
     protected function getTimesheet($seconds)


### PR DESCRIPTION
- Disallow starting records in the future
- Set rate to zero if end date is empty or clear rate if an entry is re-started
- Prevent negative duration display in timesheets
- Allow to edit existing entries with negative duration

Fixes #511 