### PR TITLE
allow markdown for customer, project and activity comments

### DIFF
--- a/src/Controller/SystemConfigurationController.php
+++ b/src/Controller/SystemConfigurationController.php
@@ -192,10 +192,6 @@ class SystemConfigurationController extends AbstractController
                         ->setType(TimesheetModeType::class)
                         ->setTranslationDomain('system-configuration'),
                     (new Configuration())
-                        ->setName('timesheet.markdown_content')
-                        ->setType(CheckboxType::class)
-                        ->setTranslationDomain('system-configuration'),
-                    (new Configuration())
                         ->setName('timesheet.rules.allow_future_times')
                         ->setType(CheckboxType::class)
                         ->setTranslationDomain('system-configuration'),
@@ -237,6 +233,11 @@ class SystemConfigurationController extends AbstractController
                         ->setName('theme.select_type')
                         ->setTranslationDomain('system-configuration')
                         ->setType(EnhancedSelectboxType::class),
+                    (new Configuration())
+                        ->setName('timesheet.markdown_content')
+                        ->setLabel('theme.markdown_content')
+                        ->setType(CheckboxType::class)
+                        ->setTranslationDomain('system-configuration'),
                 ]),
             (new SystemConfigurationModel())
                 ->setSection(SystemConfigurationModel::SECTION_CALENDAR)

--- a/src/Twig/MarkdownExtension.php
+++ b/src/Twig/MarkdownExtension.php
@@ -46,6 +46,7 @@ class MarkdownExtension extends AbstractExtension
         return [
             new TwigFilter('md2html', [$this, 'markdownToHtml'], ['is_safe' => ['html']]),
             new TwigFilter('desc2html', [$this, 'timesheetContent'], ['is_safe' => ['html']]),
+            new TwigFilter('comment2html', [$this, 'timesheetContent'], ['is_safe' => ['html']]),
         ];
     }
 

--- a/templates/activity/index.html.twig
+++ b/templates/activity/index.html.twig
@@ -47,7 +47,7 @@
                         {{ widgets.label_project(entry.project, path('admin_project_edit', {'id' : entry.project.id})) }}
                     {% endif %}
                 </td>
-                <td class="{{ tables.data_table_column_class(tableName, columns, 'comment') }}">{{ entry.comment }}</td>
+                <td class="{{ tables.data_table_column_class(tableName, columns, 'comment') }}">{{ entry.comment|comment2html }}</td>
                 <td class="{{ tables.data_table_column_class(tableName, columns, 'visible') }}">{{ widgets.label_visible(entry.visible) }}</td>
                 <td class="actions">
                     {{ actions.activity(entry, 'index') }}

--- a/templates/customer/index.html.twig
+++ b/templates/customer/index.html.twig
@@ -35,7 +35,7 @@
         {% for entry in entries %}
             <tr{% if is_granted('edit', entry) %} class="modal-ajax-form open-edit" data-href="{{ path('admin_customer_edit', {'id': entry.id}) }}"{% endif %}>
                 <td>{{ widgets.label_color_dot('customer', true, entry.name, null, entry.color) }} {% if entry.company is not empty %}({{ entry.company }}){% endif %}</td>
-                <td class="{{ tables.data_table_column_class(tableName, columns, 'comment') }}">{{ entry.comment }}</td>
+                <td class="{{ tables.data_table_column_class(tableName, columns, 'comment') }}">{{ entry.comment|comment2html }}</td>
                 <td class="{{ tables.data_table_column_class(tableName, columns, 'country') }}">{{ entry.country|country }}</td>
                 <td class="{{ tables.data_table_column_class(tableName, columns, 'number') }}">{{ entry.number }}</td>
                 <td class="{{ tables.data_table_column_class(tableName, columns, 'currency') }}">{{ entry.currency }} {{ entry.currency|currency }}</td>

--- a/templates/project/index.html.twig
+++ b/templates/project/index.html.twig
@@ -37,7 +37,7 @@
                 <td class="{{ tables.data_table_column_class(tableName, columns, 'customer') }}">
                     {{ widgets.label_customer(entry.customer, path('admin_customer_edit', {'id' : entry.customer.id})) }}
                 </td>
-                <td class="{{ tables.data_table_column_class(tableName, columns, 'comment') }}">{{ entry.comment }}</td>
+                <td class="{{ tables.data_table_column_class(tableName, columns, 'comment') }}">{{ entry.comment|comment2html }}</td>
                 <td class="{{ tables.data_table_column_class(tableName, columns, 'budget') }}">{{ entry.budget|money(entry.customer.currency) }}</td>
                 <td class="{{ tables.data_table_column_class(tableName, columns, 'visible') }}">{{ widgets.label_visible(entry.visible) }}</td>
                 <td class="actions">

