### PR TITLE
use default_begin in duration only mode

### DIFF
--- a/src/Timesheet/TrackingMode/DurationOnlyMode.php
+++ b/src/Timesheet/TrackingMode/DurationOnlyMode.php
@@ -9,6 +9,9 @@
 
 namespace App\Timesheet\TrackingMode;
 
+use App\Entity\Timesheet;
+use Symfony\Component\HttpFoundation\Request;
+
 class DurationOnlyMode extends AbstractTrackingMode
 {
     public function canEditBegin(): bool
@@ -39,5 +42,16 @@ class DurationOnlyMode extends AbstractTrackingMode
     public function canSeeBeginAndEndTimes(): bool
     {
         return false;
+    }
+
+    public function create(Timesheet $timesheet, Request $request): void
+    {
+        if (null === $timesheet->getBegin()) {
+            $timesheet->setBegin($this->dateTime->createDateTime());
+        }
+
+        $timesheet->getBegin()->modify($this->configuration->getDefaultBeginTime());
+
+        parent::create($timesheet, $request);
     }
 }

--- a/tests/Timesheet/TrackingMode/AbstractTrackingModeTest.php
+++ b/tests/Timesheet/TrackingMode/AbstractTrackingModeTest.php
@@ -24,6 +24,11 @@ abstract class AbstractTrackingModeTest extends TestCase
      */
     abstract protected function createSut();
 
+    protected function assertDefaultBegin(Timesheet $timesheet)
+    {
+        self::assertNull($timesheet->getBegin());
+    }
+
     public function testCreateDoesNotChangeAnythingOnEmptyRequest()
     {
         $sut = $this->createSut();
@@ -35,7 +40,7 @@ abstract class AbstractTrackingModeTest extends TestCase
 
         $sut->create($timesheet, new Request());
 
-        self::assertNull($timesheet->getBegin());
+        $this->assertDefaultBegin($timesheet);
         self::assertNull($timesheet->getEnd());
     }
 
@@ -88,7 +93,7 @@ abstract class AbstractTrackingModeTest extends TestCase
 
         $sut->create($timesheet, $request);
 
-        self::assertNull($timesheet->getBegin());
+        $this->assertDefaultBegin($timesheet);
         self::assertNull($timesheet->getEnd());
         self::assertEquals(0, $timesheet->getDuration());
     }
@@ -181,7 +186,7 @@ abstract class AbstractTrackingModeTest extends TestCase
 
         $sut->create($timesheet, $request);
 
-        self::assertNull($timesheet->getBegin());
+        $this->assertDefaultBegin($timesheet);
         self::assertNull($timesheet->getEnd());
         self::assertEquals(0, $timesheet->getDuration());
     }

--- a/tests/Timesheet/TrackingMode/DurationOnlyModeTest.php
+++ b/tests/Timesheet/TrackingMode/DurationOnlyModeTest.php
@@ -10,6 +10,7 @@
 namespace App\Tests\Timesheet\TrackingMode;
 
 use App\Configuration\TimesheetConfiguration;
+use App\Entity\Timesheet;
 use App\Tests\Configuration\TestConfigLoader;
 use App\Tests\Mocks\Security\UserDateTimeFactoryFactory;
 use App\Timesheet\TrackingMode\DurationOnlyMode;
@@ -19,11 +20,17 @@ use App\Timesheet\TrackingMode\DurationOnlyMode;
  */
 class DurationOnlyModeTest extends AbstractTrackingModeTest
 {
+    protected function assertDefaultBegin(Timesheet $timesheet)
+    {
+        self::assertNotNull($timesheet->getBegin());
+        self::assertEquals('13:45:37', $timesheet->getBegin()->format('H:i:s'));
+    }
+
     protected function createSut()
     {
         $loader = new TestConfigLoader([]);
         $dateTime = (new UserDateTimeFactoryFactory($this))->create();
-        $configuration = new TimesheetConfiguration($loader, []);
+        $configuration = new TimesheetConfiguration($loader, ['default_begin' => '13:45:37']);
 
         return new DurationOnlyMode($dateTime, $configuration);
     }


### PR DESCRIPTION
## Description

extending #859 the duration_only mode now uses the default_begin (defaults to now, so behaviour doesn't change)

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer kimai:code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
