### PR TITLE
allow to configure calendar slot length

### DIFF
--- a/src/Controller/SystemConfigurationController.php
+++ b/src/Controller/SystemConfigurationController.php
@@ -34,6 +34,7 @@ use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Validator\Constraints\DateTime;
 use Symfony\Component\Validator\Constraints\GreaterThanOrEqual;
 use Symfony\Component\Validator\Constraints\NotNull;
+use Symfony\Component\Validator\Constraints\Regex;
 
 /**
  * Controller used for executing system relevant tasks.
@@ -346,6 +347,11 @@ class SystemConfigurationController extends AbstractController
                         ->setTranslationDomain('system-configuration')
                         ->setType(TextType::class)
                         ->setConstraints([new DateTime(['format' => 'H:i']), new NotNull()]),
+                    (new Configuration())
+                        ->setName('calendar.slot_duration')
+                        ->setTranslationDomain('system-configuration')
+                        ->setType(TextType::class)
+                        ->setConstraints([new Regex(['pattern' => '/[0-2]{1}[0-9]{1}:[0-9]{2}:[0-9]{2}/']), new NotNull()]),
                 ]),
             (new SystemConfigurationModel())
                 ->setSection(SystemConfigurationModel::SECTION_BRANDING)

--- a/translations/system-configuration.de.xliff
+++ b/translations/system-configuration.de.xliff
@@ -100,7 +100,7 @@
             </trans-unit>
             <trans-unit id="label.calendar.slot_duration">
                 <source>label.calendar.slot_duration</source>
-                <target>Länge eines Slots für Wochen- und Tagesansicht (Format: hh:mm:ss)</target>
+                <target>Slotdauer für Wochen- und Tagesansicht (Format: hh:mm:ss)</target>
             </trans-unit>
             <trans-unit id="branding">
                 <source>branding</source>

--- a/translations/system-configuration.de.xliff
+++ b/translations/system-configuration.de.xliff
@@ -98,6 +98,10 @@
                 <source>label.calendar.visibleHours.end</source>
                 <target>Ende des sichtbaren Zeitbereichs</target>
             </trans-unit>
+            <trans-unit id="label.calendar.slot_duration">
+                <source>label.calendar.slot_duration</source>
+                <target>Länge eines Slots für Wochen- und Tagesansicht (Format: hh:mm:ss)</target>
+            </trans-unit>
             <trans-unit id="branding">
                 <source>branding</source>
                 <target>Markendarstellung</target>

--- a/translations/system-configuration.en.xliff
+++ b/translations/system-configuration.en.xliff
@@ -100,7 +100,7 @@
             </trans-unit>
             <trans-unit id="label.calendar.slot_duration">
                 <source>label.calendar.slot_duration</source>
-                <target>Length of a slot for week- and day view (format: hh:mm:ss)</target>
+                <target>Slot duration for week- and day view (format: hh:mm:ss)</target>
             </trans-unit>
             <trans-unit id="branding">
                 <source>branding</source>

--- a/translations/system-configuration.en.xliff
+++ b/translations/system-configuration.en.xliff
@@ -98,6 +98,10 @@
                 <source>label.calendar.visibleHours.end</source>
                 <target>End of visible time range</target>
             </trans-unit>
+            <trans-unit id="label.calendar.slot_duration">
+                <source>label.calendar.slot_duration</source>
+                <target>Length of a slot for week- and day view (format: hh:mm:ss)</target>
+            </trans-unit>
             <trans-unit id="branding">
                 <source>branding</source>
                 <target>Branding</target>


### PR DESCRIPTION
## Description

Make calendar slot duration configurable in system configuration screen

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer kimai:code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
