### PR TITLE
feature: duplicate projects with all settings

### DIFF
--- a/src/Controller/ProjectController.php
+++ b/src/Controller/ProjectController.php
@@ -381,7 +381,7 @@ final class ProjectController extends AbstractController
      */
     public function duplicateAction(Project $project, Request $request, ProjectDuplicationService $projectDuplicationService)
     {
-        $newProject = $projectDuplicationService->duplicate($project, 'Copy of ' . $project->getName());
+        $newProject = $projectDuplicationService->duplicate($project, $project->getName() . ' [COPY]');
 
         return $this->redirectToRoute('project_details', ['id' => $newProject->getId()]);
     }

--- a/src/Controller/ProjectController.php
+++ b/src/Controller/ProjectController.php
@@ -25,6 +25,7 @@ use App\Form\ProjectRateForm;
 use App\Form\ProjectTeamPermissionForm;
 use App\Form\Toolbar\ProjectToolbarForm;
 use App\Form\Type\ProjectType;
+use App\Project\ProjectDuplicationService;
 use App\Repository\ActivityRepository;
 use App\Repository\ProjectRateRepository;
 use App\Repository\ProjectRepository;
@@ -372,6 +373,17 @@ final class ProjectController extends AbstractController
     public function editAction(Project $project, Request $request)
     {
         return $this->renderProjectForm($project, $request);
+    }
+
+    /**
+     * @Route(path="/{id}/duplicate", name="admin_project_duplicate", methods={"GET", "POST"})
+     * @Security("is_granted('edit', project)")
+     */
+    public function duplicateAction(Project $project, Request $request, ProjectDuplicationService $projectDuplicationService)
+    {
+        $newProject = $projectDuplicationService->duplicate($project, 'Copy of ' . $project->getName());
+
+        return $this->redirectToRoute('project_details', ['id' => $newProject->getId()]);
     }
 
     /**

--- a/src/Entity/Activity.php
+++ b/src/Entity/Activity.php
@@ -31,7 +31,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 class Activity implements EntityWithMetaFields
 {
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="id", type="integer")
      * @ORM\Id

--- a/src/Entity/Activity.php
+++ b/src/Entity/Activity.php
@@ -211,4 +211,12 @@ class Activity implements EntityWithMetaFields
     {
         return $this->getName();
     }
+
+    public function __clone()
+    {
+        if ($this->id) {
+            $this->id = null;
+            $this->meta = new ArrayCollection();
+        }
+    }
 }

--- a/src/Entity/MetaTableTypeTrait.php
+++ b/src/Entity/MetaTableTypeTrait.php
@@ -234,4 +234,11 @@ trait MetaTableTypeTrait
     {
         return $this->options;
     }
+
+    public function __clone()
+    {
+        if ($this->id) {
+            $this->id = null;
+        }
+    }
 }

--- a/src/Entity/MetaTableTypeTrait.php
+++ b/src/Entity/MetaTableTypeTrait.php
@@ -19,7 +19,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 trait MetaTableTypeTrait
 {
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Id
      * @ORM\GeneratedValue

--- a/src/Entity/Project.php
+++ b/src/Entity/Project.php
@@ -382,4 +382,13 @@ class Project implements EntityWithMetaFields
     {
         return $this->getName();
     }
+
+    public function __clone()
+    {
+        if ($this->id) {
+            $this->id = null;
+            $this->teams = new ArrayCollection();
+            $this->meta = new ArrayCollection();
+        }
+    }
 }

--- a/src/Entity/Project.php
+++ b/src/Entity/Project.php
@@ -30,7 +30,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 class Project implements EntityWithMetaFields
 {
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="id", type="integer")
      * @ORM\Id

--- a/src/Entity/Rate.php
+++ b/src/Entity/Rate.php
@@ -89,4 +89,11 @@ trait Rate
 
         return $this;
     }
+
+    public function __clone()
+    {
+        if ($this->id) {
+            $this->id = null;
+        }
+    }
 }

--- a/src/Entity/Rate.php
+++ b/src/Entity/Rate.php
@@ -15,7 +15,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 trait Rate
 {
     /**
-     * @var int
+     * @var int|null
      *
      * @ORM\Column(name="id", type="integer")
      * @ORM\Id

--- a/src/Project/ProjectDuplicationService.php
+++ b/src/Project/ProjectDuplicationService.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Project;
+
+use App\Entity\ActivityRate;
+use App\Entity\Project;
+use App\Entity\ProjectRate;
+use App\Repository\ActivityRateRepository;
+use App\Repository\ActivityRepository;
+use App\Repository\ProjectRateRepository;
+use App\Repository\ProjectRepository;
+
+final class ProjectDuplicationService
+{
+    /**
+     * @var ProjectRepository
+     */
+    private $projectRepository;
+    /**
+     * @var ActivityRepository
+     */
+    private $activityRepository;
+    /**
+     * @var ProjectRateRepository
+     */
+    private $projectRateRepository;
+    /**
+     * @var ActivityRateRepository
+     */
+    private $activityRateRepository;
+
+    public function __construct(
+        ProjectRepository $projectRepository,
+        ActivityRepository $activityRepository,
+        ProjectRateRepository $projectRateRepository,
+        ActivityRateRepository $activityRateRepository
+    ) {
+        $this->projectRepository = $projectRepository;
+        $this->activityRepository = $activityRepository;
+        $this->projectRateRepository = $projectRateRepository;
+        $this->activityRateRepository = $activityRateRepository;
+    }
+
+    public function duplicate(Project $project, string $newName): Project
+    {
+        $newProject = clone $project;
+        $newProject->setName($newName);
+
+        foreach ($project->getTeams() as $team) {
+            $newProject->addTeam($team);
+        }
+
+        foreach ($project->getMetaFields() as $metaField) {
+            $newMetaField = clone $metaField;
+            $newMetaField->setEntity($newProject);
+            $newProject->setMetaField($newMetaField);
+        }
+
+        if (null !== $project->getEnd()) {
+            $newProject->setStart(clone $project->getEnd());
+            $newProject->setEnd(null);
+        }
+
+        $this->projectRepository->saveProject($newProject);
+
+        foreach ($this->projectRateRepository->getRatesForProject($project) as $rate) {
+            /** @var ProjectRate $newRate */
+            $newRate = clone $rate;
+            $newRate->setProject($newProject);
+            $this->projectRateRepository->saveRate($newRate);
+        }
+
+        $allActivities = $this->activityRepository->findByProject($project);
+        foreach ($allActivities as $activity) {
+            $newActivity = clone $activity;
+            $newActivity->setProject($newProject);
+            foreach ($activity->getMetaFields() as $metaField) {
+                $newMetaField = clone $metaField;
+                $newMetaField->setEntity($newActivity);
+                $newActivity->setMetaField($newMetaField);
+            }
+
+            $this->activityRepository->saveActivity($newActivity);
+
+            foreach ($this->activityRateRepository->getRatesForActivity($newActivity) as $rate) {
+                /** @var ActivityRate $newRate */
+                $newRate = clone $rate;
+                $newRate->setActivity($newActivity);
+                $this->activityRateRepository->saveRate($newRate);
+            }
+        }
+
+        return $newProject;
+    }
+}

--- a/src/Project/ProjectDuplicationService.php
+++ b/src/Project/ProjectDuplicationService.php
@@ -89,7 +89,7 @@ final class ProjectDuplicationService
 
             $this->activityRepository->saveActivity($newActivity);
 
