### PR TITLE
convert-timezone: add a default value 'y' to the asked question

### DIFF
--- a/src/Command/ConvertTimezoneCommand.php
+++ b/src/Command/ConvertTimezoneCommand.php
@@ -120,7 +120,7 @@ class ConvertTimezoneCommand extends Command
         $result = $this->getTimesheets($start, $end);
         $amount = count($result);
 
-        $answer = $io->ask(sprintf('This will update %s timesheet records, continue (y/n) ? ', $amount));
+        $answer = $io->ask(sprintf('This will update %s timesheet records, continue (y/n) ? ', $amount), 'y');
 
         if ('y' !== $answer) {
             $io->text('Aborting.');


### PR DESCRIPTION
Hello Kevin,

this is a pull request allowing to run convert-timezone command non-interactively. This is very important for scripts. Please merge the change.

Best regards,
blueowl04