### PR TITLE
trigger template events in authentication layout as well

### DIFF
--- a/templates/bundles/FOSUserBundle/Registration/confirmed.html.twig
+++ b/templates/bundles/FOSUserBundle/Registration/confirmed.html.twig
@@ -6,12 +6,18 @@
 {% block head %}
     {{ parent() }}
     {% include 'partials/head.html.twig' %}
+    {% set event = trigger(constant('App\\Event\\ThemeEvent::HTML_HEAD')) %}
+    {{ event.content|raw }}
 {% endblock %}
 
 {% block stylesheets %}
     {{ encore_entry_link_tags('app') }}
+    {% set event = trigger(constant('App\\Event\\ThemeEvent::STYLESHEET')) %}
+    {{ event.content|raw }}
 {% endblock %}
 
 {% block javascripts %}
     {{ encore_entry_script_tags('app') }}
+    {% set event = trigger(constant('App\\Event\\ThemeEvent::JAVASCRIPT')) %}
+    {{ event.content|raw }}
 {% endblock %}

--- a/templates/bundles/FOSUserBundle/Registration/register.html.twig
+++ b/templates/bundles/FOSUserBundle/Registration/register.html.twig
@@ -6,12 +6,18 @@
 {% block head %}
     {{ parent() }}
     {% include 'partials/head.html.twig' %}
+    {% set event = trigger(constant('App\\Event\\ThemeEvent::HTML_HEAD')) %}
+    {{ event.content|raw }}
 {% endblock %}
 
 {% block stylesheets %}
     {{ encore_entry_link_tags('app') }}
+    {% set event = trigger(constant('App\\Event\\ThemeEvent::STYLESHEET')) %}
+    {{ event.content|raw }}
 {% endblock %}
 
 {% block javascripts %}
     {{ encore_entry_script_tags('app') }}
+    {% set event = trigger(constant('App\\Event\\ThemeEvent::JAVASCRIPT')) %}
+    {{ event.content|raw }}
 {% endblock %}

--- a/templates/bundles/FOSUserBundle/Resetting/request.html.twig
+++ b/templates/bundles/FOSUserBundle/Resetting/request.html.twig
@@ -6,12 +6,18 @@
 {% block head %}
     {{ parent() }}
     {% include 'partials/head.html.twig' %}
+    {% set event = trigger(constant('App\\Event\\ThemeEvent::HTML_HEAD')) %}
+    {{ event.content|raw }}
 {% endblock %}
 
 {% block stylesheets %}
     {{ encore_entry_link_tags('app') }}
+    {% set event = trigger(constant('App\\Event\\ThemeEvent::STYLESHEET')) %}
+    {{ event.content|raw }}
 {% endblock %}
 
 {% block javascripts %}
     {{ encore_entry_script_tags('app') }}
+    {% set event = trigger(constant('App\\Event\\ThemeEvent::JAVASCRIPT')) %}
+    {{ event.content|raw }}
 {% endblock %}

--- a/templates/bundles/FOSUserBundle/Security/login.html.twig
+++ b/templates/bundles/FOSUserBundle/Security/login.html.twig
@@ -6,12 +6,18 @@
 {% block head %}
     {{ parent() }}
     {% include 'partials/head.html.twig' %}
+    {% set event = trigger(constant('App\\Event\\ThemeEvent::HTML_HEAD')) %}
+    {{ event.content|raw }}
 {% endblock %}
 
 {% block stylesheets %}
     {{ encore_entry_link_tags('app') }}
+    {% set event = trigger(constant('App\\Event\\ThemeEvent::STYLESHEET')) %}
+    {{ event.content|raw }}
 {% endblock %}
 
 {% block javascripts %}
     {{ encore_entry_script_tags('app') }}
+    {% set event = trigger(constant('App\\Event\\ThemeEvent::JAVASCRIPT')) %}
+    {{ event.content|raw }}
 {% endblock %}

--- a/templates/bundles/FOSUserBundle/layout.html.twig
+++ b/templates/bundles/FOSUserBundle/layout.html.twig
@@ -6,12 +6,18 @@
 {% block head %}
     {{ parent() }}
     {% include 'partials/head.html.twig' %}
+    {% set event = trigger(constant('App\\Event\\ThemeEvent::HTML_HEAD')) %}
+    {{ event.content|raw }}
 {% endblock %}
 
 {% block stylesheets %}
     {{ encore_entry_link_tags('app') }}
+    {% set event = trigger(constant('App\\Event\\ThemeEvent::STYLESHEET')) %}
+    {{ event.content|raw }}
 {% endblock %}
 
 {% block javascripts %}
     {{ encore_entry_script_tags('app') }}
+    {% set event = trigger(constant('App\\Event\\ThemeEvent::JAVASCRIPT')) %}
+    {{ event.content|raw }}
 {% endblock %}


### PR DESCRIPTION
## Description

Adds the theme events to the register/login/password reset screens.

Allows to customize the styles with the [CustomCSSBundle](https://www.kimai.org/store/keleo-css-custom-bundle.html)

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer kimai:code-check`)
- [x] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
