### PR TITLE
export tags in spreadsheets

### DIFF
--- a/src/Export/Renderer/AbstractSpreadsheetRenderer.php
+++ b/src/Export/Renderer/AbstractSpreadsheetRenderer.php
@@ -14,6 +14,7 @@ use App\Repository\Query\TimesheetQuery;
 use App\Twig\DateExtensions;
 use App\Twig\Extensions;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Style\Border;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
@@ -110,6 +111,7 @@ abstract class AbstractSpreadsheetRenderer
         $sheet->setCellValueByColumnAndRow($recordsHeaderColumn++, $recordsHeaderRow, $this->translator->trans('label.activity'));
         $sheet->setCellValueByColumnAndRow($recordsHeaderColumn++, $recordsHeaderRow, $this->translator->trans('label.description'));
         $sheet->setCellValueByColumnAndRow($recordsHeaderColumn++, $recordsHeaderRow, $this->translator->trans('label.exported'));
+        $sheet->setCellValueByColumnAndRow($recordsHeaderColumn++, $recordsHeaderRow, $this->translator->trans('label.tags'));
         $sheet->setCellValueByColumnAndRow($recordsHeaderColumn++, $recordsHeaderRow, $this->translator->trans('label.hourlyRate'));
         $sheet->setCellValueByColumnAndRow($recordsHeaderColumn++, $recordsHeaderRow, $this->translator->trans('label.fixedRate'));
         $sheet->setCellValueByColumnAndRow($recordsHeaderColumn++, $recordsHeaderRow, $this->translator->trans('label.duration'));
@@ -145,6 +147,7 @@ abstract class AbstractSpreadsheetRenderer
             $sheet->setCellValueByColumnAndRow($entryHeaderColumn++, $entryHeaderRow, $timesheet->getActivity()->getName());
             $sheet->setCellValueByColumnAndRow($entryHeaderColumn++, $entryHeaderRow, $timesheet->getDescription());
             $sheet->setCellValueByColumnAndRow($entryHeaderColumn++, $entryHeaderRow, $this->translator->trans($exported));
+            $sheet->setCellValueByColumnAndRow($entryHeaderColumn++, $entryHeaderRow, implode(',', $timesheet->getTagsAsArray()));
             $sheet->setCellValueByColumnAndRow($entryHeaderColumn++, $entryHeaderRow, $this->getFormattedMoney($timesheet->getHourlyRate(), $customerCurrency));
             $sheet->setCellValueByColumnAndRow($entryHeaderColumn++, $entryHeaderRow, $this->getFormattedMoney($timesheet->getFixedRate(), $customerCurrency));
             $sheet->setCellValueByColumnAndRow($entryHeaderColumn++, $entryHeaderRow, $this->getFormattedDuration($timesheet->getDuration()));
@@ -153,13 +156,13 @@ abstract class AbstractSpreadsheetRenderer
             $entryHeaderRow++;
         }
 
-        $sheet->setCellValueByColumnAndRow(11, $entryHeaderRow, $this->getFormattedDuration($durationTotal));
-        $sheet->setCellValueByColumnAndRow(12, $entryHeaderRow, $this->getFormattedMoney($rateTotal, $currency));
-        $sheet->getCellByColumnAndRow(11, $entryHeaderRow)->getStyle()->getBorders()->getTop()->setBorderStyle(\PhpOffice\PhpSpreadsheet\Style\Border::BORDER_THIN);
-        $sheet->getCellByColumnAndRow(11, $entryHeaderRow)->getStyle()->getFont()->setBold(true);
-
-        $sheet->getCellByColumnAndRow(12, $entryHeaderRow)->getStyle()->getBorders()->getTop()->setBorderStyle(\PhpOffice\PhpSpreadsheet\Style\Border::BORDER_THIN);
+        $sheet->setCellValueByColumnAndRow(12, $entryHeaderRow, $this->getFormattedDuration($durationTotal));
+        $sheet->setCellValueByColumnAndRow(13, $entryHeaderRow, $this->getFormattedMoney($rateTotal, $currency));
+        $sheet->getCellByColumnAndRow(12, $entryHeaderRow)->getStyle()->getBorders()->getTop()->setBorderStyle(Border::BORDER_THIN);
         $sheet->getCellByColumnAndRow(12, $entryHeaderRow)->getStyle()->getFont()->setBold(true);
+
+        $sheet->getCellByColumnAndRow(13, $entryHeaderRow)->getStyle()->getBorders()->getTop()->setBorderStyle(Border::BORDER_THIN);
+        $sheet->getCellByColumnAndRow(13, $entryHeaderRow)->getStyle()->getFont()->setBold(true);
 
         return $spreadsheet;
     }

--- a/tests/Export/Renderer/AbstractRendererTest.php
+++ b/tests/Export/Renderer/AbstractRendererTest.php
@@ -13,6 +13,7 @@ use App\Configuration\LanguageFormattings;
 use App\Entity\Activity;
 use App\Entity\Customer;
 use App\Entity\Project;
+use App\Entity\Tag;
 use App\Entity\Timesheet;
 use App\Entity\User;
 use App\Export\RendererInterface;
@@ -124,6 +125,7 @@ abstract class AbstractRendererTest extends KernelTestCase
             ->setProject($project)
             ->setBegin(new \DateTime())
             ->setEnd(new \DateTime())
+            ->addTag((new Tag())->setName('foo'))
         ;
 
         $timesheet5 = new Timesheet();
@@ -133,8 +135,10 @@ abstract class AbstractRendererTest extends KernelTestCase
             ->setUser((new User())->setUsername('kevin'))
             ->setActivity($activity)
             ->setProject($project)
-            ->setBegin(new \DateTime())
-            ->setEnd(new \DateTime())
+            ->setBegin(new \DateTime('2019-06-16 12:00:00'))
+            ->setEnd(new \DateTime('2019-06-16 12:06:40'))
+            ->addTag((new Tag())->setName('foo'))
+            ->addTag((new Tag())->setName('bar'))
         ;
 
         $entries = [$timesheet, $timesheet2, $timesheet3, $timesheet4, $timesheet5];

--- a/tests/Export/Renderer/CsvRendererTest.php
+++ b/tests/Export/Renderer/CsvRendererTest.php
@@ -68,5 +68,32 @@ class CsvRendererTest extends AbstractRendererTest
 
         $this->assertEquals($content, $content2);
         $this->assertFalse(file_exists($file->getRealPath()));
+
+        $all = [];
+        $rows = str_getcsv($content2, PHP_EOL);
+        foreach ($rows as $row) {
+            $all[] = str_getcsv($row);
+        }
+        self::assertEquals(7, count($all));
+        self::assertEquals(13, count($all[0]));
+        self::assertEquals('foo', $all[4][8]);
+
+        $expected = [
+            0 => '2019.06.16 12:00',
+            1 => '2019.06.16 12:06',
+            2 => 'kevin',
+            3 => 'Customer Name',
+            4 => 'project name',
+            5 => 'activity description',
+            6 => '',
+            7 => '',
+            8 => 'foo,bar',
+            9 => '€0.00',
+            10 => '€84.00',
+            11 => '00:06 h',
+            12 => '€0.00',
+        ];
+
+        self::assertEquals($expected, $all[5]);
     }
 }


### PR DESCRIPTION
## Description

This PR adds a new column to all spreadsheet exports with a comma separated list of the records tags. ping @rarvin

If you used an Excel export with custom macros to calculate data, you have to adjust the columns, as a new column was added in the middle.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer kimai:code-check`)
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