-            foreach ($this->activityRateRepository->getRatesForActivity($newActivity) as $rate) {
+            foreach ($this->activityRateRepository->getRatesForActivity($activity) as $rate) {
                 /** @var ActivityRate $newRate */
                 $newRate = clone $rate;
                 $newRate->setActivity($newActivity);

--- a/src/Repository/ActivityRepository.php
+++ b/src/Repository/ActivityRepository.php
@@ -10,6 +10,7 @@
 namespace App\Repository;
 
 use App\Entity\Activity;
+use App\Entity\Project;
 use App\Entity\Timesheet;
 use App\Entity\User;
 use App\Model\ActivityStatistic;
@@ -44,6 +45,15 @@ class ActivityRepository extends EntityRepository
         $loader->loadResults([$activity]);
 
         return $activity;
+    }
+
+    /**
+     * @param Project $project
+     * @return Activity[]
+     */
+    public function findByProject(Project $project)
+    {
+        return $this->findBy(['project' => $project]);
     }
 
     /**

--- a/templates/activity/actions.html.twig
+++ b/templates/activity/actions.html.twig
@@ -37,7 +37,7 @@
         {% if is_granted('create_other_timesheet') %}
             {% set actions = actions|merge({'create-timesheet': {'url': path('admin_timesheet_create', {'project': activity.project ? activity.project.id : null, 'activity': activity.id}), 'class': 'modal-ajax-form'}}) %}
         {% endif %}
-        {% if view == 'index' and is_granted('delete', activity) %}
+        {% if (view == 'index' or view == 'custom') and is_granted('delete', activity) %}
             {% set actions = actions|merge({'trash': {'url': path('admin_activity_delete', {'id': activity.id}), 'class': 'modal-ajax-form'}}) %}
         {% endif %}
     {% endif %}

--- a/templates/project/actions.html.twig
+++ b/templates/project/actions.html.twig
@@ -47,7 +47,7 @@
         {% if is_granted('create_activity') and project.visible and project.customer.visible %}
             {% set actions = actions|merge({'create-activity': path('admin_activity_create_with_project', {'project': project.id})}) %}
         {% endif %}
-        {% if view == 'index' and is_granted('delete', project) %}
+        {% if (view == 'index' or view == 'custom') and is_granted('delete', project) %}
             {% set actions = actions|merge({'trash': {'url': path('admin_project_delete', {'id': project.id}), 'class': 'modal-ajax-form'}}) %}
         {% endif %}
     {% endif %}

--- a/templates/project/actions.html.twig
+++ b/templates/project/actions.html.twig
@@ -27,6 +27,7 @@
                 {% set class = 'modal-ajax-form' %}
             {% endif %}
             {% set actions = actions|merge({'edit': {'url': path('admin_project_edit', {'id': project.id}), 'class': class}}) %}
+            {% set actions = actions|merge({'copy': {'url': path('admin_project_duplicate', {'id': project.id})}}) %}
         {% endif %}
         {% if is_granted('permissions', project) %}
             {% set class = '' %}

--- a/templates/project/embed_activities.html.twig
+++ b/templates/project/embed_activities.html.twig
@@ -16,6 +16,7 @@
                 {% for activity in activities %}
                     <tr>
                         <td>{{ activity.name }}</td>
+                        <td>{{ activity.comment|comment2html }}</td>
                         <td class="actions">{{ actions.activity(activity, 'custom') }}</td>
                     </tr>
                 {% endfor %}

--- a/tests/API/APIControllerBaseTest.php
+++ b/tests/API/APIControllerBaseTest.php
@@ -12,16 +12,16 @@ namespace App\Tests\API;
 use App\DataFixtures\UserFixtures;
 use App\Entity\User;
 use App\Tests\Controller\ControllerBaseTest;
-use Symfony\Bundle\FrameworkBundle\Client;
 use Symfony\Component\DomCrawler\Crawler;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\HttpKernelBrowser;
 
 /**
  * Adds some useful functions for writing API integration tests.
  */
 abstract class APIControllerBaseTest extends ControllerBaseTest
 {
-    protected function getClientForAuthenticatedUser(string $role = User::ROLE_USER): Client
+    protected function getClientForAuthenticatedUser(string $role = User::ROLE_USER): HttpKernelBrowser
     {
         switch ($role) {
             case User::ROLE_SUPER_ADMIN:
@@ -69,7 +69,7 @@ abstract class APIControllerBaseTest extends ControllerBaseTest
         return '/' . ltrim($url, '/') . ($json ? '.json' : '');
     }
 
-    protected function assertRequestIsSecured(Client $client, string $url, $method = 'GET')
+    protected function assertRequestIsSecured(HttpKernelBrowser $client, string $url, $method = 'GET')
     {
         $this->request($client, $url, $method);
         $this->assertResponseIsSecured($client->getResponse(), $url);
@@ -124,7 +124,7 @@ abstract class APIControllerBaseTest extends ControllerBaseTest
         );
     }
 
-    protected function request(Client $client, string $url, $method = 'GET', array $parameters = [], string $content = null): Crawler
+    protected function request(HttpKernelBrowser $client, string $url, $method = 'GET', array $parameters = [], string $content = null): Crawler
     {
         $server = ['HTTP_CONTENT_TYPE' => 'application/json', 'CONTENT_TYPE' => 'application/json'];
 
@@ -201,7 +201,7 @@ abstract class APIControllerBaseTest extends ControllerBaseTest
         self::assertEquals(['code' => 500, 'message' => $message], json_decode($response->getContent(), true));
     }
 
-    protected function assertApiAccessDenied(Client $client, string $url, string $message)
+    protected function assertApiAccessDenied(HttpKernelBrowser $client, string $url, string $message)
     {
         $this->request($client, $url);
         $this->assertApiResponseAccessDenied($client->getResponse(), $message);

--- a/tests/API/ActivityControllerTest.php
+++ b/tests/API/ActivityControllerTest.php
@@ -14,8 +14,8 @@ use App\Entity\Customer;
 use App\Entity\Project;
 use App\Entity\User;
 use App\Tests\Mocks\ActivityTestMetaFieldSubscriberMock;
-use Symfony\Bundle\FrameworkBundle\Client;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\HttpKernelBrowser;
 
 /**
  * @group integration
@@ -27,9 +27,9 @@ class ActivityControllerTest extends APIControllerBaseTest
         $this->assertUrlIsSecured('/api/activities');
     }
 
-    protected function loadActivityTestData(Client $client)
+    protected function loadActivityTestData(HttpKernelBrowser $client)
     {
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
 
         $project = $em->getRepository(Project::class)->find(1);
         $customer = $em->getRepository(Customer::class)->find(1);
@@ -266,7 +266,7 @@ class ActivityControllerTest extends APIControllerBaseTest
     public function testMetaAction()
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_ADMIN);
-        $client->getContainer()->get('event_dispatcher')->addSubscriber(new ActivityTestMetaFieldSubscriberMock());
+        static::$kernel->getContainer()->get('event_dispatcher')->addSubscriber(new ActivityTestMetaFieldSubscriberMock());
 
         $data = [
             'name' => 'metatestmock',
@@ -276,7 +276,7 @@ class ActivityControllerTest extends APIControllerBaseTest
 
         $this->assertTrue($client->getResponse()->isSuccessful());
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         /** @var Activity $activity */
         $activity = $em->getRepository(Activity::class)->find(1);
         $this->assertEquals('another,testing,bar', $activity->getMetaField('metatestmock')->getValue());

--- a/tests/API/CustomerControllerTest.php
+++ b/tests/API/CustomerControllerTest.php
@@ -211,7 +211,7 @@ class CustomerControllerTest extends APIControllerBaseTest
     public function testMetaAction()
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_ADMIN);
-        $client->getContainer()->get('event_dispatcher')->addSubscriber(new CustomerTestMetaFieldSubscriberMock());
+        static::$kernel->getContainer()->get('event_dispatcher')->addSubscriber(new CustomerTestMetaFieldSubscriberMock());
 
         $data = [
             'name' => 'metatestmock',
@@ -221,7 +221,7 @@ class CustomerControllerTest extends APIControllerBaseTest
 
         $this->assertTrue($client->getResponse()->isSuccessful());
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         /** @var Customer $customer */
         $customer = $em->getRepository(Customer::class)->find(1);
         $this->assertEquals('another,testing,bar', $customer->getMetaField('metatestmock')->getValue());

--- a/tests/API/ProjectControllerTest.php
+++ b/tests/API/ProjectControllerTest.php
@@ -14,8 +14,8 @@ use App\Entity\Project;
 use App\Entity\User;
 use App\Repository\Query\VisibilityInterface;
 use App\Tests\Mocks\ProjectTestMetaFieldSubscriberMock;
-use Symfony\Bundle\FrameworkBundle\Client;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\HttpKernelBrowser;
 
 /**
  * @group integration
@@ -39,9 +39,9 @@ class ProjectControllerTest extends APIControllerBaseTest
         $this->assertStructure($result[0], false);
     }
 
-    protected function loadProjectTestData(Client $client)
+    protected function loadProjectTestData(HttpKernelBrowser $client)
     {
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
 
         $customer = $em->getRepository(Customer::class)->find(1);
 
@@ -264,7 +264,7 @@ class ProjectControllerTest extends APIControllerBaseTest
     public function testMetaAction()
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_ADMIN);
-        $client->getContainer()->get('event_dispatcher')->addSubscriber(new ProjectTestMetaFieldSubscriberMock());
+        static::$kernel->getContainer()->get('event_dispatcher')->addSubscriber(new ProjectTestMetaFieldSubscriberMock());
 
         $data = [
             'name' => 'metatestmock',
@@ -274,7 +274,7 @@ class ProjectControllerTest extends APIControllerBaseTest
 
         $this->assertTrue($client->getResponse()->isSuccessful());
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         /** @var Project $project */
         $project = $em->getRepository(Project::class)->find(1);
         $this->assertEquals('another,testing,bar', $project->getMetaField('metatestmock')->getValue());

--- a/tests/API/TeamControllerTest.php
+++ b/tests/API/TeamControllerTest.php
@@ -13,15 +13,15 @@ use App\Entity\Customer;
 use App\Entity\Project;
 use App\Entity\User;
 use App\Tests\DataFixtures\TeamFixtures;
-use Symfony\Bundle\FrameworkBundle\Client;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\HttpKernelBrowser;
 
 /**
  * @group integration
  */
 class TeamControllerTest extends APIControllerBaseTest
 {
-    protected function importTeamFixtures(Client $client): void
+    protected function importTeamFixtures(HttpKernelBrowser $client): void
     {
         $fixture = new TeamFixtures();
         $fixture->setAmount(1);
@@ -334,7 +334,7 @@ class TeamControllerTest extends APIControllerBaseTest
         $customer->setVisible(false);
         $customer->setCountry('DE');
         $customer->setTimezone('Europe/Berlin');
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         $em->persist($customer);
         $em->flush();
 
@@ -472,7 +472,7 @@ class TeamControllerTest extends APIControllerBaseTest
         $project->setName('foooo');
         $project->setVisible(false);
         $project->setCustomer($customer);
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         $em->persist($customer);
         $em->persist($project);
         $em->flush();

--- a/tests/API/TimesheetControllerTest.php
+++ b/tests/API/TimesheetControllerTest.php
@@ -45,7 +45,7 @@ class TimesheetControllerTest extends APIControllerBaseTest
     protected function importFixtureForUser(string $role)
     {
         $client = $this->getClientForAuthenticatedUser($role);
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
 
         $fixture = new TimesheetFixtures();
         $fixture
@@ -92,7 +92,7 @@ class TimesheetControllerTest extends APIControllerBaseTest
     public function testGetCollectionForOtherUser()
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_TEAMLEAD);
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
 
         $fixture = new TimesheetFixtures();
         $fixture
@@ -117,7 +117,7 @@ class TimesheetControllerTest extends APIControllerBaseTest
     public function testGetCollectionForAllUser()
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_TEAMLEAD);
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
 
         $fixture = new TimesheetFixtures();
         $fixture
@@ -184,7 +184,7 @@ class TimesheetControllerTest extends APIControllerBaseTest
     public function testExportedFilter()
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_USER);
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
 
         $fixture = new TimesheetFixtures();
         $fixture
@@ -313,7 +313,7 @@ class TimesheetControllerTest extends APIControllerBaseTest
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_USER);
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         $customer = (new Customer())->setName('foo-bar-1')->setVisible(false)->setCountry('DE')->setTimezone('Europe/Berlin');
         $em->persist($customer);
         $project = (new Project())->setName('foo-bar-2')->setVisible(true)->setCustomer($customer);
@@ -341,7 +341,7 @@ class TimesheetControllerTest extends APIControllerBaseTest
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_USER);
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         $customer = (new Customer())->setName('foo-bar-1')->setVisible(true)->setCountry('DE')->setTimezone('Europe/Berlin');
         $em->persist($customer);
         $project = (new Project())->setName('foo-bar-2')->setVisible(true)->setCustomer($customer);
@@ -388,7 +388,7 @@ class TimesheetControllerTest extends APIControllerBaseTest
     public function testPatchActionWithInvalidUser()
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_USER);
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
 
         $fixture = new TimesheetFixtures();
         $fixture
