### PR TITLE
translate time-tracking in login screen and browser title

### DIFF
--- a/src/EventSubscriber/MenuSubscriber.php
+++ b/src/EventSubscriber/MenuSubscriber.php
@@ -69,13 +69,13 @@ class MenuSubscriber implements EventSubscriberInterface
 
         if ($auth->isGranted('view_own_timesheet')) {
             $menu->addItem(
-                new MenuItemModel('timesheet', 'menu.timesheet', 'timesheet', [], 'far fa-clock')
+                new MenuItemModel('timesheet', 'menu.timesheet', 'timesheet', [], 'fas fa-clock')
             );
         }
 
         if ($auth->isGranted('view_invoice')) {
             $menu->addItem(
-                new MenuItemModel('invoice', 'menu.invoice', 'invoice', [], 'far fa-file-alt')
+                new MenuItemModel('invoice', 'menu.invoice', 'invoice', [], 'fas fa-file-invoice')
             );
         }
 

--- a/src/Twig/DatatableExtensions.php
+++ b/src/Twig/DatatableExtensions.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Twig;
+
+use Symfony\Component\HttpFoundation\RequestStack;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
+
+class DatatableExtensions extends AbstractExtension
+{
+    /**
+     * @var RequestStack
+     */
+    protected $requestStack;
+
+    /**
+     * @var array
+     */
+    protected $cookies = [];
+
+    /**
+     * @param RequestStack $requestStack
+     */
+    public function __construct(RequestStack $requestStack)
+    {
+        $this->requestStack = $requestStack;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFunctions()
+    {
+        return [
+            new TwigFunction('is_visible_column', [$this, 'isColumnVisible']),
+            new TwigFunction('is_datatable_configured', [$this, 'isDatatableConfigured']),
+        ];
+    }
+
+    /**
+     * @param string $dataTable
+     * @return bool
+     */
+    public function isDatatableConfigured(string $dataTable)
+    {
+        $cookie = $this->getVisibilityCookieName($dataTable);
+
+        return $this->requestStack->getCurrentRequest()->cookies->has($cookie);
+    }
+
+    /**
+     * @param string $dataTable
+     * @return string
+     */
+    protected function getVisibilityCookieName(string $dataTable)
+    {
+        return $dataTable . '_visibility';
+    }
+
+    /**
+     * This is only for datatables, do not use it outside this context.
+     *
+     * @param string $dataTable
+     * @param string $column
+     * @return bool
+     */
+    public function isColumnVisible(string $dataTable, string $column)
+    {
+        // name handling is spread between here and datatables.html.twig (data_table_column_modal)
+        $cookie = $this->getVisibilityCookieName($dataTable);
+
+        if (!isset($this->cookies[$cookie])) {
+            $visibility = false;
+            if ($this->requestStack->getCurrentRequest()->cookies->has($cookie)) {
+                $visibility = json_decode($this->requestStack->getCurrentRequest()->cookies->get($cookie), true);
+            }
+            $this->cookies[$cookie] = $visibility;
+        }
+        $values = $this->cookies[$cookie];
+
+        if (empty($values) || !is_array($values)) {
+            return true;
+        }
+
+        if (isset($values[$column]) && $values[$column] === false) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Twig/TitleExtension.php
+++ b/src/Twig/TitleExtension.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Twig;
+
+use App\Constants;
+use App\Entity\Timesheet;
+use App\Utils\Duration;
+use App\Utils\LocaleSettings;
+use NumberFormatter;
+use Symfony\Component\Intl\Intl;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFilter;
+use Twig\TwigFunction;
+
+class TitleExtension extends AbstractExtension
+{
+    /**
+     * @var TranslatorInterface
+     */
+    protected $translator;
+
+    /**
+     * @param TranslatorInterface $translator
+     */
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getFunctions()
+    {
+        return [
+            new TwigFunction('get_title', [$this, 'generateTitle']),
+        ];
+    }
+
+    /**
+     * @param null|string $prefix
+     * @param string $delimiter
+     * @return string
+     */
+    public function generateTitle(?string $prefix = null, string $delimiter = ' – ')
+    {
+        return ($prefix ?? '') . 'Kimai' . $delimiter . $this->translator->trans('time_tracking', [], 'messages');
+    }
+}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -32,7 +32,7 @@
 {% endblock %}
 
 {% block title %}
-    {{ 'browser.title'|trans }}
+    Kimai - {{ 'time_tracking'|trans }}
 {% endblock %}
 
 {% block page_subtitle %}{% endblock %}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -32,7 +32,7 @@
 {% endblock %}
 
 {% block title %}
-    Kimai - {{ 'time_tracking'|trans }}
+    {{- get_title() -}}
 {% endblock %}
 
 {% block page_subtitle %}{% endblock %}

--- a/templates/bundles/FOSUserBundle/Registration/confirmed.html.twig
+++ b/templates/bundles/FOSUserBundle/Registration/confirmed.html.twig
@@ -1,7 +1,7 @@
 {% extends '@AdminLTE/FOSUserBundle/Registration/confirmed.html.twig' %}
 
 {% block logo_login %}{% include 'partials/logo_login.html.twig' %}{% endblock %}
-{% block title %}{{ 'browser.title'|trans }}{% endblock %}
+{% block title %}Kimai - {{ 'time_tracking'|trans }}{% endblock %}
 
 {% block head %}
     {{ parent() }}

--- a/templates/bundles/FOSUserBundle/Registration/confirmed.html.twig
+++ b/templates/bundles/FOSUserBundle/Registration/confirmed.html.twig
@@ -1,7 +1,7 @@
 {% extends '@AdminLTE/FOSUserBundle/Registration/confirmed.html.twig' %}
 
 {% block logo_login %}{% include 'partials/logo_login.html.twig' %}{% endblock %}
-{% block title %}Kimai - {{ 'time_tracking'|trans }}{% endblock %}
+{% block title %}{{- get_title() -}}{% endblock %}
 
 {% block head %}
     {{ parent() }}

--- a/templates/bundles/FOSUserBundle/Registration/register.html.twig
+++ b/templates/bundles/FOSUserBundle/Registration/register.html.twig
@@ -1,7 +1,7 @@
 {% extends '@AdminLTE/FOSUserBundle/Registration/register.html.twig' %}
 
 {% block logo_login %}{% include 'partials/logo_login.html.twig' %}{% endblock %}
-{% block title %}{{ 'browser.title'|trans }}{% endblock %}
+{% block title %}Kimai - {{ 'time_tracking'|trans }}{% endblock %}
 
 {% block head %}
     {{ parent() }}

--- a/templates/bundles/FOSUserBundle/Registration/register.html.twig
+++ b/templates/bundles/FOSUserBundle/Registration/register.html.twig
@@ -1,7 +1,7 @@
 {% extends '@AdminLTE/FOSUserBundle/Registration/register.html.twig' %}
 
 {% block logo_login %}{% include 'partials/logo_login.html.twig' %}{% endblock %}
-{% block title %}Kimai - {{ 'time_tracking'|trans }}{% endblock %}
+{% block title %}{{- get_title() -}}{% endblock %}
 
 {% block head %}
     {{ parent() }}

--- a/templates/bundles/FOSUserBundle/Resetting/request.html.twig
+++ b/templates/bundles/FOSUserBundle/Resetting/request.html.twig
@@ -1,7 +1,7 @@
 {% extends '@AdminLTE/FOSUserBundle/Resetting/request.html.twig' %}
 
 {% block logo_login %}{% include 'partials/logo_login.html.twig' %}{% endblock %}
-{% block title %}{{ 'browser.title'|trans }}{% endblock %}
+{% block title %}Kimai - {{ 'time_tracking'|trans }}{% endblock %}
 
 {% block head %}
     {{ parent() }}

--- a/templates/bundles/FOSUserBundle/Resetting/request.html.twig
+++ b/templates/bundles/FOSUserBundle/Resetting/request.html.twig
@@ -1,7 +1,7 @@
 {% extends '@AdminLTE/FOSUserBundle/Resetting/request.html.twig' %}
 
 {% block logo_login %}{% include 'partials/logo_login.html.twig' %}{% endblock %}
-{% block title %}Kimai - {{ 'time_tracking'|trans }}{% endblock %}
+{% block title %}{{- get_title() -}}{% endblock %}
 
 {% block head %}
     {{ parent() }}

--- a/templates/bundles/FOSUserBundle/Security/login.html.twig
+++ b/templates/bundles/FOSUserBundle/Security/login.html.twig
@@ -1,7 +1,7 @@
 {% extends '@AdminLTE/FOSUserBundle/Security/login.html.twig' %}
 
 {% block logo_login %}{% include 'partials/logo_login.html.twig' %}{% endblock %}
-{% block title %}Kimai - {{ 'time_tracking'|trans }}{% endblock %}
+{% block title %}{{- get_title() -}}{% endblock %}
 
 {% block login_box_icon %}
     <span class="glyphicon glyphicon-user"></span>

--- a/templates/bundles/FOSUserBundle/Security/login.html.twig
+++ b/templates/bundles/FOSUserBundle/Security/login.html.twig
@@ -1,7 +1,7 @@
 {% extends '@AdminLTE/FOSUserBundle/Security/login.html.twig' %}
 
 {% block logo_login %}{% include 'partials/logo_login.html.twig' %}{% endblock %}
-{% block title %}{{ 'browser.title'|trans }}{% endblock %}
+{% block title %}Kimai - {{ 'time_tracking'|trans }}{% endblock %}
 
 {% block login_box_icon %}
     <span class="glyphicon glyphicon-user"></span>

--- a/templates/bundles/FOSUserBundle/layout.html.twig
+++ b/templates/bundles/FOSUserBundle/layout.html.twig
@@ -1,7 +1,7 @@
 {% extends '@AdminLTE/FOSUserBundle/layout.html.twig' %}
 
 {% block logo_login %}{% include 'partials/logo_login.html.twig' %}{% endblock %}
-{% block title %}{{ 'browser.title'|trans }}{% endblock %}
+{% block title %}Kimai - {{ 'time_tracking'|trans }}{% endblock %}
 
 {% block head %}
     {{ parent() }}

--- a/templates/bundles/FOSUserBundle/layout.html.twig
+++ b/templates/bundles/FOSUserBundle/layout.html.twig
@@ -1,7 +1,7 @@
 {% extends '@AdminLTE/FOSUserBundle/layout.html.twig' %}
 
 {% block logo_login %}{% include 'partials/logo_login.html.twig' %}{% endblock %}
-{% block title %}Kimai - {{ 'time_tracking'|trans }}{% endblock %}
+{% block title %}{{- get_title() -}}{% endblock %}
 
 {% block head %}
     {{ parent() }}

--- a/templates/macros/datatables.html.twig
+++ b/templates/macros/datatables.html.twig
@@ -12,7 +12,7 @@
                     {% for title, class in entries %}
                         {% if 'alwaysVisible' not in class %}
                             <div class="form-group">
-                                <input type="checkbox" id="column_{{ title }}" name="{{ title }}"{% if is_visible_column(name, title, '') %} checked="checked"{% endif %}>
+                                <input type="checkbox" id="column_{{ title }}" name="{{ title }}"{% if is_visible_column(name, title) %} checked="checked"{% endif %}>
                                 <label class="control-label required" for="column_{{ title }}">{{ ('label.' ~ title)|trans }}</label>
                             </div>
                         {% endif %}
@@ -45,9 +45,9 @@
                 {% endif %}
             {% endfor %}
         {% else %}
-            {% if not is_visible_column(name, column, '') %}
+            {% if not is_visible_column(name, column) %}
                 {% set classes = classes ~ ' hidden' %}
-            {% elseif not is_datatable_configured(name, '') %}
+            {% elseif not is_datatable_configured(name) %}
                 {% for tmp in classes|split(' ') %}
                     {% if 'hidden' == tmp %}
                         {% set classes = classes|replace({(tmp): ''}) %}

--- a/templates/partials/logo_login.html.twig
+++ b/templates/partials/logo_login.html.twig
@@ -1,1 +1,1 @@
-<b>Kimai</b><br>TimeTracking
+<b>Kimai</b><br>{{ 'time_tracking'|trans }}

--- a/templates/partials/logo_login.html.twig
+++ b/templates/partials/logo_login.html.twig
@@ -1,1 +1,1 @@
-<b>Kimai</b><br>{{ 'time_tracking'|trans }}
+{{- get_title('<b>', '</b><br>')|raw -}}

--- a/tests/Controller/SecurityControllerTest.php
+++ b/tests/Controller/SecurityControllerTest.php
@@ -36,7 +36,7 @@ class SecurityControllerTest extends ControllerBaseTest
         $this->assertTrue($client->getResponse()->isSuccessful());
 
         $content = $response->getContent();
-        $this->assertContains('<title>Kimai - Time Tracking</title>', $content);
+        $this->assertContains('<title>Kimai – Time Tracking</title>', $content);
         $this->assertContains('<form action="/en/login_check" method="post">', $content);
         $this->assertContains('<input type="text" name="_username"', $content);
         $this->assertContains('<input name="_password" type="password"', $content);
@@ -56,7 +56,7 @@ class SecurityControllerTest extends ControllerBaseTest
         $this->assertTrue($response->isSuccessful());
 
         $content = $response->getContent();
-        $this->assertContains('<title>Kimai - Time Tracking</title>', $content);
+        $this->assertContains('<title>Kimai – Time Tracking</title>', $content);
         $this->assertContains('Register a new account', $content);
         $this->assertContains('<form name="fos_user_registration_form" method="post" action="/en/register/" class="fos_user_registration_register">', $content);
         $this->assertContains('<input type="email"', $content);
@@ -96,7 +96,7 @@ class SecurityControllerTest extends ControllerBaseTest
         $this->assertTrue($client->getResponse()->isSuccessful());
 
         $content = $client->getResponse()->getContent();
-        $this->assertContains('<title>Kimai - Time Tracking</title>', $content);
+        $this->assertContains('<title>Kimai – Time Tracking</title>', $content);
         $this->assertContains('<p>Congrats example, your account is now activated.</p>', $content);
         $this->assertContains('<a href="/en/homepage">', $content);
     }

--- a/tests/Export/Renderer/AbstractRendererTest.php
+++ b/tests/Export/Renderer/AbstractRendererTest.php
@@ -50,7 +50,7 @@ abstract class AbstractRendererTest extends KernelTestCase
 
         $translator = $this->getMockBuilder(TranslatorInterface::class)->getMock();
         $dateExtension = new DateExtensions($localeSettings);
-        $extensions = new Extensions($requestStack, $localeSettings);
+        $extensions = new Extensions($localeSettings);
 
         return new $classname($translator, $dateExtension, $extensions);
     }

--- a/tests/Invoice/Renderer/AbstractRendererTest.php
+++ b/tests/Invoice/Renderer/AbstractRendererTest.php
@@ -74,7 +74,7 @@ abstract class AbstractRendererTest extends KernelTestCase
 
         $translator = $this->getMockBuilder(TranslatorInterface::class)->getMock();
         $dateExtension = new DateExtensions($localeSettings);
-        $extensions = new Extensions($requestStack, $localeSettings);
+        $extensions = new Extensions($localeSettings);
 
         return new $classname($translator, $dateExtension, $extensions);
     }

