### PR TITLE
fix selectbox is not resettable

### DIFF
--- a/src/Controller/SystemConfigurationController.php
+++ b/src/Controller/SystemConfigurationController.php
@@ -232,7 +232,8 @@ class SystemConfigurationController extends AbstractController
                     (new Configuration())
                         ->setName('theme.select_type')
                         ->setTranslationDomain('system-configuration')
-                        ->setType(EnhancedSelectboxType::class),
+                        ->setType(EnhancedSelectboxType::class)
+                        ->setRequired(false),
                     (new Configuration())
                         ->setName('timesheet.markdown_content')
                         ->setLabel('theme.markdown_content')

--- a/src/Form/Model/Configuration.php
+++ b/src/Form/Model/Configuration.php
@@ -11,7 +11,7 @@ namespace App\Form\Model;
 
 use Symfony\Component\Validator\Constraint;
 
-class Configuration
+final class Configuration
 {
     /**
      * @var string
@@ -32,29 +32,26 @@ class Configuration
     /**
      * @var string
      */
-    protected $type;
+    private $type;
     /**
      * @var bool
      */
-    protected $enabled = true;
+    private $enabled = true;
+    /**
+     * @var bool
+     */
+    private $required = true;
     /**
      * @var Constraint[]
      */
-    protected $constraints = [];
+    private $constraints = [];
 
-    /**
-     * @return string
-     */
     public function getName(): string
     {
         return $this->name;
     }
 
-    /**
-     * @param string $name
-     * @return Configuration
-     */
-    public function setName(string $name)
+    public function setName(string $name): Configuration
     {
         $this->name = $name;
 
@@ -73,64 +70,43 @@ class Configuration
      * @param mixed $value
      * @return Configuration
      */
-    public function setValue($value)
+    public function setValue($value): Configuration
     {
         $this->value = $value;
 
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getType(): string
+    public function getType(): ?string
     {
         return $this->type;
     }
 
-    /**
-     * @param string $type
-     * @return Configuration
-     */
-    public function setType(string $type)
+    public function setType(string $type): Configuration
     {
         $this->type = $type;
 
         return $this;
     }
 
-    /**
-     * @return bool
-     */
     public function isEnabled(): bool
     {
         return $this->enabled;
     }
 
-    /**
-     * @param bool $enabled
-     * @return Configuration
-     */
-    public function setEnabled(bool $enabled)
+    public function setEnabled(bool $enabled): Configuration
     {
         $this->enabled = $enabled;
 
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getLabel()
+    public function getLabel(): ?string
     {
         return $this->label;
     }
 
-    /**
-     * @param string $label
-     * @return Configuration
-     */
-    public function setLabel(string $label)
+    public function setLabel(string $label): Configuration
     {
         $this->label = $label;
 
@@ -149,28 +125,33 @@ class Configuration
      * @param Constraint[] $constraints
      * @return Configuration
      */
-    public function setConstraints(array $constraints)
+    public function setConstraints(array $constraints): Configuration
     {
         $this->constraints = $constraints;
 
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getTranslationDomain()
+    public function getTranslationDomain(): string
     {
         return $this->translationDomain;
     }
 
-    /**
-     * @param string $translationDomain
-     * @return Configuration
-     */
-    public function setTranslationDomain(string $translationDomain)
+    public function setTranslationDomain(string $translationDomain): Configuration
     {
         $this->translationDomain = $translationDomain;
+
+        return $this;
+    }
+
+    public function isRequired(): bool
+    {
+        return $this->required;
+    }
+
+    public function setRequired(bool $required): Configuration
+    {
+        $this->required = $required;
 
         return $this;
     }

--- a/src/Form/Type/EnhancedSelectboxType.php
+++ b/src/Form/Type/EnhancedSelectboxType.php
@@ -26,7 +26,7 @@ class EnhancedSelectboxType extends AbstractType
         $resolver->setDefaults([
             'label' => 'label.select_type',
             'choices' => [
-                '' => null,
+                '' => '',
                 'Javascript' => 'selectpicker',
             ],
             'required' => false,

--- a/src/Form/Type/SystemConfigurationType.php
+++ b/src/Form/Type/SystemConfigurationType.php
@@ -44,7 +44,7 @@ class SystemConfigurationType extends AbstractType
                     return;
                 }
 
-                $required = true;
+                $required = $preference->isRequired();
                 if (CheckboxType::class == $preference->getType()) {
                     $required = false;
                 }

--- a/tests/Controller/SystemConfigurationControllerTest.php
+++ b/tests/Controller/SystemConfigurationControllerTest.php
@@ -184,7 +184,7 @@ class SystemConfigurationControllerTest extends ControllerBaseTest
         $client->submit($form, [
             'system_configuration_form_theme' => [
                 'configuration' => [
-                    ['name' => 'theme.select_type', 'value' => '1'],
+                    ['name' => 'theme.select_type', 'value' => 'selectpicker'],
                     ['name' => 'timesheet.markdown_content', 'value' => 1],
                 ]
             ]


### PR DESCRIPTION
## Description

The system config "Type of select-boxes in forms" could not be resettled after switching to Javascript.
This PR fixes the behavior and introduces the "required" flag for dynamic system configs.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer kimai:code-check`)
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
