### PR TITLE
added delete timesheet API endpoint

### DIFF
--- a/src/API/TimesheetController.php
+++ b/src/API/TimesheetController.php
@@ -349,4 +349,47 @@ class TimesheetController extends BaseApiController
 
         return $this->viewHandler->handle($view);
     }
+
+    /**
+     * Delete an existing timesheet record
+     *
+     * @SWG\Delete(
+     *      @SWG\Response(
+     *          response=204,
+     *          description="Delete one timesheet record"
+     *      ),
+     * )
+     * @SWG\Parameter(
+     *      name="id",
+     *      in="path",
+     *      type="integer",
+     *      description="Timesheet record ID to delete",
+     *      required=true,
+     * )
+     *
+     * @Security("is_granted('delete_own_timesheet') or is_granted('delete_other_timesheet')")
+     *
+     * @param int $id
+     * @return Response
+     */
+    public function deleteAction($id)
+    {
+        $timesheet = $this->repository->find($id);
+
+        if (null === $timesheet) {
+            throw new NotFoundException();
+        }
+
+        if (!$this->isGranted('delete', $timesheet)) {
+            throw $this->createAccessDeniedException('You are not allowed to delete this timesheet');
+        }
+
+        $entityManager = $this->getDoctrine()->getManager();
+        $entityManager->remove($timesheet);
+        $entityManager->flush();
+
+        $view = new View(null, Response::HTTP_NO_CONTENT);
+
+        return $this->viewHandler->handle($view);
+    }
 }


### PR DESCRIPTION
## Description

New API endpoint to delete a timesheet record.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I ran `bin/console kimai:codestyle --fix` to verify the correct code style
- [x] I have updated the [documentation](https://github.com/kimai/www.kimai.org/tree/master/_documentation) accordingly
- [x] I have added tests to cover my changes
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
