### PR TITLE
performance tuning on timesheets

### DIFF
--- a/src/API/TimesheetController.php
+++ b/src/API/TimesheetController.php
@@ -198,7 +198,7 @@ class TimesheetController extends BaseApiController
         }
 
         /** @var Pagerfanta $data */
-        $data = $this->repository->findByQuery($query);
+        $data = $this->repository->getPagerfantaForQuery($query);
         $data = (array) $data->getCurrentPageResults();
 
         $view = new View($data, 200);

--- a/src/Controller/ExportController.php
+++ b/src/Controller/ExportController.php
@@ -143,13 +143,10 @@ class ExportController extends AbstractController
      */
     protected function getEntries(ExportQuery $query)
     {
-        $query->setResultType(ExportQuery::RESULT_TYPE_QUERYBUILDER);
         $query->getBegin()->setTime(0, 0, 0);
         $query->getEnd()->setTime(23, 59, 59);
 
-        $queryBuilder = $this->timesheetRepository->findByQuery($query);
-
-        return $queryBuilder->getQuery()->getResult();
+        return $this->timesheetRepository->getTimesheetsForQuery($query);
     }
 
     /**

--- a/src/Controller/InvoiceController.php
+++ b/src/Controller/InvoiceController.php
@@ -18,7 +18,6 @@ use App\Model\InvoiceModel;
 use App\Repository\InvoiceTemplateRepository;
 use App\Repository\Query\BaseQuery;
 use App\Repository\Query\InvoiceQuery;
-use App\Repository\Query\TimesheetQuery;
 use App\Repository\TimesheetRepository;
 use App\Timesheet\UserDateTimeFactory;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
@@ -166,8 +165,6 @@ class InvoiceController extends AbstractController
             return [];
         }
 
-        $query->setResultType(TimesheetQuery::RESULT_TYPE_QUERYBUILDER);
-
         if (null === $query->getBegin()) {
             $query->setBegin($this->dateTimeFactory->createDateTime('first day of this month'));
         }
@@ -177,9 +174,7 @@ class InvoiceController extends AbstractController
         $query->getBegin()->setTime(0, 0, 0);
         $query->getEnd()->setTime(23, 59, 59);
 
-        $queryBuilder = $repository->findByQuery($query);
-
-        return $queryBuilder->getQuery()->getResult();
+        return $repository->getTimesheetsForQuery($query);
     }
 
     /**

--- a/src/Controller/TimesheetAbstractController.php
+++ b/src/Controller/TimesheetAbstractController.php
@@ -23,7 +23,6 @@ use App\Timesheet\TrackingMode\TrackingModeInterface;
 use App\Timesheet\TrackingModeService;
 use App\Timesheet\UserDateTimeFactory;
 use Doctrine\Common\Collections\ArrayCollection;
-use Pagerfanta\Pagerfanta;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -107,11 +106,10 @@ abstract class TimesheetAbstractController extends AbstractController
             );
         }
 
-        /* @var $entries Pagerfanta */
-        $entries = $this->getRepository()->findByQuery($query);
+        $pager = $this->getRepository()->getPagerfantaForQuery($query);
 
         return $this->render($renderTemplate, [
-            'entries' => $entries,
+            'entries' => $pager,
             'page' => $query->getPage(),
             'query' => $query,
             'showFilter' => $form->isSubmitted(),
@@ -212,7 +210,6 @@ abstract class TimesheetAbstractController extends AbstractController
     protected function export(Request $request, string $renderTemplate)
     {
         $query = new TimesheetQuery();
-        $query->setResultType(TimesheetQuery::RESULT_TYPE_OBJECTS);
 
         $form = $this->getToolbarForm($query);
         $form->handleRequest($request);
@@ -238,8 +235,7 @@ abstract class TimesheetAbstractController extends AbstractController
             $query->setUser($this->getUser());
         }
 
-        /* @var $entries Pagerfanta */
-        $entries = $this->getRepository()->findByQuery($query);
+        $entries = $this->getRepository()->getTimesheetsForQuery($query);
 
         return $this->render($renderTemplate, [
             'entries' => $entries,

--- a/src/Repository/Loader/LoaderInterface.php
+++ b/src/Repository/Loader/LoaderInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Repository\Loader;
+
+interface LoaderInterface
+{
+    /**
+     * Prepares the given database results, so no lazy loading will be performed.
+     *
+     * @param array $results
+     */
+    public function loadResults(array $results): void;
+}

--- a/src/Repository/Loader/TimesheetIdLoader.php
+++ b/src/Repository/Loader/TimesheetIdLoader.php
@@ -1,0 +1,134 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Repository\Loader;
+
+use App\Entity\Project;
+use App\Entity\Timesheet;
+use Doctrine\ORM\EntityManagerInterface;
+
+final class TimesheetIdLoader implements LoaderInterface
+{
+    /**
+     * @var bool
+     */
+    private $preloadUser = true;
+    /**
+     * @var bool
+     */
+    private $preloadTags = true;
+    /**
+     * @var bool
+     */
+    private $preloadMeta = true;
+    /**
+     * @var EntityManagerInterface
+     */
+    private $entityManager;
+
+    public function __construct(EntityManagerInterface $entityManager)
+    {
+        $this->entityManager = $entityManager;
+    }
+
+    public function setPreloadMetaFields(bool $preload): LoaderInterface
+    {
+        $this->preloadMeta = $preload;
+
+        return $this;
+    }
+
+    public function setPreloadUser(bool $preload): LoaderInterface
+    {
+        $this->preloadUser = $preload;
+
+        return $this;
+    }
+
+    public function setPreloadTags(bool $preload): LoaderInterface
+    {
+        $this->preloadTags = $preload;
+
+        return $this;
+    }
+
+    /**
+     * @param int[] $ids
+     */
+    public function loadResults(array $ids): void
+    {
+        if (empty($ids)) {
+            return;
+        }
+
+        $em = $this->entityManager;
+
+        $qb = $em->createQueryBuilder();
+        $projects = $qb->select('PARTIAL t.{id}', 'project')
+            ->from(Timesheet::class, 't')
+            ->leftJoin('t.project', 'project')
+            ->andWhere($qb->expr()->in('t.id', $ids))
+            ->getQuery()
+            ->execute();
+
+        if (!empty($projects)) {
+            $projectIds = array_map(function (Timesheet $timesheet) {
+                return $timesheet->getProject()->getId();
+            }, $projects);
+
+            $qb = $em->createQueryBuilder();
+            $qb->select('PARTIAL p.{id}', 'customer')
+                ->from(Project::class, 'p')
+                ->leftJoin('p.customer', 'customer')
+                ->andWhere($qb->expr()->in('p.id', $projectIds))
+                ->getQuery()
+                ->execute();
+        }
+
+        $qb = $em->createQueryBuilder();
+        $qb->select('PARTIAL t.{id}', 'activity')
+            ->from(Timesheet::class, 't')
+            ->leftJoin('t.activity', 'activity')
+            ->andWhere($qb->expr()->in('t.id', $ids))
+            ->getQuery()
+            ->execute();
+
+        if ($this->preloadUser) {
+            $qb = $em->createQueryBuilder();
+            $qb->select('PARTIAL t.{id}', 'user')
+                ->from(Timesheet::class, 't')
+                ->leftJoin('t.user', 'user')
+                ->andWhere($qb->expr()->in('t.id', $ids))
+                ->getQuery()
+                ->execute();
+        }
+
+        if ($this->preloadTags) {
+            $qb = $em->createQueryBuilder();
+            $qb->select('PARTIAL t.{id}', 'tags')
+                ->from(Timesheet::class, 't')
+                ->leftJoin('t.tags', 'tags')
+                ->andWhere($qb->expr()->in('t.id', $ids))
+                ->getQuery()
+                ->execute();
+        }
+
+        if ($this->preloadMeta) {
+            /*
+            $qb = $em->createQueryBuilder();
+            $qb->select('PARTIAL t.{id}', 'meta')
+                ->from(Timesheet::class, 't')
+                ->leftJoin('t.meta', 'meta')
+                ->andWhere($qb->expr()->in('t.id', $ids))
+                ->getQuery()
+                ->execute();
+            */
+        }
+    }
+}

--- a/src/Repository/Loader/TimesheetIdLoader.php
+++ b/src/Repository/Loader/TimesheetIdLoader.php
@@ -16,18 +16,6 @@ use Doctrine\ORM\EntityManagerInterface;
 final class TimesheetIdLoader implements LoaderInterface
 {
     /**
-     * @var bool
-     */
-    private $preloadUser = true;
-    /**
-     * @var bool
-     */
-    private $preloadTags = true;
-    /**
-     * @var bool
-     */
-    private $preloadMeta = true;
-    /**
      * @var EntityManagerInterface
      */
     private $entityManager;
@@ -35,27 +23,6 @@ final class TimesheetIdLoader implements LoaderInterface
     public function __construct(EntityManagerInterface $entityManager)
     {
         $this->entityManager = $entityManager;
-    }
-
-    public function setPreloadMetaFields(bool $preload): LoaderInterface
-    {
-        $this->preloadMeta = $preload;
-
-        return $this;
-    }
-
-    public function setPreloadUser(bool $preload): LoaderInterface
-    {
-        $this->preloadUser = $preload;
-
-        return $this;
-    }
-
-    public function setPreloadTags(bool $preload): LoaderInterface
-    {
-        $this->preloadTags = $preload;
-
-        return $this;
     }
 
     /**
@@ -99,36 +66,30 @@ final class TimesheetIdLoader implements LoaderInterface
             ->getQuery()
             ->execute();
 
-        if ($this->preloadUser) {
-            $qb = $em->createQueryBuilder();
-            $qb->select('PARTIAL t.{id}', 'user')
-                ->from(Timesheet::class, 't')
-                ->leftJoin('t.user', 'user')
-                ->andWhere($qb->expr()->in('t.id', $ids))
-                ->getQuery()
-                ->execute();
-        }
+        $qb = $em->createQueryBuilder();
+        $qb->select('PARTIAL t.{id}', 'user')
+            ->from(Timesheet::class, 't')
+            ->leftJoin('t.user', 'user')
+            ->andWhere($qb->expr()->in('t.id', $ids))
+            ->getQuery()
+            ->execute();
 
-        if ($this->preloadTags) {
-            $qb = $em->createQueryBuilder();
-            $qb->select('PARTIAL t.{id}', 'tags')
-                ->from(Timesheet::class, 't')
-                ->leftJoin('t.tags', 'tags')
-                ->andWhere($qb->expr()->in('t.id', $ids))
-                ->getQuery()
-                ->execute();
-        }
+        $qb = $em->createQueryBuilder();
+        $qb->select('PARTIAL t.{id}', 'tags')
+            ->from(Timesheet::class, 't')
+            ->leftJoin('t.tags', 'tags')
+            ->andWhere($qb->expr()->in('t.id', $ids))
+            ->getQuery()
+            ->execute();
 
-        if ($this->preloadMeta) {
-            /*
-            $qb = $em->createQueryBuilder();
-            $qb->select('PARTIAL t.{id}', 'meta')
-                ->from(Timesheet::class, 't')
-                ->leftJoin('t.meta', 'meta')
-                ->andWhere($qb->expr()->in('t.id', $ids))
-                ->getQuery()
-                ->execute();
-            */
-        }
+        /*
+        $qb = $em->createQueryBuilder();
+        $qb->select('PARTIAL t.{id}', 'meta')
+            ->from(Timesheet::class, 't')
+            ->leftJoin('t.meta', 'meta')
+            ->andWhere($qb->expr()->in('t.id', $ids))
+            ->getQuery()
+            ->execute();
+        */
     }
 }

--- a/src/Repository/Loader/TimesheetLoader.php
+++ b/src/Repository/Loader/TimesheetLoader.php
@@ -24,27 +24,6 @@ final class TimesheetLoader implements LoaderInterface
         $this->loader = new TimesheetIdLoader($entityManager);
     }
 
-    public function setPreloadMetaFields(bool $preload): LoaderInterface
-    {
-        $this->loader->setPreloadMetaFields($preload);
-
-        return $this;
-    }
-
-    public function setPreloadUser(bool $preload): LoaderInterface
-    {
-        $this->loader->setPreloadUser($preload);
-
-        return $this;
-    }
-
-    public function setPreloadTags(bool $preload): LoaderInterface
-    {
-        $this->loader->setPreloadTags($preload);
-
-        return $this;
-    }
-
     /**
      * @param Timesheet[] $timesheets
      */

--- a/src/Repository/Loader/TimesheetLoader.php
+++ b/src/Repository/Loader/TimesheetLoader.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Repository\Loader;
+
+use App\Entity\Timesheet;
+use Doctrine\ORM\EntityManagerInterface;
+
+final class TimesheetLoader implements LoaderInterface
+{
+    /**
+     * @var TimesheetIdLoader
+     */
+    private $loader;
+
+    public function __construct(EntityManagerInterface $entityManager)
+    {
+        $this->loader = new TimesheetIdLoader($entityManager);
+    }
+
+    public function setPreloadMetaFields(bool $preload): LoaderInterface
+    {
+        $this->loader->setPreloadMetaFields($preload);
+
+        return $this;
+    }
+
+    public function setPreloadUser(bool $preload): LoaderInterface
+    {
+        $this->loader->setPreloadUser($preload);
+
+        return $this;
+    }
+
+    public function setPreloadTags(bool $preload): LoaderInterface
+    {
+        $this->loader->setPreloadTags($preload);
+
+        return $this;
+    }
+
+    /**
+     * @param Timesheet[] $timesheets
+     */
+    public function loadResults(array $timesheets): void
+    {
+        $ids = array_map(function (Timesheet $timesheet) {
+            return $timesheet->getId();
+        }, $timesheets);
+
+        $this->loader->loadResults($ids);
+    }
+}

--- a/src/Repository/Paginator/TimesheetPaginator.php
+++ b/src/Repository/Paginator/TimesheetPaginator.php
@@ -36,27 +36,6 @@ final class TimesheetPaginator implements AdapterInterface
         $this->loader = new TimesheetLoader($query->getEntityManager());
     }
 
