### PR TITLE
Added more php requirements to documentation

### DIFF
--- a/var/docs/developers.md
+++ b/var/docs/developers.md
@@ -6,7 +6,12 @@ This page is dedicated to all developers who want to contribute to Kimai. You ar
 
 All you need is:
 - PHP >= 7.1.3
-- PHP extensions: `PDO-SQLite`, `intl` and `zip`
+- PHP extensions: `PDO-SQLite`, `intl`, `zip`, `gd`, `mbstring`, `xml`
+
+You can install php 7.2 and all dependencies on debian based linux with this command: 
+```
+apt install php7.2 php7.2-sqlite3 php7.2-intl php7.2-zip php7.2-xml
+```
 
 Optional requirement:
 - a MySQL/MariaDB instance

--- a/var/docs/developers.md
+++ b/var/docs/developers.md
@@ -10,7 +10,7 @@ All you need is:
 
 You can install php 7.2 and all dependencies on debian based linux with this command: 
 ```
-apt install php7.2 php7.2-sqlite3 php7.2-intl php7.2-zip php7.2-xml
+apt install php7.2 php7.2-sqlite3 php7.2-intl php7.2-zip php7.2-gd php7.2-mbstring php7.2-xml 
 ```
 
 Optional requirement:


### PR DESCRIPTION
## Description
I just installed kimai on a fresh install Ubuntu 18.04 on WSL on Win10, and when I ran `composer install` I got a lot of problems, which was solvable by installing other php extensions. These extensions wasn't listed on developement doc, nor in the installation doc, so I added them, so it's easier to install for those not that familiar with php.

Maybe this should be added for the installation doc as well, but I guess on running production servers this extensions would be installed already, that' why they wasn't included in the docs yet.

Here is the terminal output what it shows when I first run composer install without installing these other extensions, just those in the developers.md:

