### PR TITLE
fixing default env var for cors header

### DIFF
--- a/config/packages/nelmio_cors.yaml
+++ b/config/packages/nelmio_cors.yaml
@@ -1,15 +1,19 @@
+parameters:
+    env(CORS_ALLOW_ORIGIN): 'localhost'
+
 nelmio_cors:
     defaults:
         allow_credentials: false
-        allow_origin: ['%env(CORS_ALLOW_ORIGIN)%']
-        allow_headers: []
+#        allow_origin: ['%env(CORS_ALLOW_ORIGIN)%']
 #        allow_headers: ['Content-Type', 'Authorization', 'X-AUTH-USER', 'X-AUTH-TOKEN']
-        allow_methods: []
 #        allow_methods: ['GET', 'OPTIONS', 'POST', 'PUT', 'PATCH', 'DELETE']
-        expose_headers: []
 #        expose_headers: ['Link']
-        max_age: 0
 #        max_age: 3600
+        allow_origin: []
+        allow_headers: []
+        allow_methods: []
+        expose_headers: []
+        max_age: 0
         hosts: []
         origin_regex: true
         forced_allow_origin_value: ~


### PR DESCRIPTION
fixes cors setup for existing installations with `.env` that is missing the config `CORS_ALLOW_ORIGIN`