### PR TITLE
Support foreign keys with SQLite

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -78,6 +78,12 @@ services:
             - { name: doctrine.event_listener, event: prePersist, lazy: true }
             - { name: doctrine.event_listener, event: preUpdate, lazy: true }
 
+    # make sure, that sqlite supports foreign keys and cascade deletes
+    App\Doctrine\SqliteSessionInitSubscriber:
+        class: App\Doctrine\SqliteSessionInitSubscriber
+        tags:
+            - { name: doctrine.event_listener, event: postConnect }
+
     # ================================================================================
     # FORMS
     # ================================================================================

--- a/src/Doctrine/SqliteSessionInitSubscriber.php
+++ b/src/Doctrine/SqliteSessionInitSubscriber.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Doctrine;
+
+use Doctrine\Common\EventSubscriber;
+use Doctrine\DBAL\Event\ConnectionEventArgs;
+use Doctrine\DBAL\Events;
+
+class SqliteSessionInitSubscriber implements EventSubscriber
+{
+    /**
+     * @param ConnectionEventArgs $args
+     * @throws \Doctrine\DBAL\DBALException
+     */
+    public function postConnect(ConnectionEventArgs $args)
+    {
+        if ('sqlite' !== strtolower($args->getDatabasePlatform()->getName())) {
+            return;
+        }
+        $args->getConnection()->executeUpdate('PRAGMA foreign_keys = ON;');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSubscribedEvents()
+    {
+        return [Events::postConnect];
+    }
+}

--- a/var/docs/faq.md
+++ b/var/docs/faq.md
@@ -43,13 +43,6 @@ Further readings:
 - [MariaDB - JSON support was added with 10.2.7](https://mariadb.com/kb/en/library/json-data-type/)
 - [Using JSON fields with Doctrine ORM on PostgreSQL & MySQL](https://symfony.fi/entry/using-json-fields-with-doctrine-orm-on-postgresql-mysql)
 
-## SQLite not recommended for production usage
-
-SQLite is a great database engine for testing, but when it comes to production usage it fails due to several reasons:
-
-- It does not support ALTER TABLE commands and makes update procedures very clunky and problematic (we still try to support updates, but they are heavy on large databases)
-- It does not support FOREIGN KEY constraints [out of the box](https://www.sqlite.org/foreignkeys.html#fk_enable), which can lead to critical bugs when deleting users/activities/projects/customers 
-
 ## Dotenv::populate() must be an instance of Symfony\\Component\\Dotenv\\void
 
 If you encounter an error like this:

--- a/var/docs/installation.md
+++ b/var/docs/installation.md
@@ -29,7 +29,7 @@ chmod -R g+rw var/
 cp .env.dist .env
 ```
 
-It's up to you which database server you want to use, Kimai v2 supports MySQL/MariaDB and SQLite, but SQLite is [not recommended](faq.md) for production usage.
+It's up to you which database server you want to use, Kimai v2 supports MySQL/MariaDB and SQLite (SQLite is [not recommended](faq.md) for production usage).
 Configure the database connection string in your the `.env` file:
 ```
 # adjust all settings in .env to your needs
@@ -208,6 +208,16 @@ npm run prod
 ```
 
 ## FAQ and common problems
+
+## SQLite not recommended for production usage
+
+SQLite is a great database engine for testing, but when it comes to production usage it is imperfect due to several reasons:
+
+- It does not support ALTER TABLE commands and makes update procedures very clunky and problematic (we still try to support updates, but they are heavy on large databases)
+- It does [not support FOREIGN KEY](https://www.sqlite.org/quirks.html#foreign_key_enforcement_is_off_by_default) constraints [out of the box](https://www.sqlite.org/foreignkeys.html#fk_enable), which can lead to critical bugs when deleting users/activities/projects/customers
+
+Kimai works around the Foreign Keys issue by using a [Doctrine PostConnect EventSubscriber]({{ site.kimai_v2_file }}/src/Doctrine/SqliteSessionInitSubscriber.php) since v0.8.1, 
+but it is not guaranteed that SQLite handles everything as expected.
 
 ### Malformed parameter "url"
 

--- a/var/docs/installation.md
+++ b/var/docs/installation.md
@@ -29,13 +29,13 @@ chmod -R g+rw var/
 cp .env.dist .env
 ```
 
-It's up to you which database server you want to use, Kimai v2 supports MySQL/MariaDB and SQLite (SQLite is [not recommended](faq.md) for production usage).
-Configure the database connection string in your the `.env` file:
+Configure the database connection string in your the `.env` file (Kimai v2 supports MySQL/MariaDB and SQLite):
 ```
 # adjust all settings in .env to your needs
 APP_ENV=prod
 DATABASE_URL=mysql://user:password@127.0.0.1:3306/database
 ```
+SQLite is not recommended for production usage, check FAQ below. 
 
 Now install all dependencies for Kimai 2:
 ```bash


### PR DESCRIPTION
Fixes #589

There is now a Doctrine EventSubscriber that listens on the `postConnect` event and triggers a 
```
PRAGMA foreign_keys = ON;
```
in case that a SQLite connection is found.

This finally activates foreign keys and cascade deletes with SQLite!

See https://www.sqlite.org/pragma.html#pragma_foreign_keys