### PR TITLE
fix/LDAP multivalues Email Aliases

### DIFF
--- a/src/Ldap/LdapUserHydrator.php
+++ b/src/Ldap/LdapUserHydrator.php
@@ -66,7 +66,7 @@ class LdapUserHydrator
         if (is_array($user->getEmail())) {
             $user->setEmail($user->getEmail()[0]);
         }
-        
+
         if (null === $user->getEmail()) {
             $user->setEmail($user->getUsername());
         }

--- a/src/Ldap/LdapUserHydrator.php
+++ b/src/Ldap/LdapUserHydrator.php
@@ -63,6 +63,10 @@ class LdapUserHydrator
 
         $this->hydrateUserWithAttributesMap($user, $ldapEntry, $attributeMap);
 
+        if (is_array($user->getEmail())) {
+            $user->setEmail($user->getUsername()[0]);
+        }
+        
         if (null === $user->getEmail()) {
             $user->setEmail($user->getUsername());
         }

--- a/src/Ldap/LdapUserHydrator.php
+++ b/src/Ldap/LdapUserHydrator.php
@@ -64,7 +64,7 @@ class LdapUserHydrator
         $this->hydrateUserWithAttributesMap($user, $ldapEntry, $attributeMap);
 
         if (is_array($user->getEmail())) {
-            $user->setEmail($user->getUsername()[0]);
+            $user->setEmail($user->getEmail()[0]);
         }
         
         if (null === $user->getEmail()) {

--- a/tests/Ldap/LdapUserHydratorTest.php
+++ b/tests/Ldap/LdapUserHydratorTest.php
@@ -93,6 +93,7 @@ class LdapUserHydratorTest extends TestCase
                 'usernameAttribute' => 'foo',
                 'attributes' => [
                     ['ldap_attr' => 'uid', 'user_method' => 'setUsername'],
+                    ['ldap_attr' => 'email', 'user_method' => 'setEmail'],
                     ['ldap_attr' => 'foo', 'user_method' => 'setAlias'],
                     ['ldap_attr' => 'bar', 'user_method' => 'setTitle'],
                     ['ldap_attr' => 'xxxxxxxx', 'user_method' => 'setAvatar'],
@@ -103,6 +104,7 @@ class LdapUserHydratorTest extends TestCase
 
         $ldapEntry = [
             'uid' => ['Karl-Heinz'],
+            'email' => [['karl-heinz@example.com', 'foo@example.com', 'bar@example.com']],
             'blub' => ['dfsdfsdf'],
             'foo' => ['bar'],
             'bar' => ['foo'],
@@ -119,7 +121,7 @@ class LdapUserHydratorTest extends TestCase
         self::assertEquals('bar', $user->getAlias());
         self::assertEquals('foo', $user->getTitle());
         self::assertEquals('https://www.example.com', $user->getAvatar());
-        self::assertEquals('Karl-Heinz', $user->getEmail());
+        self::assertEquals('karl-heinz@example.com', $user->getEmail());
 
         // make sure that the password was resetted in hydrate
         $pwdCheck = clone $user;


### PR DESCRIPTION


## Description
This fix checks if LDAP Directory has multiple values into Email value, like multiple Email Aliases.
If detects multiple values, gets first value of the array.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I verified that my code applies to the guidelines (`composer kimai:code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [X] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
