### PR TITLE
Fix broken navigation and error pages

### DIFF
--- a/src/EventSubscriber/MenuBuilderSubscriber.php
+++ b/src/EventSubscriber/MenuBuilderSubscriber.php
@@ -27,7 +27,7 @@ class MenuBuilderSubscriber implements EventSubscriberInterface
      */
     private $eventDispatcher;
     /**
-     * @var TokenStorageInterface 
+     * @var TokenStorageInterface
      */
     private $tokenStorage;
 

--- a/src/EventSubscriber/MenuBuilderSubscriber.php
+++ b/src/EventSubscriber/MenuBuilderSubscriber.php
@@ -14,10 +14,11 @@ use KevinPapst\AdminLTEBundle\Event\SidebarMenuEvent;
 use KevinPapst\AdminLTEBundle\Model\MenuItemModel;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
 /**
  * Class MenuBuilder configures the main navigation.
+ * @internal
  */
 class MenuBuilderSubscriber implements EventSubscriberInterface
 {
@@ -26,19 +27,14 @@ class MenuBuilderSubscriber implements EventSubscriberInterface
      */
     private $eventDispatcher;
     /**
-     * @var AuthorizationCheckerInterface
+     * @var TokenStorageInterface 
      */
-    private $security;
+    private $tokenStorage;
 
-    /**
-     * MenuBuilderSubscriber constructor.
-     * @param EventDispatcherInterface $dispatcher
-     * @param AuthorizationCheckerInterface $security
-     */
-    public function __construct(EventDispatcherInterface $dispatcher, AuthorizationCheckerInterface $security)
+    public function __construct(EventDispatcherInterface $dispatcher, TokenStorageInterface $storage)
     {
         $this->eventDispatcher = $dispatcher;
-        $this->security = $security;
+        $this->tokenStorage = $storage;
     }
 
     /**
@@ -72,7 +68,7 @@ class MenuBuilderSubscriber implements EventSubscriberInterface
         );
 
         // error pages don't have a user and will fail when is_granted() is called
-        if (null !== $event->getRequest()->getUser()) {
+        if (null !== $this->tokenStorage->getToken()) {
             $this->eventDispatcher->dispatch($menuEvent);
         }
 

--- a/templates/bundles/TwigBundle/Exception/error404.html.twig
+++ b/templates/bundles/TwigBundle/Exception/error404.html.twig
@@ -1,1 +1,5 @@
 {% extends 'error.html.twig' %}
+
+{% block error_icon %}
+    <i class="far fa-frown"></i>
+{% endblock %}

--- a/templates/error.html.twig
+++ b/templates/error.html.twig
@@ -1,33 +1,51 @@
-{% extends 'base.html.twig' %}
+{% extends '@AdminLTE/layout/security-layout.html.twig' %}
 
-{% block page_title %}{{ 'http_error.title'|trans({}, 'exceptions') }}{% endblock %}
-{% block page_subtitle %}{{ status_code }}{% endblock %}
-
-{% block main %}
-    {% set errorTitleKey = "http_error_#{status_code}.description" %}
+{% set errorTitleKey = "http_error_#{status_code}.description" %}
+{% set errorTitleTrans = errorTitleKey|trans({ '%status_code%': status_code }, 'exceptions') %}
+{% if errorTitleKey == errorTitleTrans %}
+    {% set errorTitleKey = 'http_error.description' %}
     {% set errorTitleTrans = errorTitleKey|trans({ '%status_code%': status_code }, 'exceptions') %}
-    {% if errorTitleKey == errorTitleTrans %}
-        {% set errorTitleKey = 'http_error.description' %}
-        {% set errorTitleTrans = errorTitleKey|trans({ '%status_code%': status_code }, 'exceptions') %}
-    {% endif %}
+{% endif %}
 
-    {% set errorMessageKey = "http_error_#{status_code}.suggestion" %}
+{% set errorMessageKey = "http_error_#{status_code}.suggestion" %}
+{% set errorMessageTrans = errorMessageKey|trans({ '%status_code%': status_code }, 'exceptions') %}
+{% if errorMessageKey == errorMessageTrans %}
+    {% set errorMessageKey = 'http_error.suggestion' %}
     {% set errorMessageTrans = errorMessageKey|trans({ '%status_code%': status_code }, 'exceptions') %}
-    {% if errorMessageKey == errorMessageTrans %}
-        {% set errorMessageKey = 'http_error.suggestion' %}
-        {% set errorMessageTrans = errorMessageKey|trans({ '%status_code%': status_code }, 'exceptions') %}
-    {% endif %}
+{% endif %}
 
-    <div class="error-page">
-        <h2 class="headline {% block error_class %}text-yellow{% endblock %}"> {{ status_code }}</h2>
+{% block logo_login %}{% include 'partials/logo_login.html.twig' %}{% endblock %}
+{% block title %}{{ status_code }} - {{ 'http_error.title'|trans({}, 'exceptions') }}{% endblock %}
 
-        {% block error_content %}
-        <div class="error-content">
-            <h3>{% block error_icon %}{% endblock %} {{ errorTitleTrans }}</h3>
-            <p>{{ errorMessageTrans }}</p>
-            <a class="btn btn-primary" href="javascript:window.history.back();">{{ 'action.back'|trans }}</a>
-        </div>
-        {% endblock %}
-
-    </div>
+{% block head %}
+    {{ parent() }}
+    {% include 'partials/head.html.twig' %}
 {% endblock %}
+
+{% block stylesheets %}
+    {{ encore_entry_link_tags('app') }}
+{% endblock %}
+
+{% block javascripts %}
+    {{ encore_entry_script_tags('app') }}
+{% endblock %}
+
+{% block login_box_icon %}{% block error_icon %}{% endblock %}{% endblock %}
+
+{% block login_box_msg %}
+    {{ errorTitleTrans }}
+{% endblock %}
+
+{% block login_form %}
+    {% block error_content %}
+        <p>
+            {{ errorMessageTrans }}
+        </p>
+        <p>
+            <a class="btn btn-primary" href="{{ path('dashboard') }}">{{ 'dashboard.title'|trans }}</a>
+        </p>
+    {% endblock %}
+{% endblock %}
+
+{% block login_social_auth %}{% endblock %}
+{% block login_actions %}{% endblock %}

--- a/tests/Controller/DashboardControllerTest.php
+++ b/tests/Controller/DashboardControllerTest.php
@@ -50,25 +50,4 @@ class DashboardControllerTest extends ControllerBaseTest
         $this->assertTrue($client->getResponse()->isSuccessful());
         $this->assertMainContentClass($client, 'dashboard');
     }
-
-    /**
-     * This is not a test for the dashbaord, but for the general layout
-     */
-    public function testUserMenuIsAvailable()
-    {
-        $client = $this->getClientForAuthenticatedUser(User::ROLE_USER);
-
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
-        $user = $this->getUserByRole($em, User::ROLE_USER);
-
-        $this->request($client, '/dashboard/');
-        $this->assertTrue($client->getResponse()->isSuccessful());
-
-        $content = $client->getResponse()->getContent();
-
-        $this->assertStringContainsString('<li class="dropdown user-menu">', $content);
-        $this->assertStringContainsString('<a href="/en/profile/' . $user->getUsername() . '">', $content);
-        $this->assertStringContainsString('<a href="/en/profile/' . $user->getUsername() . '/prefs">', $content);
-        $this->assertStringContainsString('<a href="/en/logout">', $content);
-    }
 }

