### PR TITLE
Change Translation "Tag/Tags" to "Schlagworte" in DE

### DIFF
--- a/translations/tags.de.xliff
+++ b/translations/tags.de.xliff
@@ -4,11 +4,11 @@
         <body>
             <trans-unit id="tags.title">
                 <source>tags.title</source>
-                <target>Tags</target>
+                <target>Schlagworte</target>
             </trans-unit>
             <trans-unit id="tags.subtitle">
                 <source>tags.subtitle</source>
-                <target>Tags erlauben es, beliebige Zeitmessungen zusammenzufassen</target>
+                <target>Schlagworte erlauben es, beliebige Zeitmessungen zusammenzufassen</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
Change Translation "Tag/Tags" to "Schlagworte" in DE for more consistent DE wording.