```
$ composer install
Deprecation warning: require.beberlei/DoctrineExtensions is invalid, it should not contain uppercase characters. Please use beberlei/doctrineextensions instead. Make sure you fix this as Composer 2.0 will error.
Loading composer repositories with package information
Installing dependencies (including require-dev) from lock file
Warning: The lock file is not up to date with the latest changes in composer.json. You may be getting outdated dependencies. Run update to update them.
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - The requested PHP extension ext-gd * is missing from your system. Install or enable PHP's gd extension.
  Problem 2
    - The requested PHP extension ext-mbstring * is missing from your system. Install or enable PHP's mbstring extension.
  Problem 3
    - Installation request for erusev/parsedown 1.7.1 -> satisfiable by erusev/parsedown[1.7.1].
    - erusev/parsedown 1.7.1 requires ext-mbstring * -> the requested PHP extension mbstring is missing from your system.
  Problem 4
    - Installation request for mpdf/mpdf v7.1.8 -> satisfiable by mpdf/mpdf[v7.1.8].
    - mpdf/mpdf v7.1.8 requires ext-gd * -> the requested PHP extension gd is missing from your system.
  Problem 5
    - Installation request for phpoffice/phpspreadsheet 1.4.1 -> satisfiable by phpoffice/phpspreadsheet[1.4.1].
    - phpoffice/phpspreadsheet 1.4.1 requires ext-dom * -> the requested PHP extension dom is missing from your system.
  Problem 6
    - Installation request for phpoffice/phpword 0.15.0 -> satisfiable by phpoffice/phpword[0.15.0].
    - phpoffice/phpword 0.15.0 requires ext-xml * -> the requested PHP extension xml is missing from your system.
  Problem 7
    - Installation request for symfony/debug-bundle v4.1.6 -> satisfiable by symfony/debug-bundle[v4.1.6].
    - symfony/debug-bundle v4.1.6 requires ext-xml * -> the requested PHP extension xml is missing from your system.
  Problem 8
    - Installation request for symfony/framework-bundle v4.1.6 -> satisfiable by symfony/framework-bundle[v4.1.6].
    - symfony/framework-bundle v4.1.6 requires ext-xml * -> the requested PHP extension xml is missing from your system.  Problem 9
    - Installation request for symfony/security-bundle v4.1.6 -> satisfiable by symfony/security-bundle[v4.1.6].
    - symfony/security-bundle v4.1.6 requires ext-xml * -> the requested PHP extension xml is missing from your system.
  Problem 10
    - Installation request for phar-io/manifest 1.0.3 -> satisfiable by phar-io/manifest[1.0.3].
    - phar-io/manifest 1.0.3 requires ext-dom * -> the requested PHP extension dom is missing from your system.
  Problem 11
    - Installation request for phpunit/php-code-coverage 6.0.8 -> satisfiable by phpunit/php-code-coverage[6.0.8].
    - phpunit/php-code-coverage 6.0.8 requires ext-dom * -> the requested PHP extension dom is missing from your system.  Problem 12
    - Installation request for phpunit/phpunit 7.4.0 -> satisfiable by phpunit/phpunit[7.4.0].
    - phpunit/phpunit 7.4.0 requires ext-dom * -> the requested PHP extension dom is missing from your system.
  Problem 13
    - Installation request for squizlabs/php_codesniffer 3.3.2 -> satisfiable by squizlabs/php_codesniffer[3.3.2].
    - squizlabs/php_codesniffer 3.3.2 requires ext-simplexml * -> the requested PHP extension simplexml is missing from your system.
  Problem 14
    - Installation request for theseer/tokenizer 1.1.0 -> satisfiable by theseer/tokenizer[1.1.0].
    - theseer/tokenizer 1.1.0 requires ext-dom * -> the requested PHP extension dom is missing from your system.
  Problem 15
    - symfony/framework-bundle v4.1.6 requires ext-xml * -> the requested PHP extension xml is missing from your system.    - white-october/pagerfanta-bundle v1.2.2 requires symfony/framework-bundle ~2.3|~3.0|~4.0 -> satisfiable by symfony/framework-bundle[v4.1.6].
    - Installation request for white-october/pagerfanta-bundle v1.2.2 -> satisfiable by white-october/pagerfanta-bundle[v1.2.2].

  To enable extensions, verify that they are enabled in your .ini files:
    - /etc/php/7.2/cli/php.ini
    - /etc/php/7.2/cli/conf.d/10-opcache.ini
    - /etc/php/7.2/cli/conf.d/10-pdo.ini
    - /etc/php/7.2/cli/conf.d/20-calendar.ini
    - /etc/php/7.2/cli/conf.d/20-ctype.ini
    - /etc/php/7.2/cli/conf.d/20-exif.ini
    - /etc/php/7.2/cli/conf.d/20-fileinfo.ini
    - /etc/php/7.2/cli/conf.d/20-ftp.ini
    - /etc/php/7.2/cli/conf.d/20-gettext.ini
    - /etc/php/7.2/cli/conf.d/20-iconv.ini
    - /etc/php/7.2/cli/conf.d/20-intl.ini
    - /etc/php/7.2/cli/conf.d/20-json.ini
    - /etc/php/7.2/cli/conf.d/20-pdo_sqlite.ini
    - /etc/php/7.2/cli/conf.d/20-phar.ini
    - /etc/php/7.2/cli/conf.d/20-posix.ini
    - /etc/php/7.2/cli/conf.d/20-readline.ini
    - /etc/php/7.2/cli/conf.d/20-shmop.ini
    - /etc/php/7.2/cli/conf.d/20-sockets.ini
    - /etc/php/7.2/cli/conf.d/20-sqlite3.ini
    - /etc/php/7.2/cli/conf.d/20-sysvmsg.ini
    - /etc/php/7.2/cli/conf.d/20-sysvsem.ini
    - /etc/php/7.2/cli/conf.d/20-sysvshm.ini
    - /etc/php/7.2/cli/conf.d/20-tokenizer.ini
    - /etc/php/7.2/cli/conf.d/20-zip.ini
  You can also run `php --ini` inside terminal to see which files are used by PHP in CLI mode.
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] My code follows the code style
- [ ] All files have a license header 
- [ ] All methods have a doc header with type declarations
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