@@ -496,7 +496,7 @@ class TimesheetControllerTest extends APIControllerBaseTest
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_USER);
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         /** @var Timesheet $timesheet */
         $timesheet = $em->getRepository(Timesheet::class)->find(1);
         $timesheet->setExported(true);
@@ -511,7 +511,7 @@ class TimesheetControllerTest extends APIControllerBaseTest
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_ADMIN);
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         /** @var Timesheet $timesheet */
         $timesheet = $em->getRepository(Timesheet::class)->find(1);
         $timesheet->setExported(true);
@@ -525,7 +525,7 @@ class TimesheetControllerTest extends APIControllerBaseTest
     public function testGetRecentCollectionWithSubresources()
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_TEAMLEAD);
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
 
         $start = new \DateTime('-10 days');
 
@@ -558,7 +558,7 @@ class TimesheetControllerTest extends APIControllerBaseTest
     public function testActiveAction()
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_USER);
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
 
         $start = new \DateTime('-10 days');
 
@@ -586,7 +586,7 @@ class TimesheetControllerTest extends APIControllerBaseTest
     public function testStopAction()
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_USER);
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
 
         $start = new \DateTime('-10 days');
 
@@ -604,7 +604,7 @@ class TimesheetControllerTest extends APIControllerBaseTest
         $this->request($client, '/api/timesheets/11/stop', 'PATCH');
         $this->assertTrue($client->getResponse()->isSuccessful());
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         /** @var Timesheet $timesheet */
         $timesheet = $em->getRepository(Timesheet::class)->find(1);
         $this->assertInstanceOf(\DateTime::class, $timesheet->getEnd());
@@ -626,7 +626,7 @@ class TimesheetControllerTest extends APIControllerBaseTest
     public function testStopNotAllowedForUser()
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_USER);
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
 
         $start = new \DateTime('-10 days');
 
@@ -648,7 +648,7 @@ class TimesheetControllerTest extends APIControllerBaseTest
     public function testGetCollectionWithTags()
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_USER);
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
 
         $fixture = new TimesheetFixtures();
         $fixture
@@ -708,7 +708,7 @@ class TimesheetControllerTest extends APIControllerBaseTest
         $this->assertEmpty($result['description']);
         $this->assertEmpty($result['tags']);
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         /** @var Timesheet $timesheet */
         $timesheet = $em->getRepository(Timesheet::class)->find($result['id']);
         $this->assertInstanceOf(\DateTime::class, $timesheet->getBegin());
@@ -723,7 +723,7 @@ class TimesheetControllerTest extends APIControllerBaseTest
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_USER);
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         /** @var Timesheet $timesheet */
         $timesheet = $em->getRepository(Timesheet::class)->find(1);
         $timesheet->setDescription('foo');
@@ -748,7 +748,7 @@ class TimesheetControllerTest extends APIControllerBaseTest
         $this->assertEquals([['name' => 'sdfsdf', 'value' => 'nnnnn'], ['name' => '1234567890', 'value' => '1234567890']], $result['metaFields']);
         $this->assertEquals(['another', 'testing', 'bar'], $result['tags']);
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         /** @var Timesheet $timesheet */
         $timesheet = $em->getRepository(Timesheet::class)->find($result['id']);
         $this->assertInstanceOf(\DateTime::class, $timesheet->getBegin());
@@ -762,7 +762,7 @@ class TimesheetControllerTest extends APIControllerBaseTest
     public function testRestartNotAllowedForUser()
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_USER);
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
 
         $start = new \DateTime('-10 days');
 
@@ -790,7 +790,7 @@ class TimesheetControllerTest extends APIControllerBaseTest
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_ADMIN);
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         /** @var Timesheet $timesheet */
         $timesheet = $em->getRepository(Timesheet::class)->find(1);
         $this->assertEquals(false, $timesheet->isExported());
@@ -799,7 +799,7 @@ class TimesheetControllerTest extends APIControllerBaseTest
         $this->assertTrue($client->getResponse()->isSuccessful());
         $this->assertDefaultStructure(json_decode($client->getResponse()->getContent(), true), true);
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         /** @var Timesheet $timesheet */
         $timesheet = $em->getRepository(Timesheet::class)->find(1);
         $this->assertEquals(true, $timesheet->isExported());
@@ -807,7 +807,7 @@ class TimesheetControllerTest extends APIControllerBaseTest
         $this->request($client, '/api/timesheets/1/export', 'PATCH');
         $this->assertTrue($client->getResponse()->isSuccessful());
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         $timesheet = $em->getRepository(Timesheet::class)->find(1);
         $this->assertEquals(false, $timesheet->isExported());
     }
@@ -857,7 +857,7 @@ class TimesheetControllerTest extends APIControllerBaseTest
     public function testMetaAction()
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_USER);
-        $client->getContainer()->get('event_dispatcher')->addSubscriber(new TimesheetTestMetaFieldSubscriberMock());
+        static::$kernel->getContainer()->get('event_dispatcher')->addSubscriber(new TimesheetTestMetaFieldSubscriberMock());
 
         $data = [
             'name' => 'metatestmock',
@@ -867,7 +867,7 @@ class TimesheetControllerTest extends APIControllerBaseTest
 
         $this->assertTrue($client->getResponse()->isSuccessful());
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         /** @var Timesheet $timesheet */
         $timesheet = $em->getRepository(Timesheet::class)->find(1);
         $this->assertEquals('another,testing,bar', $timesheet->getMetaField('metatestmock')->getValue());

--- a/tests/Controller/ActivityControllerTest.php
+++ b/tests/Controller/ActivityControllerTest.php
@@ -72,7 +72,7 @@ class ActivityControllerTest extends ControllerBaseTest
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_ADMIN);
         /** @var EntityManager $em */
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
 
         $fixture = new TimesheetFixtures();
         $fixture->setAmount(10);
