### PR TITLE
remove mailer url from about debug info

### DIFF
--- a/src/Controller/AboutController.php
+++ b/src/Controller/AboutController.php
@@ -76,7 +76,6 @@ class AboutController extends AbstractController
             'dotenv' => [
                 'APP_ENV' => getenv('APP_ENV'),
                 'MAILER_FROM' => getenv('MAILER_FROM'),
-                'MAILER_URL' => getenv('MAILER_URL'),
                 'CORS_ALLOW_ORIGIN' => getenv('CORS_ALLOW_ORIGIN'),
             ],
             'info' => $phpInfo,


### PR DESCRIPTION
Removed MAILER_URL from about screen, as this could expose possible credentials