-    public function setPreloadMetaFields(bool $preload): TimesheetPaginator
-    {
-        $this->loader->setPreloadMetaFields($preload);
-
-        return $this;
-    }
-
-    public function setPreloadUser(bool $preload): TimesheetPaginator
-    {
-        $this->loader->setPreloadUser($preload);
-
-        return $this;
-    }
-
-    public function setPreloadTags(bool $preload): TimesheetPaginator
-    {
-        $this->loader->setPreloadTags($preload);
-
-        return $this;
-    }
-
     /**
      * {@inheritdoc}
      */

--- a/src/Repository/Paginator/TimesheetPaginator.php
+++ b/src/Repository/Paginator/TimesheetPaginator.php
@@ -9,13 +9,12 @@
 
 namespace App\Repository\Paginator;
 
-use App\Entity\Project;
-use App\Entity\Timesheet;
+use App\Repository\Loader\TimesheetLoader;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;
 use Pagerfanta\Adapter\AdapterInterface;
 
-class TimesheetPaginator implements AdapterInterface
+final class TimesheetPaginator implements AdapterInterface
 {
     /**
      * @var QueryBuilder
@@ -25,11 +24,37 @@ class TimesheetPaginator implements AdapterInterface
      * @var int
      */
     private $results = 0;
+    /**
+     * @var TimesheetLoader
+     */
+    private $loader;
 
     public function __construct(QueryBuilder $query, int $results)
     {
         $this->query = $query;
         $this->results = $results;
+        $this->loader = new TimesheetLoader($query->getEntityManager());
+    }
+
+    public function setPreloadMetaFields(bool $preload): TimesheetPaginator
+    {
+        $this->loader->setPreloadMetaFields($preload);
+
+        return $this;
+    }
+
+    public function setPreloadUser(bool $preload): TimesheetPaginator
+    {
+        $this->loader->setPreloadUser($preload);
+
+        return $this;
+    }
+
+    public function setPreloadTags(bool $preload): TimesheetPaginator
+    {
+        $this->loader->setPreloadTags($preload);
+
+        return $this;
     }
 
     /**
@@ -40,69 +65,12 @@ class TimesheetPaginator implements AdapterInterface
         return $this->results;
     }
 
-    protected function getResults(Query $query)
+    private function getResults(Query $query)
     {
         $results = $query->execute();
 
-        $ids = array_map(function (Timesheet $timesheet) {
-            return $timesheet->getId();
-        }, $results);
+        $this->loader->loadResults($results);
 
-        $em = $this->query->getEntityManager();
-
-        $qb = $em->createQueryBuilder();
-        $projects = $qb->select('PARTIAL t.{id}', 'project')
-            ->from(Timesheet::class, 't')
-            ->leftJoin('t.project', 'project')
-            ->andWhere($qb->expr()->in('t.id', $ids))
-            ->getQuery()
-            ->execute();
-
-        $projectIds = array_map(function (Timesheet $timesheet) {
-            return $timesheet->getProject()->getId();
-        }, $projects);
-
-        $qb = $em->createQueryBuilder();
-        $qb->select('PARTIAL p.{id}', 'customer')
-            ->from(Project::class, 'p')
-            ->leftJoin('p.customer', 'customer')
-            ->andWhere($qb->expr()->in('p.id', $projectIds))
-            ->getQuery()
-            ->execute();
-
-        $qb = $em->createQueryBuilder();
-        $qb->select('PARTIAL t.{id}', 'activity')
-            ->from(Timesheet::class, 't')
-            ->leftJoin('t.activity', 'activity')
-            ->andWhere($qb->expr()->in('t.id', $ids))
-            ->getQuery()
-            ->execute();
-
-        $qb = $em->createQueryBuilder();
-        $qb->select('PARTIAL t.{id}', 'user')
-            ->from(Timesheet::class, 't')
-            ->leftJoin('t.user', 'user')
-            ->andWhere($qb->expr()->in('t.id', $ids))
-            ->getQuery()
-            ->execute();
-
-        $qb = $em->createQueryBuilder();
-        $qb->select('PARTIAL t.{id}', 'tags')
-            ->from(Timesheet::class, 't')
-            ->leftJoin('t.tags', 'tags')
-            ->andWhere($qb->expr()->in('t.id', $ids))
-            ->getQuery()
-            ->execute();
-/*
-        // pre-fill the meta fields without left join
-        $qb = $em->createQueryBuilder();
-        $qb->select('PARTIAL t.{id}', 'meta')
-            ->from(Timesheet::class, 't')
-            ->leftJoin('t.meta', 'meta')
-            ->andWhere($qb->expr()->in('t.id', $ids))
-            ->getQuery()
-            ->execute();
-*/
         return $results;
     }
 