@@ -174,7 +174,7 @@ class ActivityControllerTest extends ControllerBaseTest
     public function testCreateActionShowsMetaFields()
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_ADMIN);
-        $client->getContainer()->get('event_dispatcher')->addSubscriber(new ActivityTestMetaFieldSubscriberMock());
+        static::$kernel->getContainer()->get('event_dispatcher')->addSubscriber(new ActivityTestMetaFieldSubscriberMock());
         $this->assertAccessIsGranted($client, '/admin/activity/create');
         $this->assertTrue($client->getResponse()->isSuccessful());
 
@@ -283,7 +283,7 @@ class ActivityControllerTest extends ControllerBaseTest
         $client = $this->getClientForAuthenticatedUser(User::ROLE_ADMIN);
 
         /** @var EntityManager $em */
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
 
         $fixture = new TimesheetFixtures();
         $fixture->setUser($this->getUserByRole($em, User::ROLE_USER));
@@ -324,7 +324,7 @@ class ActivityControllerTest extends ControllerBaseTest
         $client = $this->getClientForAuthenticatedUser(User::ROLE_ADMIN);
 
         /** @var EntityManager $em */
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
 
         $fixture = new TimesheetFixtures();
         $fixture->setUser($this->getUserByRole($em, User::ROLE_USER));

--- a/tests/Controller/CalendarControllerTest.php
+++ b/tests/Controller/CalendarControllerTest.php
@@ -39,7 +39,7 @@ class CalendarControllerTest extends ControllerBaseTest
         $config = new CalendarConfiguration($loader, $this->getDefaultSettings());
 
         $client = $this->getClientForAuthenticatedUser();
-        $client->getContainer()->set(CalendarConfiguration::class, $config);
+        static::$kernel->getContainer()->set(CalendarConfiguration::class, $config);
         $this->request($client, '/calendar/');
         $this->assertTrue($client->getResponse()->isSuccessful());
 

--- a/tests/Controller/ControllerBaseTest.php
+++ b/tests/Controller/ControllerBaseTest.php
@@ -15,6 +15,7 @@ use App\Tests\KernelTestTrait;
 use Symfony\Bundle\FrameworkBundle\Client;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpKernel\HttpKernelBrowser;
 
 /**
  * ControllerBaseTest adds some useful functions for writing integration tests.
@@ -25,11 +26,7 @@ abstract class ControllerBaseTest extends WebTestCase
 
     public const DEFAULT_LANGUAGE = 'en';
 
-    /**
-     * @param string $role
-     * @return Client
-     */
-    protected function getClientForAuthenticatedUser(string $role = User::ROLE_USER)
+    protected function getClientForAuthenticatedUser(string $role = User::ROLE_USER): HttpKernelBrowser
     {
         switch ($role) {
             case User::ROLE_SUPER_ADMIN:
@@ -78,24 +75,24 @@ abstract class ControllerBaseTest extends WebTestCase
     }
 
     /**
-     * @param Client $client
+     * @param HttpKernelBrowser $client
      * @param string $url
      * @param string $method
      * @param array $parameters
      * @param string $content
      * @return \Symfony\Component\DomCrawler\Crawler
      */
-    protected function request(Client $client, string $url, $method = 'GET', array $parameters = [], string $content = null)
+    protected function request(HttpKernelBrowser $client, string $url, $method = 'GET', array $parameters = [], string $content = null)
     {
         return $client->request($method, $this->createUrl($url), $parameters, [], [], $content);
     }
 
     /**
-     * @param Client $client
+     * @param HttpKernelBrowser $client
      * @param string $url
      * @param string $method
      */
-    protected function assertRequestIsSecured(Client $client, string $url, ?string $method = 'GET')
+    protected function assertRequestIsSecured(HttpKernelBrowser $client, string $url, ?string $method = 'GET')
     {
         $this->request($client, $url, $method);
 
@@ -141,7 +138,7 @@ abstract class ControllerBaseTest extends WebTestCase
         $this->assertAccessDenied($client);
     }
 
-    protected function assertAccessDenied(Client $client)
+    protected function assertAccessDenied(HttpKernelBrowser $client)
     {
         self::assertFalse(
             $client->getResponse()->isSuccessful(),
@@ -154,35 +151,35 @@ abstract class ControllerBaseTest extends WebTestCase
         );
     }
 
-    protected function assertAccessIsGranted(Client $client, string $url, string $method = 'GET', array $parameters = [])
+    protected function assertAccessIsGranted(HttpKernelBrowser $client, string $url, string $method = 'GET', array $parameters = [])
     {
         $this->request($client, $url, $method, $parameters);
         self::assertTrue($client->getResponse()->isSuccessful());
     }
 
-    protected function assertRouteNotFound(Client $client)
+    protected function assertRouteNotFound(HttpKernelBrowser $client)
     {
         self::assertFalse($client->getResponse()->isSuccessful());
         self::assertEquals(404, $client->getResponse()->getStatusCode());
     }
 
-    protected function assertMainContentClass(Client $client, string $classname)
+    protected function assertMainContentClass(HttpKernelBrowser $client, string $classname)
     {
         self::assertStringContainsString('<section class="content ' . $classname . '">', $client->getResponse()->getContent());
     }
 
     /**
-     * @param Client $client
+     * @param HttpKernelBrowser $client
      */
-    protected function assertHasDataTable(Client $client)
+    protected function assertHasDataTable(HttpKernelBrowser $client)
     {
         self::assertStringContainsString('<table class="table table-striped table-hover dataTable" role="grid" data-reload-event="', $client->getResponse()->getContent());
     }
 
     /**
-     * @param Client $client
+     * @param HttpKernelBrowser $client
      */
-    protected static function assertHasProgressbar(Client $client)
+    protected static function assertHasProgressbar(HttpKernelBrowser $client)
     {
         $content = $client->getResponse()->getContent();
         self::assertStringContainsString('<div class="progress-bar progress-bar-', $content);
@@ -191,21 +188,21 @@ abstract class ControllerBaseTest extends WebTestCase
     }
 
     /**
-     * @param Client $client
+     * @param HttpKernelBrowser $client
      * @param string $id
      * @param int $count
      */
-    protected function assertDataTableRowCount(Client $client, string $id, int $count)
+    protected function assertDataTableRowCount(HttpKernelBrowser $client, string $id, int $count)
     {
         $node = $client->getCrawler()->filter('section.content div#' . $id . ' table.table-striped tbody tr:not(.summary)');
         self::assertEquals($count, $node->count());
     }
 
     /**
-     * @param Client $client
+     * @param HttpKernelBrowser $client
      * @param array $buttons
      */
-    protected function assertPageActions(Client $client, array $buttons)
+    protected function assertPageActions(HttpKernelBrowser $client, array $buttons)
     {
         $node = $client->getCrawler()->filter('section.content-header div.breadcrumb div.box-tools div.btn-group a');
 
@@ -265,38 +262,38 @@ abstract class ControllerBaseTest extends WebTestCase
     }
 
     /**
-     * @param Client $client
+     * @param HttpKernelBrowser $client
      */
-    protected function assertHasNoEntriesWithFilter(Client $client)
+    protected function assertHasNoEntriesWithFilter(HttpKernelBrowser $client)
     {
         $this->assertCalloutWidgetWithMessage($client, 'No entries were found based on your selected filters.');
     }
 
     /**
-     * @param Client $client
+     * @param HttpKernelBrowser $client
      * @param string $message
      */
-    protected function assertCalloutWidgetWithMessage(Client $client, string $message)
+    protected function assertCalloutWidgetWithMessage(HttpKernelBrowser $client, string $message)
     {
         $node = $client->getCrawler()->filter('div.callout.callout-warning.lead');
         self::assertStringContainsString($message, $node->text(null, true));
     }
 
-    protected function assertHasFlashDeleteSuccess(Client $client)
+    protected function assertHasFlashDeleteSuccess(HttpKernelBrowser $client)
     {
         $this->assertHasFlashSuccess($client, 'Entry was deleted');
     }
 
-    protected function assertHasFlashSaveSuccess(Client $client)
+    protected function assertHasFlashSaveSuccess(HttpKernelBrowser $client)
     {
         $this->assertHasFlashSuccess($client, 'Saved changes');
     }
 
     /**
-     * @param Client $client
+     * @param HttpKernelBrowser $client
      * @param string|null $message
      */
-    protected function assertHasFlashSuccess(Client $client, string $message = null)
+    protected function assertHasFlashSuccess(HttpKernelBrowser $client, string $message = null)
     {
         $node = $client->getCrawler()->filter('div.alert.alert-success.alert-dismissible');
         self::assertGreaterThan(0, $node->count(), 'Could not find flash success message');
@@ -306,10 +303,10 @@ abstract class ControllerBaseTest extends WebTestCase
     }
 
     /**
-     * @param Client $client
+     * @param HttpKernelBrowser $client
      * @param string|null $message
      */
-    protected function assertHasFlashError(Client $client, string $message = null)
+    protected function assertHasFlashError(HttpKernelBrowser $client, string $message = null)
     {
         $node = $client->getCrawler()->filter('div.alert.alert-error.alert-dismissible');
         self::assertGreaterThan(0, $node->count(), 'Could not find flash error message');
@@ -319,10 +316,10 @@ abstract class ControllerBaseTest extends WebTestCase
     }
 
     /**
-     * @param Client $client
+     * @param HttpKernelBrowser $client
      * @param string $url
      */
-    protected function assertIsRedirect(Client $client, $url = null)
+    protected function assertIsRedirect(HttpKernelBrowser $client, $url = null)
     {
         self::assertTrue($client->getResponse()->isRedirect());
         if (null === $url) {

--- a/tests/Controller/CustomerControllerTest.php
+++ b/tests/Controller/CustomerControllerTest.php
@@ -231,7 +231,7 @@ class CustomerControllerTest extends ControllerBaseTest
         self::assertEquals(1, $node->count());
 
         /** @var EntityManager $em */
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         $customer = $em->getRepository(Customer::class)->find(1);
 
         $fixture = new ProjectFixtures();
@@ -278,7 +278,7 @@ class CustomerControllerTest extends ControllerBaseTest
     public function testCreateActionShowsMetaFields()
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_ADMIN);
-        $client->getContainer()->get('event_dispatcher')->addSubscriber(new CustomerTestMetaFieldSubscriberMock());
+        static::$kernel->getContainer()->get('event_dispatcher')->addSubscriber(new CustomerTestMetaFieldSubscriberMock());
         $this->assertAccessIsGranted($client, '/admin/customer/create');
         $this->assertTrue($client->getResponse()->isSuccessful());
 
@@ -309,7 +309,7 @@ class CustomerControllerTest extends ControllerBaseTest
     public function testTeamPermissionAction()
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_ADMIN);
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
 
         /** @var Customer $customer */
         $customer = $em->getRepository(Customer::class)->find(1);
@@ -368,7 +368,7 @@ class CustomerControllerTest extends ControllerBaseTest
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_ADMIN);
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         $fixture = new TimesheetFixtures();
         $fixture->setUser($this->getUserByRole($em, User::ROLE_USER));
         $fixture->setAmount(10);