--- a/tests/Controller/SystemConfigurationControllerTest.php
+++ b/tests/Controller/SystemConfigurationControllerTest.php
@@ -61,7 +61,6 @@ class SystemConfigurationControllerTest extends ControllerBaseTest
         $this->assertAccessIsGranted($client, '/admin/system-config/');
 
         $configService = $client->getContainer()->get(SystemConfiguration::class);
-        $this->assertEquals(false, $configService->find('timesheet.markdown_content'));
         $this->assertEquals('default', $configService->find('timesheet.mode'));
         $this->assertEquals(true, $configService->find('timesheet.rules.allow_future_times'));
         $this->assertEquals(1, $configService->find('timesheet.active_entries.hard_limit'));
@@ -72,7 +71,6 @@ class SystemConfigurationControllerTest extends ControllerBaseTest
             'system_configuration_form_timesheet' => [
                 'configuration' => [
                     ['name' => 'timesheet.mode', 'value' => 'duration_only'],
-                    ['name' => 'timesheet.markdown_content', 'value' => 1],
                     ['name' => 'timesheet.rules.allow_future_times', 'value' => false],
                     ['name' => 'timesheet.active_entries.hard_limit', 'value' => 99],
                     ['name' => 'timesheet.active_entries.soft_limit', 'value' => 77],
@@ -86,7 +84,6 @@ class SystemConfigurationControllerTest extends ControllerBaseTest
         $this->assertHasFlashSaveSuccess($client);
 
         $configService = $client->getContainer()->get(SystemConfiguration::class);
-        $this->assertEquals(true, $configService->find('timesheet.markdown_content'));
         $this->assertEquals('duration_only', $configService->find('timesheet.mode'));
         $this->assertEquals(false, $configService->find('timesheet.rules.allow_future_times'));
         $this->assertEquals(99, $configService->find('timesheet.active_entries.hard_limit'));
@@ -103,7 +100,6 @@ class SystemConfigurationControllerTest extends ControllerBaseTest
                 'system_configuration_form_timesheet' => [
                     'configuration' => [
                         ['name' => 'timesheet.mode', 'value' => 'foo'],
-                        ['name' => 'timesheet.markdown_content', 'value' => 1],
                         ['name' => 'timesheet.rules.allow_future_times', 'value' => 1],
                         ['name' => 'timesheet.active_entries.hard_limit', 'value' => -1],
                         ['name' => 'timesheet.active_entries.soft_limit', 'value' => -1],
@@ -112,8 +108,8 @@ class SystemConfigurationControllerTest extends ControllerBaseTest
             ],
             [
                 '#system_configuration_form_timesheet_configuration_0_value', // mode
-                '#system_configuration_form_timesheet_configuration_3_value', // hard_limit
-                '#system_configuration_form_timesheet_configuration_4_value', // soft_limit
+                '#system_configuration_form_timesheet_configuration_2_value', // hard_limit
+                '#system_configuration_form_timesheet_configuration_3_value', // soft_limit
             ],
             true
         );
@@ -181,6 +177,7 @@ class SystemConfigurationControllerTest extends ControllerBaseTest
         $this->assertAccessIsGranted($client, '/admin/system-config/');
 
         $configService = $client->getContainer()->get(SystemConfiguration::class);
+        $this->assertEquals(false, $configService->find('timesheet.markdown_content'));
         $this->assertNull($configService->find('theme.select_type'));
 
         $form = $client->getCrawler()->filter('form[name=system_configuration_form_theme]')->form();
@@ -188,6 +185,7 @@ class SystemConfigurationControllerTest extends ControllerBaseTest
             'system_configuration_form_theme' => [
                 'configuration' => [
                     ['name' => 'theme.select_type', 'value' => '1'],
+                    ['name' => 'timesheet.markdown_content', 'value' => 1],
                 ]
             ]
         ]);
@@ -199,6 +197,7 @@ class SystemConfigurationControllerTest extends ControllerBaseTest
 
         $configService = $client->getContainer()->get(SystemConfiguration::class);
         $this->assertEquals('selectpicker', $configService->find('theme.select_type'));
+        $this->assertEquals(true, $configService->find('timesheet.markdown_content'));
     }
 
     public function testUpdateThemeConfigValidation()
@@ -211,6 +210,7 @@ class SystemConfigurationControllerTest extends ControllerBaseTest
                 'system_configuration_form_theme' => [
                     'configuration' => [
                         ['name' => 'theme.select_type', 'value' => 'foo'],
+                        ['name' => 'timesheet.markdown_content', 'value' => 1],
                     ]
                 ]
             ],

