### PR TITLE
fix pdf export cache directory

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -59,6 +59,9 @@ services:
         arguments:
             $languageSettings: "%kimai.languages%"
 
+    App\Utils\MPdfConverter:
+        arguments: ['%kernel.cache_dir%']
+
     # ================================================================================
     # DATABASE
     # ================================================================================

--- a/src/Export/Renderer/PDFRenderer.php
+++ b/src/Export/Renderer/PDFRenderer.php
@@ -13,8 +13,7 @@ use App\Entity\Timesheet;
 use App\Export\RendererInterface;
 use App\Repository\Query\TimesheetQuery;
 use App\Timesheet\UserDateTimeFactory;
-use Mpdf\Mpdf;
-use Mpdf\Output\Destination;
+use App\Utils\HtmlToPdfConverter;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
@@ -26,20 +25,24 @@ class PDFRenderer implements RendererInterface
      * @var \Twig_Environment
      */
     protected $twig;
-
     /**
      * @var UserDateTimeFactory
      */
     protected $dateTime;
+    /**
+     * @var HtmlToPdfConverter
+     */
+    protected $converter;
 
     /**
      * @param \Twig_Environment $twig
      * @param UserDateTimeFactory $dateTime
      */
-    public function __construct(\Twig_Environment $twig, UserDateTimeFactory $dateTime)
+    public function __construct(\Twig_Environment $twig, UserDateTimeFactory $dateTime, HtmlToPdfConverter $converter)
     {
         $this->twig = $twig;
         $this->dateTime = $dateTime;
+        $this->converter = $converter;
     }
 
     /**
@@ -60,11 +63,7 @@ class PDFRenderer implements RendererInterface
             'summaries' => $this->calculateSummary($timesheets),
         ]);
 
-        //return new Response($content);
-
-        $mpdf = new Mpdf();
-        $mpdf->WriteHTML($content);
-        $content = $mpdf->Output('test', Destination::STRING_RETURN);
+        $content = $this->converter->convertToPdf($content);
 
         $response = new Response($content);
 

--- a/src/Utils/HtmlToPdfConverter.php
+++ b/src/Utils/HtmlToPdfConverter.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Utils;
+
+interface HtmlToPdfConverter
+{
+    /**
+     * Returns the binary content of the PDF, which can be saved as file or send via Reponse.
+     * @param string $html
+     * @return mixed
+     */
+    public function convertToPdf(string $html);
+}

--- a/src/Utils/MPdfConverter.php
+++ b/src/Utils/MPdfConverter.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Utils;
+
+use Mpdf\Mpdf;
+use Mpdf\Output\Destination;
+
+class MPdfConverter implements HtmlToPdfConverter
+{
+    /**
+     * @var string
+     */
+    private $cacheDirectory;
+
+    public function __construct(string $cacheDirectory)
+    {
+        $this->cacheDirectory = $cacheDirectory;
+    }
+
+    /**
+     * @param string $html
+     * @return mixed|string
+     * @throws \Mpdf\MpdfException
+     */
+    public function convertToPdf(string $html)
+    {
+        $mpdf = new Mpdf([['tempDir' => $this->cacheDirectory]]);
+        $mpdf->WriteHTML($html);
+
+        return $mpdf->Output('', Destination::STRING_RETURN);
+    }
+}

--- a/src/Utils/MPdfConverter.php
+++ b/src/Utils/MPdfConverter.php
@@ -9,6 +9,7 @@
 
 namespace App\Utils;
 
+use App\Constants;
 use Mpdf\Mpdf;
 use Mpdf\Output\Destination;
 
@@ -32,6 +33,7 @@ class MPdfConverter implements HtmlToPdfConverter
     public function convertToPdf(string $html)
     {
         $mpdf = new Mpdf([['tempDir' => $this->cacheDirectory]]);
+        $mpdf->creator = Constants::SOFTWARE;
         $mpdf->WriteHTML($html);
 
         return $mpdf->Output('', Destination::STRING_RETURN);

--- a/tests/Export/Renderer/PdfRendererTest.php
+++ b/tests/Export/Renderer/PdfRendererTest.php
@@ -14,6 +14,8 @@ use App\Export\Renderer\PDFRenderer;
 use App\Repository\UserRepository;
 use App\Security\CurrentUser;
 use App\Timesheet\UserDateTimeFactory;
+use App\Utils\HtmlToPdfConverter;
+use App\Utils\MPdfConverter;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorage;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
@@ -44,7 +46,8 @@ class PdfRendererTest extends AbstractRendererTest
     {
         $sut = new PDFRenderer(
             $this->getMockBuilder(\Twig_Environment::class)->disableOriginalConstructor()->getMock(),
-            $this->getDateTimeFactory()
+            $this->getDateTimeFactory(),
+            $this->getMockBuilder(HtmlToPdfConverter::class)->getMock()
         );
 
         $this->assertEquals('pdf', $sut->getId());
@@ -58,6 +61,8 @@ class PdfRendererTest extends AbstractRendererTest
         /** @var \Twig_Environment $twig */
         $twig = $kernel->getContainer()->get('twig');
         $stack = $kernel->getContainer()->get('request_stack');
+        $cacheDir = $kernel->getContainer()->getParameter('kernel.cache_dir');
+        $converter = new MPdfConverter($cacheDir);
         $request = new Request();
         $request->setLocale('en');
         $stack->push($request);
@@ -65,7 +70,7 @@ class PdfRendererTest extends AbstractRendererTest
         /** @var FilesystemLoader $loader */
         $loader = $twig->getLoader();
 
-        $sut = new PDFRenderer($twig, $this->getDateTimeFactory());
+        $sut = new PDFRenderer($twig, $this->getDateTimeFactory(), $converter);
 
         $response = $this->render($sut);
 

--- a/tests/Utils/MPdfConverterTest.php
+++ b/tests/Utils/MPdfConverterTest.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Utils;
+
+use App\Utils\MPdfConverter;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * @covers \App\Utils\MPdfConverter
+ */
+class MPdfConverterTest extends KernelTestCase
+{
+    function unicode_hex($unicode_dec)
+    {
+        return (sprintf("%05s", strtoupper(dechex($unicode_dec))));
+    }
+
+    public function test()
+    {
+        $kernel = self::bootKernel();
+        $cacheDir = $kernel->getContainer()->getParameter('kernel.cache_dir');
+
+        $sut = new MPdfConverter($cacheDir);
+        $result = $sut->convertToPdf('<h1>Test</h1>');
+        // Yeah, thats not a real test, I know ;-)
+        $this->assertNotEmpty($result);
+        preg_match('/\/Creator \((.*)\)/', $result, $matches);
+        $this->assertCount(2, $matches);
+    }
+}


### PR DESCRIPTION
Fixes #648 

This PR changes the PDF generation => now using the cache directory instead of the globally configured temporary directory.