### PR TITLE
Fix english translation for 'info'

### DIFF
--- a/translations/messages.en.xliff
+++ b/translations/messages.en.xliff
@@ -314,7 +314,7 @@
             -->
             <trans-unit id="more.info.link">
                 <source>more.info.link</source>
-                <target>More infos</target>
+                <target>More info</target>
             </trans-unit>
             <trans-unit id="label.toggle_dropdown">
                 <source>label.toggle_dropdown</source>


### PR DESCRIPTION
## Description
In english, 'information' and its shortened form 'info' are their own plurals. Simple spelling change.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [X] I verified that my code applies to the guidelines (`composer kimai:code-check`)
- [X] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [X] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
