### PR TITLE
removed dynamic database prefix

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -2,8 +2,6 @@
 # Copy this file to .env file for development, create environment variables when deploying to production
 # https://symfony.com/doc/current/best_practices/configuration.html#infrastructure-related-configuration
 
-# KIMAI DEFAULT ENV VARS
-DATABASE_PREFIX=kimai2_
 MAILER_FROM=kimai@example.com
 
 ###> symfony/framework-bundle ###

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -18,6 +18,11 @@ Read and follow each version info below, otherwise you risk data inconsistency o
 
 And make sure to **create a backup before you start**.
 
+## [0.9](https://github.com/kevinpapst/kimai2/releases/tag/0.9)
+
+**BC BREAK** - in an ongoing effort to simplify future installation and upgrade processes the `.env` variable `DATABASE_PREFIX` was removed.
+The table prefix is now hardcoded to `kimai2_`. If you used another prefix, you have to rename your tables manually 
+before starting the update process.
 
 ## [0.8.1](https://github.com/kevinpapst/kimai2/releases/tag/0.8.1)
 

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -66,7 +66,6 @@ services:
     # service that prefixes every database table
     App\Doctrine\TablePrefixSubscriber:
         class: App\Doctrine\TablePrefixSubscriber
-        arguments: ["%env(resolve:DATABASE_PREFIX)%"]
         tags:
             - { name: doctrine.event_subscriber }
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,7 +14,6 @@
         <env name="APP_ENV" value="test" force="true"/>
         <env name="APP_DEBUG" value="1" force="true"/>
         <env name="APP_SECRET" value="5a79a1c866efef9ca1800f971d689f3e" force="true"/>
-        <env name="DATABASE_PREFIX" value="kimai2_" force="true"/>
         <!-- define your env variables for the test env here -->
 
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>

