### PR TITLE
fix for production settings not exposing framework details

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,8 @@ RUN apt update && \
         zip && \
     apt remove -y wget && \
     apt -y autoremove && \
-    apt clean
+    apt clean && \
+    cp /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini
 
 FROM tmp_kimai2_base
 


### PR DESCRIPTION
## Description

I'm currently running kimai in a docker setup and had the mysql container fail due to other reasons overnight. This exposed all database credentials in a manner of a typical php error display message when you opened the web interface.

```php
Fatal error: Uncaught PDOException: PDO::__construct(): php_network_getaddresses: getaddrinfo failed: Temporary failure in name resolution in /opt/kimai/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOConnection.php:27 Stack trace: #0 /opt/kimai/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOConnection.php(27): PDO->__construct('mysql:host=data...', 'root', 'FbIkWN1iUy1EC9m...', Array) #1 /opt/kimai/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/PDOMySql/Driver.php(22): Doctrine\DBAL\Driver\PDOConnection->__construct('mysql:host=data...', 'DBUSERNAME', 'DBPASSWORD', Array) #2 /opt/kimai/vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php(356): Doctrine\DBAL\Driver\PDOMySql\Driver->connect(Array, 'root', 'FbIkWN1iUy1EC9m...', Array) #3 /opt/kimai/vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php(420): Doctrine\DBAL\Connection->connect() #4 /opt/kimai/vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php(380): Doctrine\DBAL\Connection->getDatabasePlatformVersion() #5 /opt/kimai/vendor/doctrine/dbal/lib/Doctrine/DB in /opt/kimai/templates/error.html.twig on line 3
```

I would suggest to implement the production php.ini file as delivered by the php:7.2 base image. This leads to a proper 500 error instead. This might change how you operate your development process (if it is based on the same docker image).

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I verified that my code applies to the guidelines (`composer kimai:code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)