### PR TITLE
fix LDAP edge-case initialization error

### DIFF
--- a/src/Ldap/LdapDriver.php
+++ b/src/Ldap/LdapDriver.php
@@ -54,7 +54,7 @@ class LdapDriver
      * @return Ldap
      * @throws \Exception
      */
-    private function getDriver()
+    protected function getDriver()
     {
         if (null === $this->driver) {
             if (!class_exists('Zend\Ldap\Ldap')) {

--- a/tests/Ldap/LdapDriverTest.php
+++ b/tests/Ldap/LdapDriverTest.php
@@ -80,8 +80,15 @@ class LdapDriverTest extends TestCase
 
 class TestLdapDriver extends LdapDriver
 {
+    private $testDriver;
+
     public function __construct(Ldap $ldap)
     {
-        $this->driver = $ldap;
+        $this->testDriver = $ldap;
+    }
+
+    protected function getDriver()
+    {
+        return $this->testDriver;
     }
 }


### PR DESCRIPTION
## Description

Fixed an edge-case problem for non-LDAP installations, that happened when a user was changed in the database.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer kimai:code-check`)
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