--- a/tests/Twig/MarkdownExtensionTest.php
+++ b/tests/Twig/MarkdownExtensionTest.php
@@ -26,9 +26,10 @@ class MarkdownExtensionTest extends TestCase
         $config = new TimesheetConfiguration($loader, ['markdown_content' => true]);
         $sut = new MarkdownExtension(new Markdown(), $config);
         $filters = $sut->getFilters();
-        $this->assertCount(2, $filters);
+        $this->assertCount(3, $filters);
         $this->assertEquals('md2html', $filters[0]->getName());
         $this->assertEquals('desc2html', $filters[1]->getName());
+        $this->assertEquals('comment2html', $filters[2]->getName());
     }
 
     public function testMarkdownToHtml()

--- a/translations/system-configuration.de.xliff
+++ b/translations/system-configuration.de.xliff
@@ -26,9 +26,9 @@
                 <source>calendar</source>
                 <target>Kalender</target>
             </trans-unit>
-            <trans-unit id="label.timesheet.markdown_content">
-                <source>label.timesheet.markdown_content</source>
-                <target>Erlaube Markdown in den Beschreibungen der erfassten Zeiten</target>
+            <trans-unit id="label.theme.markdown_content">
+                <source>label.theme.markdown_content</source>
+                <target>Erlaube Markdown-Formatierungen in Beschreibungen und Kommentaren</target>
             </trans-unit>
             <trans-unit id="label.timesheet.mode">
                 <source>label.timesheet.mode</source>

--- a/translations/system-configuration.en.xliff
+++ b/translations/system-configuration.en.xliff
@@ -26,9 +26,9 @@
                 <source>calendar</source>
                 <target>Calendar</target>
             </trans-unit>
-            <trans-unit id="label.timesheet.markdown_content">
-                <source>label.timesheet.markdown_content</source>
-                <target>Allow Markdown in the timesheet descriptions</target>
+            <trans-unit id="label.theme.markdown_content">
+                <source>label.theme.markdown_content</source>
+                <target>Allow markdown-formattings in descriptions and comments</target>
             </trans-unit>
             <trans-unit id="label.timesheet.mode">
                 <source>label.timesheet.mode</source>

--- a/translations/system-configuration.hu.xliff
+++ b/translations/system-configuration.hu.xliff
@@ -18,10 +18,6 @@
                 <source>form_customer</source>
                 <target>Új ügyfél alapértelmezett értékei</target>
             </trans-unit>
-            <trans-unit id="label.timesheet.markdown_content">
-                <source>label.timesheet.markdown_content</source>
-                <target>Markdown használatának engedélyezése a rögzítések leírásában</target>
-            </trans-unit>
             <trans-unit id="label.timesheet.mode_duration_only">
                 <source>label.timesheet.mode_duration_only</source>
                 <target>"Csak időtartam" mód - a befejezés mezőt kicseréli időtartamra</target>

--- a/translations/system-configuration.ja.xliff
+++ b/translations/system-configuration.ja.xliff
@@ -22,10 +22,6 @@
                 <source>theme</source>
                 <target>テーマ</target>
             </trans-unit>
-            <trans-unit id="label.timesheet.markdown_content">
-                <source>label.timesheet.markdown_content</source>
-                <target>タイムシートの説明文を Markdown 書式で書けるようにする</target>
-            </trans-unit>
             <trans-unit id="label.timesheet.mode">
                 <source>label.timesheet.mode</source>
                 <target>タイムトラッキング モード</target>

--- a/translations/system-configuration.sv.xliff
+++ b/translations/system-configuration.sv.xliff
@@ -18,10 +18,6 @@
                 <source>form_customer</source>
                 <target state="translated">Skapa kund - standardvärden</target>
             </trans-unit>
-            <trans-unit id="label.timesheet.markdown_content">
-                <source>label.timesheet.markdown_content</source>
-                <target state="translated">Tillåt Markdown i tidskriftsbeskrivningarna</target>
-            </trans-unit>
             <trans-unit id="label.timesheet.mode">
                 <source>label.timesheet.mode</source>
                 <target state="translated">Tidsredovisningsläge</target>


### PR DESCRIPTION
## Description

- Re-use the config `timesheet.markdown_content` to indicate, that comments for customer / projects / activities can be rendered with markdown as well
- Changed label name to `label.theme.markdown_content` (as the config might be renamed later on)
- Moved config to theme section

Fixes #677 

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation accordingly (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