--- a/src/Repository/Paginator/TimesheetPaginator.php
+++ b/src/Repository/Paginator/TimesheetPaginator.php
@@ -1,0 +1,126 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Repository\Paginator;
+
+use App\Entity\Project;
+use App\Entity\Timesheet;
+use Doctrine\ORM\Query;
+use Doctrine\ORM\QueryBuilder;
+use Pagerfanta\Adapter\AdapterInterface;
+
+class TimesheetPaginator implements AdapterInterface
+{
+    /**
+     * @var QueryBuilder
+     */
+    private $query;
+    /**
+     * @var int
+     */
+    private $results = 0;
+
+    public function __construct(QueryBuilder $query, int $results)
+    {
+        $this->query = $query;
+        $this->results = $results;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getNbResults()
+    {
+        return $this->results;
+    }
+
+    protected function getResults(Query $query)
+    {
+        $results = $query->execute();
+
+        $ids = array_map(function (Timesheet $timesheet) {
+            return $timesheet->getId();
+        }, $results);
+
+        $em = $this->query->getEntityManager();
+
+        $qb = $em->createQueryBuilder();
+        $projects = $qb->select('PARTIAL t.{id}', 'project')
+            ->from(Timesheet::class, 't')
+            ->leftJoin('t.project', 'project')
+            ->andWhere($qb->expr()->in('t.id', $ids))
+            ->getQuery()
+            ->execute();
+
+        $projectIds = array_map(function (Timesheet $timesheet) {
+            return $timesheet->getProject()->getId();
+        }, $projects);
+
+        $qb = $em->createQueryBuilder();
+        $qb->select('PARTIAL p.{id}', 'customer')
+            ->from(Project::class, 'p')
+            ->leftJoin('p.customer', 'customer')
+            ->andWhere($qb->expr()->in('p.id', $projectIds))
+            ->getQuery()
+            ->execute();
+
+        $qb = $em->createQueryBuilder();
+        $qb->select('PARTIAL t.{id}', 'activity')
+            ->from(Timesheet::class, 't')
+            ->leftJoin('t.activity', 'activity')
+            ->andWhere($qb->expr()->in('t.id', $ids))
+            ->getQuery()
+            ->execute();
+
+        $qb = $em->createQueryBuilder();
+        $qb->select('PARTIAL t.{id}', 'user')
+            ->from(Timesheet::class, 't')
+            ->leftJoin('t.user', 'user')
+            ->andWhere($qb->expr()->in('t.id', $ids))
+            ->getQuery()
+            ->execute();
+
+        $qb = $em->createQueryBuilder();
+        $qb->select('PARTIAL t.{id}', 'tags')
+            ->from(Timesheet::class, 't')
+            ->leftJoin('t.tags', 'tags')
+            ->andWhere($qb->expr()->in('t.id', $ids))
+            ->getQuery()
+            ->execute();
+/*
+        // pre-fill the meta fields without left join
+        $qb = $em->createQueryBuilder();
+        $qb->select('PARTIAL t.{id}', 'meta')
+            ->from(Timesheet::class, 't')
+            ->leftJoin('t.meta', 'meta')
+            ->andWhere($qb->expr()->in('t.id', $ids))
+            ->getQuery()
+            ->execute();
+*/
+        return $results;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSlice($offset, $length)
+    {
+        $query = $this->query
+            ->getQuery()
+            ->setFirstResult($offset)
+            ->setMaxResults($length);
+
+        return $this->getResults($query);
+    }
+
+    public function getAll()
+    {
+        return $this->getResults($this->query->getQuery());
+    }
+}

--- a/src/Repository/TimesheetRepository.php
+++ b/src/Repository/TimesheetRepository.php
@@ -414,7 +414,7 @@ class TimesheetRepository extends EntityRepository
         return $paginator;
     }
 
-    public function getPaginatorForQuery(TimesheetQuery $query): TimesheetPaginator
+    protected function getPaginatorForQuery(TimesheetQuery $query): TimesheetPaginator
     {
         $qb = $this->getQueryBuilderForQuery($query);
         $qb->select($qb->expr()->countDistinct('t.id'))->resetDQLPart('orderBy');
@@ -482,6 +482,7 @@ class TimesheetRepository extends EntityRepository
                 $qb->andWhere('t.project = :project')
                     ->setParameter('project', $query->getProject());
             } elseif (null !== $query->getCustomer()) {
+                $qb->join('t.project', 'p');
                 $qb->andWhere('p.customer = :customer')
                     ->setParameter('customer', $query->getCustomer());
             }

--- a/templates/export/renderer/default.html.twig
+++ b/templates/export/renderer/default.html.twig
@@ -8,6 +8,7 @@
     'project': true,
     'activity': true,
     'description': false,
+    'tags': false,
     'exported': false,
     'hourlyRate': false,
     'fixedRate': false,
@@ -265,6 +266,11 @@
                         <td class="column-description" {% if not columns.description %}style="display: none"{% endif %}>
                             {% if entry.description is not empty %}
                                 {{ entry.description|desc2html }}
+                            {% endif %}
+                        </td>
+                        <td class="column-tags" {% if not columns.tags %}style="display: none"{% endif %}>
+                            {% if entry.tags is not empty %}
+                                {{ entry.tagsAsArray|join(', ') }}
                             {% endif %}
                         </td>
                         <td class="column-exported" {% if not columns.exported %}style="display: none"{% endif %}>

--- a/tests/Repository/TimesheetRepositoryTest.php
+++ b/tests/Repository/TimesheetRepositoryTest.php
@@ -38,19 +38,10 @@ class TimesheetRepositoryTest extends AbstractRepositoryTest
 
         $query = new TimesheetQuery();
 
-        $result = $repository->findByQuery($query);
+        $result = $repository->getPagerfantaForQuery($query);
         $this->assertInstanceOf(Pagerfanta::class, $result);
 
-        $query->setResultType(BaseQuery::RESULT_TYPE_QUERYBUILDER);
-        $result = $repository->findByQuery($query);
-        $this->assertInstanceOf(QueryBuilder::class, $result);
-
-        $query->setResultType(BaseQuery::RESULT_TYPE_PAGER);
-        $result = $repository->findByQuery($query);
-        $this->assertInstanceOf(Pagerfanta::class, $result);
-
-        $query->setResultType(BaseQuery::RESULT_TYPE_OBJECTS);
-        $result = $repository->findByQuery($query);
+        $result = $repository->getTimesheetsForQuery($query);
         $this->assertIsArray($result);
     }
 