@@ -407,7 +407,7 @@ class CustomerControllerTest extends ControllerBaseTest
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_ADMIN);
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         $fixture = new TimesheetFixtures();
         $fixture->setUser($this->getUserByRole($em, User::ROLE_USER));
         $fixture->setAmount(10);

--- a/tests/Controller/ExportControllerTest.php
+++ b/tests/Controller/ExportControllerTest.php
@@ -39,7 +39,7 @@ class ExportControllerTest extends ControllerBaseTest
     public function testIndexActionWithEntriesAndTeams()
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_TEAMLEAD);
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
 
         $teamlead = $this->getUserByRole($em, User::ROLE_TEAMLEAD);
         $user = $this->getUserByRole($em, User::ROLE_USER);
@@ -100,7 +100,7 @@ class ExportControllerTest extends ControllerBaseTest
     public function testIndexActionWithEntriesForTeamleadDoesNotShowUserWithoutTeam()
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_TEAMLEAD);
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
 
         $begin = new \DateTime('first day of this month');
         $user = $this->getUserByRole($em, User::ROLE_USER);
@@ -185,7 +185,7 @@ class ExportControllerTest extends ControllerBaseTest
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_ADMIN);
         /** @var EntityManager $em */
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
 
         $begin = new \DateTime('first day of this month');
         $fixture = new TimesheetFixtures();

--- a/tests/Controller/HomepageControllerTest.php
+++ b/tests/Controller/HomepageControllerTest.php
@@ -35,7 +35,7 @@ class HomepageControllerTest extends ControllerBaseTest
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_USER);
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         $user = $this->getUserByRole($em, User::ROLE_USER);
 
         $pref = (new UserPreference())

--- a/tests/Controller/InvoiceControllerTest.php
+++ b/tests/Controller/InvoiceControllerTest.php
@@ -89,7 +89,7 @@ class InvoiceControllerTest extends ControllerBaseTest
     public function testCopyTemplateAction()
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_ADMIN);
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
 
         $fixture = new InvoiceFixtures();
         $this->importFixture($client, $fixture);
@@ -118,7 +118,7 @@ class InvoiceControllerTest extends ControllerBaseTest
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_TEAMLEAD);
         /** @var EntityManager $em */
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
 
         $fixture = new InvoiceFixtures();
         $this->importFixture($client, $fixture);
@@ -211,7 +211,7 @@ class InvoiceControllerTest extends ControllerBaseTest
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_ADMIN);
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         $fixture = new InvoiceFixtures();
         $this->importFixture($client, $fixture);
 

--- a/tests/Controller/LayoutControllerTest.php
+++ b/tests/Controller/LayoutControllerTest.php
@@ -21,7 +21,7 @@ class LayoutControllerTest extends ControllerBaseTest
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_USER);
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         $user = $this->getUserByRole($em, User::ROLE_USER);
 
         $this->request($client, '/dashboard/');
@@ -77,7 +77,7 @@ class LayoutControllerTest extends ControllerBaseTest
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_USER);
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         $user = $this->getUserByRole($em, User::ROLE_USER);
 
         $this->request($client, '/layou/active_entries');

--- a/tests/Controller/PermissionControllerTest.php
+++ b/tests/Controller/PermissionControllerTest.php
@@ -122,7 +122,7 @@ class PermissionControllerTest extends ControllerBaseTest
         $this->assertIsRedirect($client, $this->createUrl('/admin/permissions'));
 
         /** @var EntityManager $em */
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         $rolePermissions = $em->getRepository(RolePermission::class)->findAll();
         $this->assertEquals(0, count($rolePermissions));
 

--- a/tests/Controller/ProfileControllerTest.php
+++ b/tests/Controller/ProfileControllerTest.php
@@ -14,8 +14,8 @@ use App\Entity\User;
 use App\Entity\UserPreference;
 use App\Tests\DataFixtures\TeamFixtures;
 use App\Tests\DataFixtures\TimesheetFixtures;
-use Symfony\Bundle\FrameworkBundle\Client;
 use Symfony\Component\DomCrawler\Field\ChoiceFormField;
+use Symfony\Component\HttpKernel\HttpKernelBrowser;
 use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
 
 /**
@@ -48,7 +48,7 @@ class ProfileControllerTest extends ControllerBaseTest
             new \DateTime('-1 year'),
         ];
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
 
         foreach ($dates as $start) {
             $fixture = new TimesheetFixtures();
@@ -72,7 +72,7 @@ class ProfileControllerTest extends ControllerBaseTest
         $this->assertHasAboutMeBox($client, UserFixtures::USERNAME_USER);
     }
 
-    protected function assertHasProfileBox(Client $client, string $username)
+    protected function assertHasProfileBox(HttpKernelBrowser $client, string $username)
     {
         $profileBox = $client->getCrawler()->filter('div.box-body.box-profile');
         $this->assertEquals(1, $profileBox->count());
@@ -83,7 +83,7 @@ class ProfileControllerTest extends ControllerBaseTest
         $this->assertEquals($username, $alt);
     }
 
-    protected function assertHasAboutMeBox(Client $client, string $username)
+    protected function assertHasAboutMeBox(HttpKernelBrowser $client, string $username)
     {
         $content = $client->getResponse()->getContent();
 
@@ -133,7 +133,7 @@ class ProfileControllerTest extends ControllerBaseTest
         $client = $this->getClientForAuthenticatedUser(User::ROLE_USER);
         $this->request($client, '/profile/' . UserFixtures::USERNAME_USER . '/edit');
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         /** @var User $user */
         $user = $this->getUserByRole($em, User::ROLE_USER);
 