--- a/tests/Controller/LayoutTest.php
+++ b/tests/Controller/LayoutTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Controller;
+
+use App\Entity\User;
+use Symfony\Component\HttpKernel\HttpKernelBrowser;
+
+/**
+ * @group integration
+ */
+class LayoutTest extends ControllerBaseTest
+{
+    public function testNavigationMenus()
+    {
+        $client = $this->getClientForAuthenticatedUser(User::ROLE_USER);
+
+        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $user = $this->getUserByRole($em, User::ROLE_USER);
+
+        $this->request($client, '/dashboard/');
+        $this->assertTrue($client->getResponse()->isSuccessful());
+
+        $this->assertHasMainHeader($client, $user);
+        $this->assertHasSidebar($client, $user);
+    }
+
+    protected function assertHasMainHeader(HttpKernelBrowser $client, User $user)
+    {
+        // TODO improve me
+        // main-header > a.logo
+        // # href = homepage
+        // && > span.logo-mini
+        // && > span.logo-lg
+        // && > nav.navbar.navbar-static-top
+        //    && div.navbar-custom-menu
+
+        $content = $client->getResponse()->getContent();
+
+        $this->assertStringContainsString('<li class="dropdown user-menu">', $content);
+        $this->assertStringContainsString('<a href="/en/profile/' . $user->getUsername() . '">', $content);
+        $this->assertStringContainsString('<a href="/en/profile/' . $user->getUsername() . '/prefs">', $content);
+        $this->assertStringContainsString('<a href="/en/logout">', $content);
+    }
+
+    protected function assertHasSidebar(HttpKernelBrowser $client, User $user)
+    {
+        // TODO improve me
+        // aside.main-sidebar
+        // && section.sidebar
+        //    && ul.sidebar-menu tree
+        //       && li#dashboard > a href=dashboard
+        //       && li#... with links
+
+        $content = $client->getResponse()->getContent();
+
+        $this->assertStringContainsString('<li id="dashboard"', $content);
+        $this->assertStringContainsString('<a href="/en/dashboard/">', $content);
+        $this->assertStringContainsString('<span>Dashboard</span>', $content);
+
+        $this->assertStringContainsString('<li id="timesheet"', $content);
+        $this->assertStringContainsString('<a href="/en/timesheet/">', $content);
+        $this->assertStringContainsString('<span>My times</span>', $content);
+
+        $this->assertStringContainsString('<li id="calendar"', $content);
+        $this->assertStringContainsString('<a href="/en/calendar/">', $content);
+        $this->assertStringContainsString('<span>Calendar</span>', $content);
+    }
+}

