### PR TITLE
Improve Japanese Translation on "timesheet" / "entry"

### DIFF
--- a/translations/flashmessages.ja.xliff
+++ b/translations/flashmessages.ja.xliff
@@ -32,11 +32,11 @@
             </trans-unit>
             <trans-unit id="action.delete.success">
                 <source>action.delete.success</source>
-                <target>エントリを削除しました</target>
+                <target>明細を削除しました</target>
             </trans-unit>
             <trans-unit id="action.delete.error">
                 <source>action.delete.error</source>
-                <target>エントリを削除できませんでした: %reason%</target>
+                <target>明細を削除できませんでした: %reason%</target>
             </trans-unit>
             <trans-unit id="invoice.first_template">
                 <source>invoice.first_template</source>

--- a/translations/invoice-calculator.ja.xliff
+++ b/translations/invoice-calculator.ja.xliff
@@ -8,7 +8,7 @@
             </trans-unit>
             <trans-unit id="default">
                 <source>default</source>
-                <target>エントリ基準 - 時間を記録した個々の明細を出力します (デフォルト)</target>
+                <target>明細基準 - 時間を記録した個々の明細を出力します (デフォルト)</target>
             </trans-unit>
             <trans-unit id="short">
                 <source>short</source>

--- a/translations/messages.ja.xliff
+++ b/translations/messages.ja.xliff
@@ -99,7 +99,7 @@
             </trans-unit>
             <trans-unit id="menu.timesheet">
                 <source>menu.timesheet</source>
-                <target>時間の記録</target>
+                <target>タイムシート</target>
             </trans-unit>
             <trans-unit id="menu.invoice">
                 <source>menu.invoice</source>
@@ -111,7 +111,7 @@
             </trans-unit>
             <trans-unit id="menu.admin_timesheet">
                 <source>menu.admin_timesheet</source>
-                <target>タイムシート</target>
+                <target>チームのタイムシート</target>
             </trans-unit>
             <trans-unit id="menu.admin_customer">
                 <source>menu.admin_customer</source>
@@ -323,11 +323,11 @@
             -->
             <trans-unit id="timesheet.title">
                 <source>timesheet.title</source>
-                <target>時間の記録</target>
+                <target>タイムシート</target>
             </trans-unit>
             <trans-unit id="timesheet.subtitle">
                 <source>timesheet.subtitle</source>
-                <target>時間記録の管理</target>
+                <target>タイムシートの管理</target>
             </trans-unit>
             <trans-unit id="timesheet.edit">
                 <source>timesheet.edit</source>
@@ -448,7 +448,7 @@
             -->
             <trans-unit id="admin_timesheet.title">
                 <source>admin_timesheet.title</source>
-                <target>タイムシート</target>
+                <target>チームのタイムシート</target>
             </trans-unit>
             <trans-unit id="admin_timesheet.subtitle">
                 <source>admin_timesheet.subtitle</source>

--- a/translations/messages.ja.xliff
+++ b/translations/messages.ja.xliff
@@ -147,7 +147,7 @@
             -->
             <trans-unit id="error.no_entries_found">
                 <source>error.no_entries_found</source>
-                <target>指定されたフィルタ条件に該当するエントリは見付かりませんでした。</target>
+                <target>指定されたフィルタ条件に該当する明細は見付かりませんでした。</target>
             </trans-unit>
 
             <!--
@@ -251,7 +251,7 @@
             </trans-unit>
             <trans-unit id="label.create_more">
                 <source>label.create_more</source>
-                <target>未来のエントリを作成する</target>
+                <target>未来時間の明細を作成する</target>
             </trans-unit>
 
             <!--

--- a/translations/system-configuration.ja.xliff
+++ b/translations/system-configuration.ja.xliff
@@ -44,11 +44,11 @@
             </trans-unit>
             <trans-unit id="label.timesheet.active_entries.hard_limit">
                 <source>label.timesheet.active_entries.hard_limit</source>
-                <target>同じ期間内に同時進行のものとして入力可能とするエントリの上限数</target>
+                <target>同じ期間内に同時進行のものとして記録可能とする明細の上限数</target>
             </trans-unit>
             <trans-unit id="label.timesheet.active_entries.soft_limit">
                 <source>label.timesheet.active_entries.soft_limit</source>
-                <target>同時進行のエントリがこちらの数を超える場合に警告を表示する</target>
+                <target>同時進行の記録明細がこちらの数を超える場合に警告を表示する</target>
             </trans-unit>
             <trans-unit id="label.theme.select_type">
                 <source>label.theme.select_type</source>


### PR DESCRIPTION
## Description
This commits are trying to improve Japanese translation on "timesheet" / "entry"

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I ran `bin/console kimai:codestyle --fix` to verify the correct code style
- [ ] I have updated the [documentation](https://github.com/kimai/www.kimai.org/tree/master/_documentation) accordingly
- [ ] I have added tests to cover my changes
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
