### PR TITLE
Decreased the logo font size by 2px.

### DIFF
--- a/assets/sass/navbar.scss
+++ b/assets/sass/navbar.scss
@@ -89,4 +89,8 @@ li.open .ticktac i.running{
     left: 40px;
     padding-top: 0px;
 }
+.logo-lg {
+    font-size: 18px;
+}
+
 */


### PR DESCRIPTION
I find the logo was a little big before. I tested the new font-size on mobile and desktop. IMO it looked better. 

![new fontsize](https://user-images.githubusercontent.com/43857362/60747625-bbff1000-9f86-11e9-9831-323835c14211.png)
![old fontsize](https://user-images.githubusercontent.com/43857362/60747626-bbff1000-9f86-11e9-8052-56cb2a08d3b6.png)