@@ -73,7 +64,7 @@ class TimesheetRepositoryTest extends AbstractRepositoryTest
         $query->setState(TimesheetQuery::STATE_STOPPED);
 
         /** @var array $entities */
-        $entities = $repository->findByQuery($query);
+        $entities = $repository->getTimesheetsForQuery($query);
 
         $this->assertCount(1, $entities);
         $this->assertInstanceOf(Timesheet::class, $entities[0]);

--- a/tests/Repository/TimesheetRepositoryTest.php
+++ b/tests/Repository/TimesheetRepositoryTest.php
@@ -21,7 +21,6 @@ use App\Repository\Query\TimesheetQuery;
 use App\Repository\RepositoryException;
 use App\Repository\TimesheetRepository;
 use App\Tests\DataFixtures\TimesheetFixtures;
-use Doctrine\ORM\QueryBuilder;
 use Pagerfanta\Pagerfanta;
 
 /**


### PR DESCRIPTION
## Description

This PR introduces partial fetches instead of joining multiple tables in one query.
For users with small databases this might not make a big difference, but users of large setups will notice a dramatic performance improvement.

In one of my large demo systems with approx.:
- 1.500.000 timesheet records
- 1200 users
- 55 customers
- 1500 projects
- 38000 activities

this PR could reduce opening the initial team timesheet view from ~10 seconds to ~2 seconds.
The same applies for the memory consumption.

All timesheet list/collection fetches (also API) will benefit from this change.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer kimai:code-check`)
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