@@ -160,7 +160,7 @@ class ProfileControllerTest extends ControllerBaseTest
 
         $this->assertHasFlashSuccess($client);
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         $user = $this->getUserByRole($em, User::ROLE_USER);
 
         $this->assertEquals(UserFixtures::USERNAME_USER, $user->getUsername());
@@ -193,7 +193,7 @@ class ProfileControllerTest extends ControllerBaseTest
 
         $this->assertHasFlashSuccess($client);
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         $user = $this->getUserByRole($em, User::ROLE_USER);
 
         $this->assertEquals(UserFixtures::USERNAME_USER, $user->getUsername());
@@ -209,12 +209,12 @@ class ProfileControllerTest extends ControllerBaseTest
         $client = $this->getClientForAuthenticatedUser(User::ROLE_USER);
         $this->request($client, '/profile/' . UserFixtures::USERNAME_USER . '/password');
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         /** @var User $user */
         $user = $this->getUserByRole($em, User::ROLE_USER);
 
         /** @var EncoderFactoryInterface $passwordEncoder */
-        $passwordEncoder = $client->getContainer()->get('test.PasswordEncoder');
+        $passwordEncoder = static::$kernel->getContainer()->get('test.PasswordEncoder');
 
         $this->assertTrue($passwordEncoder->getEncoder($user)->isPasswordValid($user->getPassword(), UserFixtures::DEFAULT_PASSWORD, $user->getSalt()));
         $this->assertFalse($passwordEncoder->getEncoder($user)->isPasswordValid($user->getPassword(), 'test123', $user->getSalt()));
@@ -236,7 +236,7 @@ class ProfileControllerTest extends ControllerBaseTest
 
         $this->assertHasFlashSuccess($client);
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         $user = $this->getUserByRole($em, User::ROLE_USER);
 
         $this->assertFalse($passwordEncoder->getEncoder($user)->isPasswordValid($user->getPassword(), UserFixtures::DEFAULT_PASSWORD, $user->getSalt()));
@@ -248,11 +248,11 @@ class ProfileControllerTest extends ControllerBaseTest
         $client = $this->getClientForAuthenticatedUser(User::ROLE_USER);
         $this->request($client, '/profile/' . UserFixtures::USERNAME_USER . '/api-token');
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         /** @var User $user */
         $user = $this->getUserByRole($em, User::ROLE_USER);
         /** @var EncoderFactoryInterface $passwordEncoder */
-        $passwordEncoder = $client->getContainer()->get('test.PasswordEncoder');
+        $passwordEncoder = static::$kernel->getContainer()->get('test.PasswordEncoder');
 
         $this->assertTrue($passwordEncoder->getEncoder($user)->isPasswordValid($user->getApiToken(), UserFixtures::DEFAULT_API_TOKEN, $user->getSalt()));
         $this->assertFalse($passwordEncoder->getEncoder($user)->isPasswordValid($user->getApiToken(), 'test123', $user->getSalt()));
@@ -274,7 +274,7 @@ class ProfileControllerTest extends ControllerBaseTest
 
         $this->assertHasFlashSuccess($client);
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         $user = $this->getUserByRole($em, User::ROLE_USER);
 
         $this->assertFalse($passwordEncoder->getEncoder($user)->isPasswordValid($user->getApiToken(), UserFixtures::DEFAULT_API_TOKEN, $user->getSalt()));
@@ -293,7 +293,7 @@ class ProfileControllerTest extends ControllerBaseTest
         $client = $this->getClientForAuthenticatedUser(User::ROLE_SUPER_ADMIN);
         $this->request($client, '/profile/' . UserFixtures::USERNAME_USER . '/roles');
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         /** @var User $user */
         $user = $this->getUserByRole($em, User::ROLE_USER);
 
@@ -313,7 +313,7 @@ class ProfileControllerTest extends ControllerBaseTest
 
         $this->assertHasFlashSuccess($client);
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         $user = $this->getUserByRole($em, User::ROLE_USER);
 
         $this->assertEquals(['ROLE_TEAMLEAD', 'ROLE_SUPER_ADMIN', 'ROLE_USER'], $user->getRoles());
@@ -328,7 +328,7 @@ class ProfileControllerTest extends ControllerBaseTest
     public function testTeamsAction()
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_SUPER_ADMIN);
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
 
         /** @var User $user */
         $user = $this->getUserByRole($em, User::ROLE_USER);
@@ -359,7 +359,7 @@ class ProfileControllerTest extends ControllerBaseTest
 
         $this->assertHasFlashSuccess($client);
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         $user = $this->getUserByRole($em, User::ROLE_USER);
 
         $this->assertEquals(1, $user->getTeams()->count());
@@ -385,7 +385,7 @@ class ProfileControllerTest extends ControllerBaseTest
         $client = $this->getClientForAuthenticatedUser($role);
         $this->request($client, '/profile/' . $username . '/prefs');
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         /** @var User $user */
         $user = $this->getUserByName($em, $username);
 
@@ -417,7 +417,7 @@ class ProfileControllerTest extends ControllerBaseTest
 
         $this->assertHasFlashSuccess($client);
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         $user = $this->getUserByName($em, $username);
 
         $this->assertEquals($hourlyRate, $user->getPreferenceValue(UserPreference::HOURLY_RATE));

--- a/tests/Controller/SystemConfigurationControllerTest.php
+++ b/tests/Controller/SystemConfigurationControllerTest.php
@@ -63,7 +63,7 @@ class SystemConfigurationControllerTest extends ControllerBaseTest
         $client = $this->getClientForAuthenticatedUser(User::ROLE_SUPER_ADMIN);
         $this->assertAccessIsGranted($client, '/admin/system-config/');
 
-        $configService = $client->getContainer()->get(SystemConfiguration::class);
+        $configService = static::$kernel->getContainer()->get(SystemConfiguration::class);
         $this->assertEquals('default', $configService->find('timesheet.mode'));
         $this->assertEquals(true, $configService->find('timesheet.rules.allow_future_times'));
         $this->assertEquals(1, $configService->find('timesheet.active_entries.hard_limit'));
@@ -86,7 +86,7 @@ class SystemConfigurationControllerTest extends ControllerBaseTest
         $this->assertTrue($client->getResponse()->isSuccessful());
         $this->assertHasFlashSaveSuccess($client);
 
-        $configService = $client->getContainer()->get(SystemConfiguration::class);
+        $configService = static::$kernel->getContainer()->get(SystemConfiguration::class);
         $this->assertEquals('duration_only', $configService->find('timesheet.mode'));
         $this->assertEquals(false, $configService->find('timesheet.rules.allow_future_times'));
         $this->assertEquals(99, $configService->find('timesheet.active_entries.hard_limit'));
@@ -123,7 +123,7 @@ class SystemConfigurationControllerTest extends ControllerBaseTest
         $client = $this->getClientForAuthenticatedUser(User::ROLE_SUPER_ADMIN);
         $this->assertAccessIsGranted($client, '/admin/system-config/');
 
-        $configService = $client->getContainer()->get(SystemConfiguration::class);
+        $configService = static::$kernel->getContainer()->get(SystemConfiguration::class);
         $this->assertNull($configService->find('defaults.customer.timezone'));
         $this->assertEquals('DE', $configService->find('defaults.customer.country'));
         $this->assertEquals('EUR', $configService->find('defaults.customer.currency'));
@@ -144,7 +144,7 @@ class SystemConfigurationControllerTest extends ControllerBaseTest
         $this->assertTrue($client->getResponse()->isSuccessful());
         $this->assertHasFlashSaveSuccess($client);
 
-        $configService = $client->getContainer()->get(SystemConfiguration::class);
+        $configService = static::$kernel->getContainer()->get(SystemConfiguration::class);
         $this->assertEquals('Atlantic/Canary', $configService->find('defaults.customer.timezone'));
         $this->assertEquals('BB', $configService->find('defaults.customer.country'));
         $this->assertEquals('GBP', $configService->find('defaults.customer.currency'));
@@ -155,7 +155,7 @@ class SystemConfigurationControllerTest extends ControllerBaseTest
         $client = $this->getClientForAuthenticatedUser(User::ROLE_SUPER_ADMIN);
         $this->assertAccessIsGranted($client, '/admin/system-config/');
 
-        $configService = $client->getContainer()->get(SystemConfiguration::class);
+        $configService = static::$kernel->getContainer()->get(SystemConfiguration::class);
         $this->assertNull($configService->find('defaults.user.timezone'));
         $this->assertNull($configService->find('defaults.user.theme'));
         $this->assertEquals('en', $configService->find('defaults.user.language'));
