### PR TITLE
added calendar slot_duration config

### DIFF
--- a/config/packages/kimai.yaml
+++ b/config/packages/kimai.yaml
@@ -124,6 +124,7 @@ kimai:
 #        week_numbers: true
 #        weekends: true
 #        day_limit: 4
+#        slot_duration: '00:30:00'
 #        businessHours:
 #            days: [1, 2, 3, 4, 5]
 #            begin: '08:00'

--- a/src/Configuration/CalendarConfiguration.php
+++ b/src/Configuration/CalendarConfiguration.php
@@ -97,4 +97,9 @@ class CalendarConfiguration implements SystemBundleConfiguration
     {
         return $this->find('google.sources');
     }
+
+    public function getSlotDuration(): string
+    {
+        return (string) $this->find('slot_duration');
+    }
 }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -250,6 +250,7 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->booleanNode('week_numbers')->defaultTrue()->end()
                 ->integerNode('day_limit')->defaultValue(4)->end()
+                ->scalarNode('slot_duration')->defaultValue('00:30:00')->end()
                 ->arrayNode('businessHours')
                     ->addDefaultsIfNotSet()
                     ->children()

--- a/templates/calendar/user.html.twig
+++ b/templates/calendar/user.html.twig
@@ -215,9 +215,8 @@
                 eventResize: changeHandler,
                 {% endif %}
             {% endif %}
-                /*
-                slotDuration: '00:30:00',                               // TODO make me configurable
-                */
+                slotDuration: '{{ config.slotDuration }}',
+                slotLabelInterval: '{{ config.slotDuration }}',
                 minTime: '{{ config.timeframeBegin }}',
                 maxTime: '{{ config.timeframeEnd }}',
                 defaultTimedEventDuration: '00:30'

--- a/tests/Configuration/CalendarConfigurationTest.php
+++ b/tests/Configuration/CalendarConfigurationTest.php
@@ -42,6 +42,7 @@ class CalendarConfigurationTest extends TestCase
                 'end' => '19:27'
             ],
             'day_limit' => 20,
+            'slot_duration' => '01:11:00',
             'week_numbers' => false,
             'google' => [
                 'api_key' => 'wertwertwegsdfbdf243w567fg8ihuon',
@@ -72,6 +73,7 @@ class CalendarConfigurationTest extends TestCase
         $this->assertEquals([2, 4, 6], $sut->getBusinessDays());
         $this->assertEquals('07:49', $sut->getBusinessTimeBegin());
         $this->assertEquals('19:27', $sut->getBusinessTimeEnd());
+        $this->assertEquals('01:11:00', $sut->getSlotDuration());
         $this->assertEquals(20, $sut->getDayLimit());
         $this->assertFalse($sut->isShowWeekNumbers());
 

--- a/tests/Controller/CalendarControllerTest.php
+++ b/tests/Controller/CalendarControllerTest.php
@@ -68,6 +68,7 @@ class CalendarControllerTest extends ControllerBaseTest
             ],
             'day_limit' => 20,
             'week_numbers' => false,
+            'slot_duration' => '00:15:00',
             'google' => [
                 'api_key' => 'wertwertwegsdfbdf243w567fg8ihuon',
                 'sources' => [

--- a/tests/DependencyInjection/AppExtensionTest.php
+++ b/tests/DependencyInjection/AppExtensionTest.php
@@ -231,7 +231,7 @@ class AppExtensionTest extends TestCase
     }
 
     /**
-     * @expectedException \Notice
+     * @expectedException \PHPUnit\Framework\Error\Notice
      * @expectedExceptionMessage Found ambiguous configuration. Please remove "kimai.timesheet.duration_only" and set "kimai.timesheet.mode" instead.
      * @expectedDeprecation Configuration "kimai.timesheet.duration_only" is deprecated, please remove it
      * @group legacy
@@ -320,7 +320,7 @@ class AppExtensionTest extends TestCase
     }
 
     /**
-     * @expectedException \Notice
+     * @expectedException \PHPUnit\Framework\Error\Notice
      * @expectedExceptionMessage Found invalid "kimai" configuration: The child node "data_dir" at path "kimai" must be configured.
      */
     public function testInvalidConfiguration()

--- a/tests/DependencyInjection/AppExtensionTest.php
+++ b/tests/DependencyInjection/AppExtensionTest.php
@@ -10,7 +10,7 @@
 namespace App\Tests\DependencyInjection;
 
 use App\DependencyInjection\AppExtension;
-use PHPUnit\Framework\Error\Notice;
+use Notice;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 

--- a/tests/DependencyInjection/AppExtensionTest.php
+++ b/tests/DependencyInjection/AppExtensionTest.php
@@ -10,7 +10,6 @@
 namespace App\Tests\DependencyInjection;
 
 use App\DependencyInjection\AppExtension;
-use Notice;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
@@ -232,7 +231,7 @@ class AppExtensionTest extends TestCase
     }
 
     /**
-     * @expectedException Notice
+     * @expectedException \Notice
      * @expectedExceptionMessage Found ambiguous configuration. Please remove "kimai.timesheet.duration_only" and set "kimai.timesheet.mode" instead.
      * @expectedDeprecation Configuration "kimai.timesheet.duration_only" is deprecated, please remove it
      * @group legacy
@@ -321,7 +320,7 @@ class AppExtensionTest extends TestCase
     }
 
     /**
-     * @expectedException Notice
+     * @expectedException \Notice
      * @expectedExceptionMessage Found invalid "kimai" configuration: The child node "data_dir" at path "kimai" must be configured.
      */
     public function testInvalidConfiguration()

--- a/tests/DependencyInjection/AppExtensionTest.php
+++ b/tests/DependencyInjection/AppExtensionTest.php
@@ -10,6 +10,7 @@
 namespace App\Tests\DependencyInjection;
 
 use App\DependencyInjection\AppExtension;
+use PHPUnit\Framework\Error\Notice;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 
@@ -63,6 +64,7 @@ class AppExtensionTest extends TestCase
             'kimai.calendar' => [
                 'week_numbers' => true,
                 'day_limit' => 4,
+                'slot_duration' => '00:30:00',
                 'businessHours' => [
                     'days' => [1, 2, 3, 4, 5],
                     'begin' => '08:00',
@@ -230,7 +232,7 @@ class AppExtensionTest extends TestCase
     }
 
     /**
-     * @expectedException \PHPUnit\Framework\Error\Notice
+     * @expectedException Notice
      * @expectedExceptionMessage Found ambiguous configuration. Please remove "kimai.timesheet.duration_only" and set "kimai.timesheet.mode" instead.
      * @expectedDeprecation Configuration "kimai.timesheet.duration_only" is deprecated, please remove it
      * @group legacy
@@ -319,7 +321,7 @@ class AppExtensionTest extends TestCase
     }
 
     /**
-     * @expectedException \PHPUnit\Framework\Error\Notice
+     * @expectedException Notice
      * @expectedExceptionMessage Found invalid "kimai" configuration: The child node "data_dir" at path "kimai" must be configured.
      */
     public function testInvalidConfiguration()


### PR DESCRIPTION
## Description

Allows to configure the slot duration for calendar: week and day view

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer kimai:code-check`)
- [x] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
