### PR TITLE
loose email validation on customer

### DIFF
--- a/src/Form/CustomerEditForm.php
+++ b/src/Form/CustomerEditForm.php
@@ -10,10 +10,10 @@
 namespace App\Form;
 
 use App\Entity\Customer;
+use App\Form\Type\MailType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CountryType;
 use Symfony\Component\Form\Extension\Core\Type\CurrencyType;
-use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\TelType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -84,8 +84,7 @@ class CustomerEditForm extends AbstractType
                 'required' => false,
                 'attr' => ['icon' => 'mobile'],
             ])
-            ->add('email', EmailType::class, [
-                'label' => 'label.email',
+            ->add('email', MailType::class, [
                 'required' => false,
             ])
             ->add('homepage', UrlType::class, [

--- a/src/Form/Type/MailType.php
+++ b/src/Form/Type/MailType.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Validator\Constraints\Email;
+
+class MailType extends AbstractType
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'label' => 'label.email',
+            'icon' => 'mail',
+            'constraints' => [
+                new Email(['mode' => 'loose'])
+            ],
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getParent()
+    {
+        return TextType::class;
+    }
+}


### PR DESCRIPTION
## Description

Allowing to use `Test <test@example.com>` and `test@example.com` for customer email address

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer kimai:code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