--- a/src/Controller/AboutController.php
+++ b/src/Controller/AboutController.php
@@ -75,7 +75,6 @@ class AboutController extends AbstractController
             'modules' => get_loaded_extensions(),
             'dotenv' => [
                 'APP_ENV' => getenv('APP_ENV'),
-                'DATABASE_PREFIX' => getenv('DATABASE_PREFIX'),
                 'MAILER_FROM' => getenv('MAILER_FROM'),
                 'MAILER_URL' => getenv('MAILER_URL'),
                 'CORS_ALLOW_ORIGIN' => getenv('CORS_ALLOW_ORIGIN'),

--- a/src/Doctrine/AbstractMigration.php
+++ b/src/Doctrine/AbstractMigration.php
@@ -48,7 +48,7 @@ abstract class AbstractMigration extends BaseAbstractMigration implements Contai
      */
     protected function getTableName($name)
     {
-        return getenv('DATABASE_PREFIX') . $name;
+        return TablePrefixSubscriber::PREFIX . $name;
     }
 
     /**

--- a/src/Doctrine/TablePrefixSubscriber.php
+++ b/src/Doctrine/TablePrefixSubscriber.php
@@ -18,15 +18,7 @@ use Doctrine\ORM\Events;
  */
 class TablePrefixSubscriber implements EventSubscriber
 {
-    protected $prefix = '';
-
-    /**
-     * @param string $prefix
-     */
-    public function __construct($prefix)
-    {
-        $this->prefix = (string) $prefix;
-    }
+    public const PREFIX = 'kimai2_';
 
     /**
      * @return array|string[]
@@ -49,7 +41,7 @@ class TablePrefixSubscriber implements EventSubscriber
             return;
         }
 
-        $classMetadata->setPrimaryTable(['name' => $this->prefix . $classMetadata->getTableName()]);
+        $classMetadata->setPrimaryTable(['name' => self::PREFIX . $classMetadata->getTableName()]);
 
         foreach ($classMetadata->getAssociationMappings() as $fieldName => $mapping) {
             if (\Doctrine\ORM\Mapping\ClassMetadataInfo::MANY_TO_MANY == $mapping['type']
@@ -57,7 +49,7 @@ class TablePrefixSubscriber implements EventSubscriber
                 // it can be null if this field is the reverse side of a ManyToMany relationship
                 && array_key_exists('name', $classMetadata->associationMappings[$fieldName]['joinTable'])) {
                 $mappedTableName = $classMetadata->associationMappings[$fieldName]['joinTable']['name'];
-                $classMetadata->associationMappings[$fieldName]['joinTable']['name'] = $this->prefix . $mappedTableName;
+                $classMetadata->associationMappings[$fieldName]['joinTable']['name'] = self::PREFIX . $mappedTableName;
             }
         }
     }

--- a/src/Migrations/Version20180701120000.php
+++ b/src/Migrations/Version20180701120000.php
@@ -20,11 +20,6 @@ use Doctrine\DBAL\Schema\Schema;
  */
 final class Version20180701120000 extends AbstractMigration
 {
-    /**
-     * @param Schema $schema
-     * @throws \Doctrine\DBAL\DBALException
-     * @throws \Doctrine\DBAL\Migrations\AbortMigrationException
-     */
     public function up(Schema $schema): void
     {
         $platform = $this->getPlatform();
@@ -33,45 +28,48 @@ final class Version20180701120000 extends AbstractMigration
             $this->abortIf(true, 'Unsupported database platform: ' . $platform);
         }
 
+        $users = $this->getTableName('users');
+        $userPreferences = $this->getTableName('user_preferences');
+        $customers = $this->getTableName('customers');
+        $projects = $this->getTableName('projects');
+        $activities = $this->getTableName('activities');
+        $timesheets = $this->getTableName('timesheet');
+        $invoiceTemplates = $this->getTableName('invoice_templates');
+
         if ($platform === 'sqlite') {
-            $this->addSql('CREATE TABLE ' . $this->getTableName('users') . ' (id INTEGER NOT NULL, name VARCHAR(60) NOT NULL, mail VARCHAR(160) NOT NULL, password VARCHAR(254) DEFAULT NULL, alias VARCHAR(60) DEFAULT NULL, active BOOLEAN NOT NULL, registration_date DATETIME DEFAULT NULL, title VARCHAR(50) DEFAULT NULL, avatar VARCHAR(255) DEFAULT NULL, roles CLOB NOT NULL --(DC2Type:json_array)
+            $this->addSql('CREATE TABLE ' . $users . ' (id INTEGER NOT NULL, name VARCHAR(60) NOT NULL, mail VARCHAR(160) NOT NULL, password VARCHAR(254) DEFAULT NULL, alias VARCHAR(60) DEFAULT NULL, active BOOLEAN NOT NULL, registration_date DATETIME DEFAULT NULL, title VARCHAR(50) DEFAULT NULL, avatar VARCHAR(255) DEFAULT NULL, roles CLOB NOT NULL --(DC2Type:json_array)
         , PRIMARY KEY(id))');
-            $this->addSql('CREATE UNIQUE INDEX UNIQ_B9AC5BCE5E237E06 ON ' . $this->getTableName('users') . ' (name)');
-            $this->addSql('CREATE UNIQUE INDEX UNIQ_B9AC5BCE5126AC48 ON ' . $this->getTableName('users') . ' (mail)');
-            $this->addSql('CREATE TABLE ' . $this->getTableName('user_preferences') . ' (id INTEGER NOT NULL, user_id INTEGER DEFAULT NULL, name VARCHAR(50) NOT NULL, value VARCHAR(255) DEFAULT NULL, PRIMARY KEY(id))');
-            $this->addSql('CREATE INDEX IDX_8D08F631A76ED395 ON ' . $this->getTableName('user_preferences') . ' (user_id)');
-            $this->addSql('CREATE UNIQUE INDEX UNIQ_8D08F631A76ED3955E237E06 ON ' . $this->getTableName('user_preferences') . ' (user_id, name)');
-            $this->addSql('CREATE TABLE ' . $this->getTableName('customers') . ' (id INTEGER NOT NULL, name VARCHAR(255) NOT NULL, number VARCHAR(50) DEFAULT NULL, comment CLOB DEFAULT NULL, visible BOOLEAN NOT NULL, company VARCHAR(255) DEFAULT NULL, contact VARCHAR(255) DEFAULT NULL, address CLOB DEFAULT NULL, country VARCHAR(2) NOT NULL, currency VARCHAR(3) NOT NULL, phone VARCHAR(255) DEFAULT NULL, fax VARCHAR(255) DEFAULT NULL, mobile VARCHAR(255) DEFAULT NULL, mail VARCHAR(255) DEFAULT NULL, homepage VARCHAR(255) DEFAULT NULL, timezone VARCHAR(255) NOT NULL, PRIMARY KEY(id))');
-            $this->addSql('CREATE TABLE ' . $this->getTableName('projects') . ' (id INTEGER NOT NULL, customer_id INTEGER DEFAULT NULL, name VARCHAR(255) NOT NULL, order_number CLOB DEFAULT NULL, comment CLOB DEFAULT NULL, visible BOOLEAN NOT NULL, budget NUMERIC(10, 2) NOT NULL, PRIMARY KEY(id))');
-            $this->addSql('CREATE INDEX IDX_407F12069395C3F3 ON ' . $this->getTableName('projects') . ' (customer_id)');
-            $this->addSql('CREATE TABLE ' . $this->getTableName('activities') . ' (id INTEGER NOT NULL, project_id INTEGER DEFAULT NULL, name VARCHAR(255) NOT NULL, comment CLOB DEFAULT NULL, visible BOOLEAN NOT NULL, PRIMARY KEY(id))');
-            $this->addSql('CREATE INDEX IDX_8811FE1C166D1F9C ON ' . $this->getTableName('activities') . ' (project_id)');
-            $this->addSql('CREATE TABLE ' . $this->getTableName('timesheet') . ' (id INTEGER NOT NULL, user INTEGER DEFAULT NULL, activity_id INTEGER DEFAULT NULL, start_time DATETIME NOT NULL, end_time DATETIME DEFAULT NULL, duration INTEGER DEFAULT NULL, description CLOB DEFAULT NULL, rate NUMERIC(10, 2) NOT NULL, PRIMARY KEY(id))');
-            $this->addSql('CREATE INDEX IDX_4F60C6B18D93D649 ON ' . $this->getTableName('timesheet') . ' (user)');
-            $this->addSql('CREATE INDEX IDX_4F60C6B181C06096 ON ' . $this->getTableName('timesheet') . ' (activity_id)');
-            $this->addSql('CREATE TABLE ' . $this->getTableName('invoice_templates') . ' (id INTEGER NOT NULL, name VARCHAR(255) NOT NULL, title VARCHAR(255) NOT NULL, company VARCHAR(255) NOT NULL, address CLOB DEFAULT NULL, due_days INTEGER NOT NULL, vat INTEGER DEFAULT NULL, calculator VARCHAR(20) NOT NULL, number_generator VARCHAR(20) NOT NULL, renderer VARCHAR(20) NOT NULL, payment_terms CLOB DEFAULT NULL, PRIMARY KEY(id))');
-            $this->addSql('CREATE UNIQUE INDEX UNIQ_1626CFE95E237E06 ON ' . $this->getTableName('invoice_templates') . ' (name)');
+            $this->addSql('CREATE UNIQUE INDEX UNIQ_B9AC5BCE5E237E06 ON ' . $users . ' (name)');
+            $this->addSql('CREATE UNIQUE INDEX UNIQ_B9AC5BCE5126AC48 ON ' . $users . ' (mail)');
+            $this->addSql('CREATE TABLE ' . $userPreferences . ' (id INTEGER NOT NULL, user_id INTEGER DEFAULT NULL, name VARCHAR(50) NOT NULL, value VARCHAR(255) DEFAULT NULL, PRIMARY KEY(id))');
+            $this->addSql('CREATE INDEX IDX_8D08F631A76ED395 ON ' . $userPreferences . ' (user_id)');
+            $this->addSql('CREATE UNIQUE INDEX UNIQ_8D08F631A76ED3955E237E06 ON ' . $userPreferences . ' (user_id, name)');
+            $this->addSql('CREATE TABLE ' . $customers . ' (id INTEGER NOT NULL, name VARCHAR(255) NOT NULL, number VARCHAR(50) DEFAULT NULL, comment CLOB DEFAULT NULL, visible BOOLEAN NOT NULL, company VARCHAR(255) DEFAULT NULL, contact VARCHAR(255) DEFAULT NULL, address CLOB DEFAULT NULL, country VARCHAR(2) NOT NULL, currency VARCHAR(3) NOT NULL, phone VARCHAR(255) DEFAULT NULL, fax VARCHAR(255) DEFAULT NULL, mobile VARCHAR(255) DEFAULT NULL, mail VARCHAR(255) DEFAULT NULL, homepage VARCHAR(255) DEFAULT NULL, timezone VARCHAR(255) NOT NULL, PRIMARY KEY(id))');
+            $this->addSql('CREATE TABLE ' . $projects . ' (id INTEGER NOT NULL, customer_id INTEGER DEFAULT NULL, name VARCHAR(255) NOT NULL, order_number CLOB DEFAULT NULL, comment CLOB DEFAULT NULL, visible BOOLEAN NOT NULL, budget NUMERIC(10, 2) NOT NULL, PRIMARY KEY(id))');
+            $this->addSql('CREATE INDEX IDX_407F12069395C3F3 ON ' . $projects . ' (customer_id)');
+            $this->addSql('CREATE TABLE ' . $activities . ' (id INTEGER NOT NULL, project_id INTEGER DEFAULT NULL, name VARCHAR(255) NOT NULL, comment CLOB DEFAULT NULL, visible BOOLEAN NOT NULL, PRIMARY KEY(id))');
+            $this->addSql('CREATE INDEX IDX_8811FE1C166D1F9C ON ' . $activities . ' (project_id)');
+            $this->addSql('CREATE TABLE ' . $timesheets . ' (id INTEGER NOT NULL, user INTEGER DEFAULT NULL, activity_id INTEGER DEFAULT NULL, start_time DATETIME NOT NULL, end_time DATETIME DEFAULT NULL, duration INTEGER DEFAULT NULL, description CLOB DEFAULT NULL, rate NUMERIC(10, 2) NOT NULL, PRIMARY KEY(id))');
+            $this->addSql('CREATE INDEX IDX_4F60C6B18D93D649 ON ' . $timesheets . ' (user)');
+            $this->addSql('CREATE INDEX IDX_4F60C6B181C06096 ON ' . $timesheets . ' (activity_id)');
+            $this->addSql('CREATE TABLE ' . $invoiceTemplates . ' (id INTEGER NOT NULL, name VARCHAR(255) NOT NULL, title VARCHAR(255) NOT NULL, company VARCHAR(255) NOT NULL, address CLOB DEFAULT NULL, due_days INTEGER NOT NULL, vat INTEGER DEFAULT NULL, calculator VARCHAR(20) NOT NULL, number_generator VARCHAR(20) NOT NULL, renderer VARCHAR(20) NOT NULL, payment_terms CLOB DEFAULT NULL, PRIMARY KEY(id))');
+            $this->addSql('CREATE UNIQUE INDEX UNIQ_1626CFE95E237E06 ON ' . $invoiceTemplates . ' (name)');
         } else {
-            $this->addSql('CREATE TABLE ' . $this->getTableName('users') . ' (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(60) NOT NULL, mail VARCHAR(160) NOT NULL, password VARCHAR(254) DEFAULT NULL, alias VARCHAR(60) DEFAULT NULL, active TINYINT(1) NOT NULL, registration_date DATETIME DEFAULT NULL, title VARCHAR(50) DEFAULT NULL, avatar VARCHAR(255) DEFAULT NULL, roles JSON NOT NULL COMMENT \'(DC2Type:json_array)\', UNIQUE INDEX UNIQ_B9AC5BCE5E237E06 (name), UNIQUE INDEX UNIQ_B9AC5BCE5126AC48 (mail), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE = InnoDB');
-            $this->addSql('CREATE TABLE ' . $this->getTableName('user_preferences') . ' (id INT AUTO_INCREMENT NOT NULL, user_id INT DEFAULT NULL, name VARCHAR(50) NOT NULL, value VARCHAR(255) DEFAULT NULL, INDEX IDX_8D08F631A76ED395 (user_id), UNIQUE INDEX UNIQ_8D08F631A76ED3955E237E06 (user_id, name), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE = InnoDB');
-            $this->addSql('CREATE TABLE ' . $this->getTableName('customers') . ' (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(255) NOT NULL, number VARCHAR(50) DEFAULT NULL, comment TEXT DEFAULT NULL, visible TINYINT(1) NOT NULL, company VARCHAR(255) DEFAULT NULL, contact VARCHAR(255) DEFAULT NULL, address TEXT DEFAULT NULL, country VARCHAR(2) NOT NULL, currency VARCHAR(3) NOT NULL, phone VARCHAR(255) DEFAULT NULL, fax VARCHAR(255) DEFAULT NULL, mobile VARCHAR(255) DEFAULT NULL, mail VARCHAR(255) DEFAULT NULL, homepage VARCHAR(255) DEFAULT NULL, timezone VARCHAR(255) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE = InnoDB');
-            $this->addSql('CREATE TABLE ' . $this->getTableName('projects') . ' (id INT AUTO_INCREMENT NOT NULL, customer_id INT DEFAULT NULL, name VARCHAR(255) NOT NULL, order_number TINYTEXT DEFAULT NULL, comment TEXT DEFAULT NULL, visible TINYINT(1) NOT NULL, budget NUMERIC(10, 2) NOT NULL, INDEX IDX_407F12069395C3F3 (customer_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE = InnoDB');
-            $this->addSql('CREATE TABLE ' . $this->getTableName('activities') . ' (id INT AUTO_INCREMENT NOT NULL, project_id INT DEFAULT NULL, name VARCHAR(255) NOT NULL, comment TEXT DEFAULT NULL, visible TINYINT(1) NOT NULL, INDEX IDX_8811FE1C166D1F9C (project_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE = InnoDB');
-            $this->addSql('CREATE TABLE ' . $this->getTableName('timesheet') . ' (id INT AUTO_INCREMENT NOT NULL, user INT DEFAULT NULL, activity_id INT DEFAULT NULL, start_time DATETIME NOT NULL, end_time DATETIME DEFAULT NULL, duration INT DEFAULT NULL, description TEXT DEFAULT NULL, rate NUMERIC(10, 2) NOT NULL, INDEX IDX_4F60C6B18D93D649 (user), INDEX IDX_4F60C6B181C06096 (activity_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE = InnoDB');
-            $this->addSql('CREATE TABLE ' . $this->getTableName('invoice_templates') . ' (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(255) NOT NULL, title VARCHAR(255) NOT NULL, company VARCHAR(255) NOT NULL, address TEXT DEFAULT NULL, due_days INT NOT NULL, vat INT DEFAULT NULL, calculator VARCHAR(20) NOT NULL, number_generator VARCHAR(20) NOT NULL, renderer VARCHAR(20) NOT NULL, payment_terms TEXT DEFAULT NULL, UNIQUE INDEX UNIQ_1626CFE95E237E06 (name), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE = InnoDB');
-            $this->addSql('ALTER TABLE ' . $this->getTableName('user_preferences') . ' ADD CONSTRAINT FK_8D08F631A76ED395 FOREIGN KEY (user_id) REFERENCES ' . $this->getTableName('users') . ' (id) ON DELETE CASCADE');
-            $this->addSql('ALTER TABLE ' . $this->getTableName('projects') . ' ADD CONSTRAINT FK_407F12069395C3F3 FOREIGN KEY (customer_id) REFERENCES ' . $this->getTableName('customers') . ' (id) ON DELETE CASCADE');
-            $this->addSql('ALTER TABLE ' . $this->getTableName('activities') . ' ADD CONSTRAINT FK_8811FE1C166D1F9C FOREIGN KEY (project_id) REFERENCES ' . $this->getTableName('projects') . ' (id) ON DELETE CASCADE');
-            $this->addSql('ALTER TABLE ' . $this->getTableName('timesheet') . ' ADD CONSTRAINT FK_4F60C6B18D93D649 FOREIGN KEY (user) REFERENCES ' . $this->getTableName('users') . ' (id)');
-            $this->addSql('ALTER TABLE ' . $this->getTableName('timesheet') . ' ADD CONSTRAINT FK_4F60C6B181C06096 FOREIGN KEY (activity_id) REFERENCES ' . $this->getTableName('activities') . ' (id) ON DELETE CASCADE');
+            $this->addSql('CREATE TABLE ' . $users . ' (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(60) NOT NULL, mail VARCHAR(160) NOT NULL, password VARCHAR(254) DEFAULT NULL, alias VARCHAR(60) DEFAULT NULL, active TINYINT(1) NOT NULL, registration_date DATETIME DEFAULT NULL, title VARCHAR(50) DEFAULT NULL, avatar VARCHAR(255) DEFAULT NULL, roles JSON NOT NULL COMMENT \'(DC2Type:json_array)\', UNIQUE INDEX UNIQ_B9AC5BCE5E237E06 (name), UNIQUE INDEX UNIQ_B9AC5BCE5126AC48 (mail), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE = InnoDB');
+            $this->addSql('CREATE TABLE ' . $userPreferences . ' (id INT AUTO_INCREMENT NOT NULL, user_id INT DEFAULT NULL, name VARCHAR(50) NOT NULL, value VARCHAR(255) DEFAULT NULL, INDEX IDX_8D08F631A76ED395 (user_id), UNIQUE INDEX UNIQ_8D08F631A76ED3955E237E06 (user_id, name), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE = InnoDB');
+            $this->addSql('CREATE TABLE ' . $customers . ' (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(255) NOT NULL, number VARCHAR(50) DEFAULT NULL, comment TEXT DEFAULT NULL, visible TINYINT(1) NOT NULL, company VARCHAR(255) DEFAULT NULL, contact VARCHAR(255) DEFAULT NULL, address TEXT DEFAULT NULL, country VARCHAR(2) NOT NULL, currency VARCHAR(3) NOT NULL, phone VARCHAR(255) DEFAULT NULL, fax VARCHAR(255) DEFAULT NULL, mobile VARCHAR(255) DEFAULT NULL, mail VARCHAR(255) DEFAULT NULL, homepage VARCHAR(255) DEFAULT NULL, timezone VARCHAR(255) NOT NULL, PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE = InnoDB');
+            $this->addSql('CREATE TABLE ' . $projects . ' (id INT AUTO_INCREMENT NOT NULL, customer_id INT DEFAULT NULL, name VARCHAR(255) NOT NULL, order_number TINYTEXT DEFAULT NULL, comment TEXT DEFAULT NULL, visible TINYINT(1) NOT NULL, budget NUMERIC(10, 2) NOT NULL, INDEX IDX_407F12069395C3F3 (customer_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE = InnoDB');
+            $this->addSql('CREATE TABLE ' . $activities . ' (id INT AUTO_INCREMENT NOT NULL, project_id INT DEFAULT NULL, name VARCHAR(255) NOT NULL, comment TEXT DEFAULT NULL, visible TINYINT(1) NOT NULL, INDEX IDX_8811FE1C166D1F9C (project_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE = InnoDB');
+            $this->addSql('CREATE TABLE ' . $timesheets . ' (id INT AUTO_INCREMENT NOT NULL, user INT DEFAULT NULL, activity_id INT DEFAULT NULL, start_time DATETIME NOT NULL, end_time DATETIME DEFAULT NULL, duration INT DEFAULT NULL, description TEXT DEFAULT NULL, rate NUMERIC(10, 2) NOT NULL, INDEX IDX_4F60C6B18D93D649 (user), INDEX IDX_4F60C6B181C06096 (activity_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE = InnoDB');
+            $this->addSql('CREATE TABLE ' . $invoiceTemplates . ' (id INT AUTO_INCREMENT NOT NULL, name VARCHAR(255) NOT NULL, title VARCHAR(255) NOT NULL, company VARCHAR(255) NOT NULL, address TEXT DEFAULT NULL, due_days INT NOT NULL, vat INT DEFAULT NULL, calculator VARCHAR(20) NOT NULL, number_generator VARCHAR(20) NOT NULL, renderer VARCHAR(20) NOT NULL, payment_terms TEXT DEFAULT NULL, UNIQUE INDEX UNIQ_1626CFE95E237E06 (name), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE = InnoDB');
+            $this->addSql('ALTER TABLE ' . $userPreferences . ' ADD CONSTRAINT FK_8D08F631A76ED395 FOREIGN KEY (user_id) REFERENCES ' . $users . ' (id) ON DELETE CASCADE');
+            $this->addSql('ALTER TABLE ' . $projects . ' ADD CONSTRAINT FK_407F12069395C3F3 FOREIGN KEY (customer_id) REFERENCES ' . $customers . ' (id) ON DELETE CASCADE');
+            $this->addSql('ALTER TABLE ' . $activities . ' ADD CONSTRAINT FK_8811FE1C166D1F9C FOREIGN KEY (project_id) REFERENCES ' . $projects . ' (id) ON DELETE CASCADE');
+            $this->addSql('ALTER TABLE ' . $timesheets . ' ADD CONSTRAINT FK_4F60C6B18D93D649 FOREIGN KEY (user) REFERENCES ' . $users . ' (id)');
+            $this->addSql('ALTER TABLE ' . $timesheets . ' ADD CONSTRAINT FK_4F60C6B181C06096 FOREIGN KEY (activity_id) REFERENCES ' . $activities . ' (id) ON DELETE CASCADE');
         }
     }
 
-    /**
-     * @param Schema $schema
-     * @throws \Doctrine\DBAL\DBALException
-     * @throws \Doctrine\DBAL\Migrations\AbortMigrationException
-     */
     public function down(Schema $schema): void
     {
         $platform = $this->getPlatform();
@@ -79,5 +77,21 @@ final class Version20180701120000 extends AbstractMigration
         if (!in_array($platform, ['sqlite', 'mysql'])) {
             $this->abortIf(true, 'Unsupported database platform: ' . $platform);
         }
+
+        $users = $this->getTableName('users');
+        $userPreferences = $this->getTableName('user_preferences');
+        $customers = $this->getTableName('customers');
+        $projects = $this->getTableName('projects');
+        $activities = $this->getTableName('activities');
+        $timesheets = $this->getTableName('timesheet');
+        $invoiceTemplates = $this->getTableName('invoice_templates');
+
+        $this->addSql('DROP TABLE ' . $users);
+        $this->addSql('DROP TABLE ' . $userPreferences);
+        $this->addSql('DROP TABLE ' . $customers);
+        $this->addSql('DROP TABLE ' . $projects);
+        $this->addSql('DROP TABLE ' . $activities);
+        $this->addSql('DROP TABLE ' . $timesheets);
+        $this->addSql('DROP TABLE ' . $invoiceTemplates);
     }
 }

--- a/src/Migrations/Version20180701120000.php
+++ b/src/Migrations/Version20180701120000.php
@@ -86,12 +86,12 @@ final class Version20180701120000 extends AbstractMigration
         $timesheets = $this->getTableName('timesheet');
         $invoiceTemplates = $this->getTableName('invoice_templates');
 
-        $this->addSql('DROP TABLE ' . $users);
-        $this->addSql('DROP TABLE ' . $userPreferences);
-        $this->addSql('DROP TABLE ' . $customers);
-        $this->addSql('DROP TABLE ' . $projects);
-        $this->addSql('DROP TABLE ' . $activities);
-        $this->addSql('DROP TABLE ' . $timesheets);
         $this->addSql('DROP TABLE ' . $invoiceTemplates);
+        $this->addSql('DROP TABLE ' . $timesheets);
+        $this->addSql('DROP TABLE ' . $userPreferences);
+        $this->addSql('DROP TABLE ' . $users);
+        $this->addSql('DROP TABLE ' . $activities);
+        $this->addSql('DROP TABLE ' . $projects);
+        $this->addSql('DROP TABLE ' . $customers);
     }
 }

--- a/tests/.env.dist.mysql
+++ b/tests/.env.dist.mysql
@@ -1,4 +1,3 @@
-DATABASE_PREFIX=abc_
 MAILER_FROM=kimai@example.com
 
 ###> symfony/framework-bundle ###

--- a/tests/.env.dist.sqlite
+++ b/tests/.env.dist.sqlite
@@ -1,4 +1,3 @@
-DATABASE_PREFIX=abc_
 MAILER_FROM=kimai@example.com
 
 ###> symfony/framework-bundle ###


### PR DESCRIPTION
Fixes #633 

**BC BREAK** - in an ongoing effort to simplify future installation and upgrade processes the `.env` variable `DATABASE_PREFIX` was removed.
The table prefix is now hardcoded to `kimai2_`. If you used another prefix, you have to rename your tables manually before starting the update process.