@@ -176,7 +176,7 @@ class SystemConfigurationControllerTest extends ControllerBaseTest
         $this->assertTrue($client->getResponse()->isSuccessful());
         $this->assertHasFlashSaveSuccess($client);
 
-        $configService = $client->getContainer()->get(SystemConfiguration::class);
+        $configService = static::$kernel->getContainer()->get(SystemConfiguration::class);
         $this->assertEquals('Pacific/Tahiti', $configService->find('defaults.user.timezone'));
         $this->assertEquals('purple', $configService->find('defaults.user.theme'));
         $this->assertEquals('ru', $configService->find('defaults.user.language'));
@@ -211,7 +211,7 @@ class SystemConfigurationControllerTest extends ControllerBaseTest
         $client = $this->getClientForAuthenticatedUser(User::ROLE_SUPER_ADMIN);
         $this->assertAccessIsGranted($client, '/admin/system-config/');
 
-        $configService = $client->getContainer()->get(SystemConfiguration::class);
+        $configService = static::$kernel->getContainer()->get(SystemConfiguration::class);
         $this->assertEquals(false, $configService->find('timesheet.markdown_content'));
         $this->assertEquals('selectpicker', $configService->find('theme.select_type'));
 
@@ -230,7 +230,7 @@ class SystemConfigurationControllerTest extends ControllerBaseTest
         $this->assertTrue($client->getResponse()->isSuccessful());
         $this->assertHasFlashSaveSuccess($client);
 
-        $configService = $client->getContainer()->get(SystemConfiguration::class);
+        $configService = static::$kernel->getContainer()->get(SystemConfiguration::class);
         $this->assertEquals('selectpicker', $configService->find('theme.select_type'));
         $this->assertEquals(true, $configService->find('timesheet.markdown_content'));
     }
@@ -261,7 +261,7 @@ class SystemConfigurationControllerTest extends ControllerBaseTest
         $client = $this->getClientForAuthenticatedUser(User::ROLE_SUPER_ADMIN);
         $this->assertAccessIsGranted($client, '/admin/system-config/');
 
-        $configService = $client->getContainer()->get(SystemConfiguration::class);
+        $configService = static::$kernel->getContainer()->get(SystemConfiguration::class);
         $this->assertTrue($configService->find('calendar.week_numbers'));
         $this->assertTrue($configService->find('calendar.weekends'));
         $this->assertEquals('08:00', $configService->find('calendar.businessHours.begin'));
@@ -288,7 +288,7 @@ class SystemConfigurationControllerTest extends ControllerBaseTest
         $this->assertTrue($client->getResponse()->isSuccessful());
         $this->assertHasFlashSaveSuccess($client);
 
-        $configService = $client->getContainer()->get(SystemConfiguration::class);
+        $configService = static::$kernel->getContainer()->get(SystemConfiguration::class);
         $this->assertFalse($configService->find('calendar.week_numbers'));
         $this->assertFalse($configService->find('calendar.weekends'));
         $this->assertEquals('10:00', $configService->find('calendar.businessHours.begin'));

--- a/tests/Controller/TagControllerTest.php
+++ b/tests/Controller/TagControllerTest.php
@@ -12,14 +12,14 @@ namespace App\Tests\Controller;
 use App\Entity\Tag;
 use App\Entity\User;
 use App\Tests\DataFixtures\TagFixtures;
