### PR TITLE
Copy meta fields

### DIFF
--- a/tests/API/TimesheetControllerTest.php
+++ b/tests/API/TimesheetControllerTest.php
@@ -744,7 +744,7 @@ class TimesheetControllerTest extends APIControllerBaseTest
         $result = json_decode($client->getResponse()->getContent(), true);
         $this->assertDefaultStructure($result, true);
         $this->assertEquals('foo', $result['description']);
-        $this->assertEquals([['name' => 'sdfsdf', 'value' => 'nnnnn'],['name' => '1234567890', 'value' => '1234567890']], $result['metaFields']);
+        $this->assertEquals([['name' => 'sdfsdf', 'value' => 'nnnnn'], ['name' => '1234567890', 'value' => '1234567890']], $result['metaFields']);
         $this->assertEquals(['another', 'testing', 'bar'], $result['tags']);
 
         $em = $client->getContainer()->get('doctrine.orm.entity_manager');

--- a/tests/API/TimesheetControllerTest.php
+++ b/tests/API/TimesheetControllerTest.php
@@ -808,7 +808,7 @@ class TimesheetControllerTest extends APIControllerBaseTest
         $client = $this->getClientForAuthenticatedUser(User::ROLE_USER);
 
         $this->request($client, '/api/timesheets/1/export', 'PATCH');
-        $this->assertApiResponseAccessDenied($client->getResponse(), 'Access denied.');
+        $this->assertApiResponseAccessDenied($client->getResponse(), 'You are not allowed to lock this timesheet');
     }
 
     public function testExportThrowsNotFound()


### PR DESCRIPTION
## Description

Copy timesheet meta-fields on restart action (as with all fields).

Fixes #1015

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer kimai:code-check`)
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