--- a/tests/Timesheet/UserDateTimeFactoryTest.php
+++ b/tests/Timesheet/UserDateTimeFactoryTest.php
@@ -23,7 +23,7 @@ use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
  */
 class UserDateTimeFactoryTest extends TestCase
 {
-    public const TEST_TIMEZONE = 'Antarctica/DumontDUrville';
+    public const TEST_TIMEZONE = 'Europe/London';
 
     protected function createDateTimeFactory(string $timezone)
     {

--- a/tests/Twig/DatatableExtensionsTest.php
+++ b/tests/Twig/DatatableExtensionsTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Twig;
+
+use App\Twig\DatatableExtensions;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
+use Twig\TwigFunction;
+
+/**
+ * @covers \App\Twig\DatatableExtensions
+ */
+class DatatableExtensionsTest extends TestCase
+{
+    protected function getSut(string $locale): DatatableExtensions
+    {
+        $request = new Request();
+        $request->setLocale($locale);
+        $requestStack = new RequestStack();
+        $requestStack->push($request);
+
+        return new DatatableExtensions($requestStack);
+    }
+
+    public function testGetFunctions()
+    {
+        $functions = ['is_visible_column', 'is_datatable_configured'];
+        $sut = $this->getSut('de');
+        $twigFunctions = $sut->getFunctions();
+        $this->assertCount(count($functions), $twigFunctions);
+        $i = 0;
+        /** @var TwigFunction $function */
+        foreach ($twigFunctions as $function) {
+            $this->assertInstanceOf(TwigFunction::class, $function);
+            $this->assertEquals($functions[$i++], $function->getName());
+        }
+    }
+}

--- a/tests/Twig/ExtensionsTest.php
+++ b/tests/Twig/ExtensionsTest.php
@@ -45,7 +45,7 @@ class ExtensionsTest extends TestCase
 
         $localeSettings = new LocaleSettings($requestStack, new LanguageFormattings($locales));
 
-        return new Extensions($requestStack, $localeSettings);
+        return new Extensions($localeSettings);
     }
 
     public function testGetFilters()
@@ -55,6 +55,7 @@ class ExtensionsTest extends TestCase
         $twigFilters = $sut->getFilters();
         $this->assertCount(count($filters), $twigFilters);
         $i = 0;
+        /** @var TwigFilter $filter */
         foreach ($twigFilters as $filter) {
             $this->assertInstanceOf(TwigFilter::class, $filter);
             $this->assertEquals($filters[$i++], $filter->getName());
@@ -63,11 +64,12 @@ class ExtensionsTest extends TestCase
 
     public function testGetFunctions()
     {
-        $functions = ['locales', 'is_visible_column', 'is_datatable_configured', 'class_name'];
+        $functions = ['locales', 'class_name'];
         $sut = $this->getSut($this->localeDe);
         $twigFunctions = $sut->getFunctions();
         $this->assertCount(count($functions), $twigFunctions);
         $i = 0;
+        /** @var TwigFunction $filter */
         foreach ($twigFunctions as $filter) {
             $this->assertInstanceOf(TwigFunction::class, $filter);
             $this->assertEquals($functions[$i++], $filter->getName());

--- a/tests/Twig/TitleExtensionTest.php
+++ b/tests/Twig/TitleExtensionTest.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Twig;
+
+use App\Twig\TitleExtension;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Twig\TwigFunction;
+
+/**
+ * @covers \App\Twig\TitleExtension
+ */
+class TitleExtensionTest extends TestCase
+{
+    protected function getSut(): TitleExtension
+    {
+        $translator = $this->getMockBuilder(TranslatorInterface::class)->getMock();
+        $translator->method('trans')->willReturn('foo');
+
+        return new TitleExtension($translator);
+    }
+
+    public function testGetFunctions()
+    {
+        $functions = ['get_title'];
+        $sut = $this->getSut();
+        $twigFunctions = $sut->getFunctions();
+        $this->assertCount(count($functions), $twigFunctions);
+        $i = 0;
+        /** @var TwigFunction $function */
+        foreach ($twigFunctions as $function) {
+            $this->assertInstanceOf(TwigFunction::class, $function);
+            $this->assertEquals($functions[$i++], $function->getName());
+        }
+    }
+
+    public function testGetTitle()
+    {
+        $sut = $this->getSut();
+        $this->assertEquals('Kimai – foo', $sut->generateTitle());
+        $this->assertEquals('sdfsdf | Kimai – foo', $sut->generateTitle('sdfsdf | '));
+        $this->assertEquals('<b>Kimai</b> ... foo', $sut->generateTitle('<b>', '</b> ... '));
+        $this->assertEquals('Kimai | foo', $sut->generateTitle(null, ' | '));
+    }
+}

--- a/translations/messages.ar.xliff
+++ b/translations/messages.ar.xliff
@@ -5,9 +5,9 @@
             <!--
               Global template keys
             -->
-            <trans-unit id="browser.title">
-                <source>browser.title</source>
-                <target>Kimai - Time Tracking</target>
+            <trans-unit id="time_tracking">
+                <source>time_tracking</source>
+                <target>Time Tracking</target>
             </trans-unit>
             <trans-unit id="yes">
                 <source>yes</source>

--- a/translations/messages.de.xliff
+++ b/translations/messages.de.xliff
@@ -5,9 +5,9 @@
             <!--
               Global template keys
             -->
-            <trans-unit id="browser.title">
-                <source>browser.title</source>
-                <target>Kimai - Zeiterfassung</target>
+            <trans-unit id="time_tracking">
+                <source>time_tracking</source>
+                <target>Zeiterfassung</target>
             </trans-unit>
             <trans-unit id="yes">
                 <source>yes</source>

--- a/translations/messages.en.xliff
+++ b/translations/messages.en.xliff
@@ -5,9 +5,9 @@
             <!--
               Global template keys
             -->
-            <trans-unit id="browser.title">
-                <source>browser.title</source>
-                <target>Kimai - Time Tracking</target>
+            <trans-unit id="time_tracking">
+                <source>time_tracking</source>
+                <target>Time Tracking</target>
             </trans-unit>
             <trans-unit id="yes">
                 <source>yes</source>

--- a/translations/messages.es.xliff
+++ b/translations/messages.es.xliff
@@ -5,9 +5,9 @@
             <!--
               Global template keys
             -->
-            <trans-unit id="browser.title">
-                <source>browser.title</source>
-                <target>Kimai - Control de Tiempo</target>
+            <trans-unit id="time_tracking">
+                <source>time_tracking</source>
+                <target>Control de Tiempo</target>
             </trans-unit>
             <trans-unit id="yes">
                 <source>yes</source>

--- a/translations/messages.fr.xliff
+++ b/translations/messages.fr.xliff
@@ -5,9 +5,9 @@
             <!--
               Global template keys
             -->
-            <trans-unit id="browser.title">
-                <source>browser.title</source>
-                <target>Kimai - Suivi des temps</target>
+            <trans-unit id="time_tracking">
+                <source>time_tracking</source>
+                <target>Suivi des temps</target>
             </trans-unit>
             <trans-unit id="yes">
                 <source>yes</source>

--- a/translations/messages.hu.xliff
+++ b/translations/messages.hu.xliff
@@ -5,9 +5,9 @@
             <!--
               Global template keys
             -->
-            <trans-unit id="browser.title">
-                <source>browser.title</source>
-                <target>Kimai - Időrögzítő</target>
+            <trans-unit id="time_tracking">
+                <source>time_tracking</source>
+                <target>Időrögzítő</target>
             </trans-unit>
             <trans-unit id="yes">
                 <source>yes</source>

--- a/translations/messages.it.xliff
+++ b/translations/messages.it.xliff
@@ -5,9 +5,9 @@
             <!--
               Global template keys
             -->
-            <trans-unit id="browser.title">
-                <source>browser.title</source>
-                <target>Kimai - Time Tracking</target>
+            <trans-unit id="time_tracking">
+                <source>time_tracking</source>
+                <target>Time Tracking</target>
             </trans-unit>
             <trans-unit id="yes">
                 <source>yes</source>

--- a/translations/messages.pt_BR.xliff
+++ b/translations/messages.pt_BR.xliff
@@ -5,9 +5,9 @@
             <!--
               Global template keys
             -->
-            <trans-unit id="browser.title">
-                <source>browser.title</source>
-                <target>Kimai - Time Tracking</target>
+            <trans-unit id="time_tracking">
+                <source>time_tracking</source>
+                <target>Time Tracking</target>
             </trans-unit>
             <trans-unit id="yes">
                 <source>yes</source>

--- a/translations/messages.ru.xliff
+++ b/translations/messages.ru.xliff
@@ -5,9 +5,9 @@
             <!--
               Global template keys
             -->
-            <trans-unit id="browser.title">
-                <source>browser.title</source>
-                <target>Kimai - Учет времени</target>
+            <trans-unit id="time_tracking">
+                <source>time_tracking</source>
+                <target>Учет времени</target>
             </trans-unit>
             <trans-unit id="yes">
                 <source>yes</source>

--- a/translations/messages.sv.xliff
+++ b/translations/messages.sv.xliff
@@ -5,9 +5,9 @@
             <!--
               Global template keys
             -->
-            <trans-unit id="browser.title">
-                <source>browser.title</source>
-                <target state="translated">Kimai - Tidsredovisning</target>
+            <trans-unit id="time_tracking">
+                <source>time_tracking</source>
+                <target state="translated">Tidsredovisning</target>
             </trans-unit>
             <trans-unit id="yes">
                 <source>yes</source>


### PR DESCRIPTION
## Description

translate the string "time-tracking" in login screen and browser title

**TODO**
- [x] create a new "title" twig filter, which takes a delimiter (`-` or `<br>`) and an optional prefix
- [x] use twig filter instead of the hardcoded version `Kimai - {{ 'time_tracking'|trans }}`

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