-use Symfony\Bundle\FrameworkBundle\Client;
+use Symfony\Component\HttpKernel\HttpKernelBrowser;
 
 /**
  * @group integration
  */
 class TagControllerTest extends ControllerBaseTest
 {
-    protected function importTags(Client $client): void
+    protected function importTags(HttpKernelBrowser $client): void
     {
         $tagList = ['Test', 'Administration', 'Support', '#2018-001', '#2018-002', '#2018-003', 'Development',
             'Marketing', 'First Level Support', 'Bug Fixing'];
@@ -110,7 +110,7 @@ class TagControllerTest extends ControllerBaseTest
         $node = $form->getFormNode();
         $node->setAttribute('action', $this->createUrl('/admin/tags/multi-delete'));
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         /** @var Tag[] $tags */
         $tags = $em->getRepository(Tag::class)->findAll();
         self::assertCount(10, $tags);

--- a/tests/Controller/TeamControllerTest.php
+++ b/tests/Controller/TeamControllerTest.php
@@ -13,8 +13,8 @@ use App\Entity\Team;
 use App\Entity\User;
 use App\Tests\DataFixtures\TeamFixtures;
 use Doctrine\ORM\EntityManager;
-use Symfony\Bundle\FrameworkBundle\Client;
 use Symfony\Component\DomCrawler\Field\ChoiceFormField;
+use Symfony\Component\HttpKernel\HttpKernelBrowser;
 
 /**
  * @group integration
@@ -30,7 +30,7 @@ class TeamControllerTest extends ControllerBaseTest
     public function testIndexAction()
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_ADMIN);
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         $fixture = new TeamFixtures();
         $fixture->setAmount(5);
         $this->importFixture($em, $fixture);
@@ -49,7 +49,7 @@ class TeamControllerTest extends ControllerBaseTest
     public function testIndexActionWithSearchTermQuery()
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_ADMIN);
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         $fixture = new TeamFixtures();
         $fixture->setAmount(5);
         $fixture->setCallback(function (Team $team) {
@@ -91,7 +91,7 @@ class TeamControllerTest extends ControllerBaseTest
         $this->assertHasCustomerAndProjectPermissionBoxes($client);
     }
 
-    protected function assertHasCustomerAndProjectPermissionBoxes(Client $client)
+    protected function assertHasCustomerAndProjectPermissionBoxes(HttpKernelBrowser $client)
     {
         $content = $client->getResponse()->getContent();
         $this->assertStringContainsString('Grant access to customers', $content);
@@ -104,7 +104,7 @@ class TeamControllerTest extends ControllerBaseTest
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_ADMIN);
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         $fixture = new TeamFixtures();
         $fixture->setAmount(2);
         $this->importFixture($em, $fixture);
@@ -127,7 +127,7 @@ class TeamControllerTest extends ControllerBaseTest
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_ADMIN);
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         $fixture = new TeamFixtures();
         $fixture->setAmount(2);
         $this->importFixture($em, $fixture);
@@ -151,7 +151,7 @@ class TeamControllerTest extends ControllerBaseTest
         $client = $this->getClientForAuthenticatedUser(User::ROLE_ADMIN);
 
         /** @var EntityManager $em */
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
 
         $fixture = new TeamFixtures();
         $fixture->setAmount(2);
@@ -180,7 +180,7 @@ class TeamControllerTest extends ControllerBaseTest
         $client = $this->getClientForAuthenticatedUser(User::ROLE_ADMIN);
 
         /** @var EntityManager $em */
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
 
         $fixture = new TeamFixtures();
         $fixture->setAmount(2);

--- a/tests/Controller/TimesheetControllerTest.php
+++ b/tests/Controller/TimesheetControllerTest.php
@@ -51,7 +51,7 @@ class TimesheetControllerTest extends ControllerBaseTest
         $client = $this->getClientForAuthenticatedUser(User::ROLE_USER);
         $start = new \DateTime('first day of this month');
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         $fixture = new TimesheetFixtures();
         $fixture->setAmount(5);
         $fixture->setAmountRunning(2);
@@ -86,7 +86,7 @@ class TimesheetControllerTest extends ControllerBaseTest
         $client = $this->getClientForAuthenticatedUser(User::ROLE_USER);
         $start = new \DateTime('first day of this month');
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         $fixture = new TimesheetFixtures();
         $fixture->setAmount(5);
         $fixture->setUser($this->getUserByRole($em, User::ROLE_USER));
@@ -123,7 +123,7 @@ class TimesheetControllerTest extends ControllerBaseTest
     {
         $client = $this->getClientForAuthenticatedUser();
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         $fixture = new TimesheetFixtures();
         $fixture->setAmount(5);
         $fixture->setUser($this->getUserByRole($em, User::ROLE_USER));
@@ -180,7 +180,7 @@ class TimesheetControllerTest extends ControllerBaseTest
         $this->assertTrue($client->getResponse()->isSuccessful());
         $this->assertHasFlashSuccess($client);
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         /** @var Timesheet $timesheet */
         $timesheet = $em->getRepository(Timesheet::class)->find(1);
         $this->assertInstanceOf(\DateTime::class, $timesheet->getBegin());
@@ -194,7 +194,7 @@ class TimesheetControllerTest extends ControllerBaseTest
     public function testCreateActionShowsMetaFields()
     {
         $client = $this->getClientForAuthenticatedUser();
-        $client->getContainer()->get('event_dispatcher')->addSubscriber(new TimesheetTestMetaFieldSubscriberMock());
+        static::$kernel->getContainer()->get('event_dispatcher')->addSubscriber(new TimesheetTestMetaFieldSubscriberMock());
         $this->request($client, '/timesheet/create');
         $this->assertTrue($client->getResponse()->isSuccessful());
 
@@ -234,7 +234,7 @@ class TimesheetControllerTest extends ControllerBaseTest
         $this->assertTrue($client->getResponse()->isSuccessful());
         $this->assertHasFlashSuccess($client);
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         /** @var Timesheet $timesheet */
         $timesheet = $em->getRepository(Timesheet::class)->find(1);
         $this->assertInstanceOf(\DateTime::class, $timesheet->getBegin());
@@ -268,7 +268,7 @@ class TimesheetControllerTest extends ControllerBaseTest
         $this->assertTrue($client->getResponse()->isSuccessful());
         $this->assertHasFlashSuccess($client);
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         /** @var Timesheet $timesheet */
         $timesheet = $em->getRepository(Timesheet::class)->find(1);
         $this->assertInstanceOf(\DateTime::class, $timesheet->getBegin());
@@ -288,7 +288,7 @@ class TimesheetControllerTest extends ControllerBaseTest
     {
         $client = $this->getClientForAuthenticatedUser();
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         $fixture = new TimesheetFixtures();
         $fixture->setAmount(10);
         $fixture->setUser($this->getUserByRole($em, User::ROLE_USER));
@@ -319,7 +319,7 @@ class TimesheetControllerTest extends ControllerBaseTest
         $this->assertTrue($client->getResponse()->isSuccessful());
         $this->assertHasFlashSaveSuccess($client);
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         /** @var Timesheet $timesheet */
         $timesheet = $em->getRepository(Timesheet::class)->find(1);
         $this->assertEquals('foo-bar', $timesheet->getDescription());
@@ -329,7 +329,7 @@ class TimesheetControllerTest extends ControllerBaseTest
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_USER);
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         $user = $this->getUserByRole($em, User::ROLE_USER);
         $fixture = new TimesheetFixtures();
         $fixture->setAmount(10);
@@ -342,7 +342,7 @@ class TimesheetControllerTest extends ControllerBaseTest
         $node = $form->getFormNode();
         $node->setAttribute('action', $this->createUrl('/timesheet/multi-delete'));
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         /** @var Timesheet[] $timesheets */
         $timesheets = $em->getRepository(Timesheet::class)->findAll();
         self::assertCount(10, $timesheets);
@@ -368,7 +368,7 @@ class TimesheetControllerTest extends ControllerBaseTest
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_SUPER_ADMIN);
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         $user = $this->getUserByRole($em, User::ROLE_SUPER_ADMIN);
         $fixture = new TimesheetFixtures();
         $fixture->setAmount(10);
@@ -381,7 +381,7 @@ class TimesheetControllerTest extends ControllerBaseTest
         $node = $form->getFormNode();
         $node->setAttribute('action', $this->createUrl('/timesheet/multi-update'));
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         /** @var Timesheet[] $timesheets */
         $timesheets = $em->getRepository(Timesheet::class)->findAll();
         self::assertCount(10, $timesheets);

--- a/tests/Controller/TimesheetTeamControllerTest.php
+++ b/tests/Controller/TimesheetTeamControllerTest.php
@@ -54,7 +54,7 @@ class TimesheetTeamControllerTest extends ControllerBaseTest
         $client = $this->getClientForAuthenticatedUser(User::ROLE_ADMIN);
         $start = new \DateTime('first day of this month');
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         $user = $this->getUserByRole($em, User::ROLE_USER);
         $fixture = new TimesheetFixtures();
         $fixture->setAmount(10);
@@ -91,7 +91,7 @@ class TimesheetTeamControllerTest extends ControllerBaseTest
         $client = $this->getClientForAuthenticatedUser(User::ROLE_ADMIN);
         $start = new \DateTime('first day of this month');
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         $fixture = new TimesheetFixtures();
         $fixture->setAmount(5);
         $fixture->setUser($this->getUserByRole($em, User::ROLE_USER));
@@ -128,7 +128,7 @@ class TimesheetTeamControllerTest extends ControllerBaseTest
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_ADMIN);
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         $fixture = new TimesheetFixtures();
         $fixture->setAmount(7);
         $fixture->setUser($this->getUserByRole($em, User::ROLE_USER));
@@ -185,7 +185,7 @@ class TimesheetTeamControllerTest extends ControllerBaseTest
         $this->assertTrue($client->getResponse()->isSuccessful());
         $this->assertHasFlashSuccess($client);
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         /** @var Timesheet $timesheet */
         $timesheet = $em->getRepository(Timesheet::class)->find(1);
         $this->assertInstanceOf(\DateTime::class, $timesheet->getBegin());
@@ -200,7 +200,7 @@ class TimesheetTeamControllerTest extends ControllerBaseTest
     {
         $client = $this->getClientForAuthenticatedUser();
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         $user = $this->getUserByRole($em, User::ROLE_USER);
         $teamlead = $this->getUserByRole($em, User::ROLE_TEAMLEAD);
         $fixture = new TimesheetFixtures();
@@ -235,7 +235,7 @@ class TimesheetTeamControllerTest extends ControllerBaseTest
         $this->assertTrue($client->getResponse()->isSuccessful());
         $this->assertHasFlashSaveSuccess($client);
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         /** @var Timesheet $timesheet */
         $timesheet = $em->getRepository(Timesheet::class)->find(1);
         $this->assertEquals('foo-bar', $timesheet->getDescription());
@@ -246,7 +246,7 @@ class TimesheetTeamControllerTest extends ControllerBaseTest
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_TEAMLEAD);
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         $user = $this->getUserByRole($em, User::ROLE_TEAMLEAD);
         $fixture = new TimesheetFixtures();
         $fixture->setAmount(10);
@@ -259,7 +259,7 @@ class TimesheetTeamControllerTest extends ControllerBaseTest
         $node = $form->getFormNode();
         $node->setAttribute('action', $this->createUrl('/team/timesheet/multi-delete'));
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         /** @var Timesheet[] $timesheets */
         $timesheets = $em->getRepository(Timesheet::class)->findAll();
         self::assertCount(10, $timesheets);
@@ -285,7 +285,7 @@ class TimesheetTeamControllerTest extends ControllerBaseTest
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_SUPER_ADMIN);
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         $user = $this->getUserByRole($em, User::ROLE_TEAMLEAD);
         $fixture = new TimesheetFixtures();
         $fixture->setAmount(10);
@@ -298,7 +298,7 @@ class TimesheetTeamControllerTest extends ControllerBaseTest
         $node = $form->getFormNode();
         $node->setAttribute('action', $this->createUrl('/team/timesheet/multi-update'));
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         /** @var Timesheet[] $timesheets */
         $timesheets = $em->getRepository(Timesheet::class)->findAll();
         self::assertCount(10, $timesheets);

--- a/tests/Controller/UserControllerTest.php
+++ b/tests/Controller/UserControllerTest.php
@@ -141,7 +141,7 @@ class UserControllerTest extends ControllerBaseTest
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_SUPER_ADMIN);
 
-        $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         $user = $this->getUserByRole($em, User::ROLE_USER);
 
         $fixture = new TimesheetFixtures();

--- a/tests/KernelTestTrait.php
+++ b/tests/KernelTestTrait.php
@@ -15,7 +15,7 @@ use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\Executor\ORMExecutor;
 use Doctrine\Common\DataFixtures\Loader;
 use Doctrine\ORM\EntityManager;
-use Symfony\Bundle\FrameworkBundle\Client;
+use Symfony\Component\HttpKernel\HttpKernelBrowser;
 
 /**
  * A trait to be used in all tests that extend the KernelTestCase.
@@ -24,8 +24,8 @@ trait KernelTestTrait
 {
     protected function importFixture($client, Fixture $fixture)
     {
-        if ($client instanceof Client) {
-            $em = $client->getContainer()->get('doctrine.orm.entity_manager');
+        if ($client instanceof HttpKernelBrowser) {
+            $em = static::$kernel->getContainer()->get('doctrine.orm.entity_manager');
         } elseif ($client instanceof EntityManager) {
             $em = $client;
         } else {


### PR DESCRIPTION
## Description

Can be tested at https://demo-branch.kimai.org ping @wdenx @HeinzWuert

A new function in the project "action" menu allows to duplicate existing projects.

The following data will be copied:
- all project settings
  - if an end date was defined, this will become the start date of the new project
- all team permissions
- all configured rates
- all meta-field values
- all activities will be copied
  - all settings
  - all configured rates
  - all meta-field values

Fixes #1381 
Fixes #1246 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer kimai:code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