--- a/translations/exceptions.de.xliff
+++ b/translations/exceptions.de.xliff
@@ -16,30 +16,29 @@
             </trans-unit>
             <trans-unit id="http_error.description">
                 <source>http_error.description</source>
-                <target>Oops! Ein Fehler ist aufgetreten.</target>
+                <target>Etwas läuft falsch</target>
             </trans-unit>
             <trans-unit id="http_error.suggestion">
                 <source>http_error.suggestion</source>
                 <target>
-                    Ein unerwarteter Fehler ist aufgetreten.
-                    Möglicherweise haben Sie einen Bug gefunden, daher kontaktieren Sie bitte ihren Administrator
-                    wenn der Fehler nach einem erneuten Versuch immer noch vorhanden sein sollte.
+                    Ein kritischer Fehler ist aufgetreten.
+                    Möglicherweise haben Sie einen Software Fehler gefunden, kontaktieren Sie bitte ihren Administrator wenn der Fehler bestehen bleibt.
                 </target>
             </trans-unit>
             <trans-unit id="http_error_404.description">
                 <source>http_error_404.description</source>
-                <target>Oops! Seite wurde nicht gefunden.</target>
+                <target>Seite wurde nicht gefunden</target>
             </trans-unit>
             <trans-unit id="http_error_404.suggestion">
                 <source>http_error_404.suggestion</source>
                 <target>
                     Wir konnten die angeforderte Seite leider nicht finden.
-                    Bitte wechseln Sie zurück zu ihrem Dashboard und starten von vorne.
+                    Bitte wechseln Sie zu ihrem Dashboard und starten von vorne.
                 </target>
             </trans-unit>
             <trans-unit id="http_error_403.description">
                 <source>http_error_403.description</source>
-                <target>Diese Seite ist geschützt.</target>
+                <target>Seite ist geschützt</target>
             </trans-unit>
             <trans-unit id="http_error_403.suggestion">
                 <source>http_error_403.suggestion</source>

--- a/translations/exceptions.en.xliff
+++ b/translations/exceptions.en.xliff
@@ -16,35 +16,34 @@
             </trans-unit>
             <trans-unit id="http_error.description">
                 <source>http_error.description</source>
-                <target>Oops! An error occured.</target>
+                <target>Something is wrong</target>
             </trans-unit>
             <trans-unit id="http_error.suggestion">
                 <source>http_error.suggestion</source>
                 <target>
-                    An unexpected error occured, please try again.
-                    You may have found a bug, so please contact your administrator if the problem
-                    doesn't go away after you tried it again.
+                    A critical error occurred, please try again.
+                    You may have found a software problem, please contact your administrator if the problem persists.
                 </target>
             </trans-unit>
             <trans-unit id="http_error_404.description">
                 <source>http_error_404.description</source>
-                <target>Oops! Page not found.</target>
+                <target>Page not found</target>
             </trans-unit>
             <trans-unit id="http_error_404.suggestion">
                 <source>http_error_404.suggestion</source>
                 <target>
                     We could not find the page you were looking for.
-                    Meanwhile, you may return to your dashboard and start over.
+                    Please return to your dashboard and start over.
                 </target>
             </trans-unit>
             <trans-unit id="http_error_403.description">
                 <source>http_error_403.description</source>
-                <target>This page is restricted.</target>
+                <target>Page is restricted</target>
             </trans-unit>
             <trans-unit id="http_error_403.suggestion">
                 <source>http_error_403.suggestion</source>
                 <target>
-                    Sorry, but you do not have sufficient permissions to see this page.
+                    Sorry, but you don't have sufficient permissions to see this page.
                     Please talk to your administrator if you think this is an error.
                 </target>
             </trans-unit>


### PR DESCRIPTION
## Description

Fixes #1194 

Adds a new error page design, to remove all elements from the page:
<img width="640" alt="Bildschirmfoto 2019-10-31 um 12 29 00" src="https://user-images.githubusercontent.com/533162/67943336-19743800-fbda-11e9-90c6-29f6d36387be.png">


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer kimai:code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
