### PR TITLE
format excel cell types in invoices

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -11,6 +11,7 @@ Perform EACH version specific task between your version and the new one, otherwi
 ## [1.8](https://github.com/kevinpapst/kimai2/releases/tag/1.8)
 
 - New mailer library: check if emails are still working (eg. by using the "password forgotten" function) or if you need to adjust your configuration, [see docs at symfony.com](https://symfony.com/doc/current/components/mailer.html#transport)
+- Support for line breaks in multiline invoice fields for spreadsheets (check your invoice templates after the update) 
 
 Permission changes:
 

--- a/src/Invoice/Renderer/AbstractSpreadsheetRenderer.php
+++ b/src/Invoice/Renderer/AbstractSpreadsheetRenderer.php
@@ -11,6 +11,8 @@ namespace App\Invoice\Renderer;
 
 use App\Entity\InvoiceDocument;
 use App\Invoice\InvoiceModel;
+use PhpOffice\PhpSpreadsheet\Cell\AdvancedValueBinder;
+use PhpOffice\PhpSpreadsheet\Cell\Cell;
 use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
@@ -58,6 +60,8 @@ abstract class AbstractSpreadsheetRenderer extends AbstractRenderer
         $worksheet->setTitle($title);
 
         $entryRow = 0;
+
+        Cell::setValueBinder(new AdvancedValueBinder());
 
         foreach ($worksheet->getRowIterator() as $row) {
             $sheetValues = false;

--- a/src/Invoice/Renderer/AbstractSpreadsheetRenderer.php
+++ b/src/Invoice/Renderer/AbstractSpreadsheetRenderer.php
@@ -11,7 +11,6 @@ namespace App\Invoice\Renderer;
 
 use App\Entity\InvoiceDocument;
 use App\Invoice\InvoiceModel;
-use PhpOffice\PhpSpreadsheet\Cell\AdvancedValueBinder;
 use PhpOffice\PhpSpreadsheet\Cell\Cell;
 use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;

--- a/src/Invoice/Renderer/AdvancedValueBinder.php
+++ b/src/Invoice/Renderer/AdvancedValueBinder.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Invoice\Renderer;
+
+use PhpOffice\PhpSpreadsheet\Cell\Cell;
+use PhpOffice\PhpSpreadsheet\Cell\DataType;
+use PhpOffice\PhpSpreadsheet\Cell\DefaultValueBinder;
+use PhpOffice\PhpSpreadsheet\Cell\IValueBinder;
+use PhpOffice\PhpSpreadsheet\RichText\RichText;
+use PhpOffice\PhpSpreadsheet\Shared\StringHelper;
+
+class AdvancedValueBinder extends DefaultValueBinder implements IValueBinder
+{
+    /**
+     * Bind value to a cell.
+     *
+     * @param Cell $cell Cell to bind value to
+     * @param mixed $value Value to bind in cell
+     *
+     * @throws \PhpOffice\PhpSpreadsheet\Exception
+     *
+     * @return bool
+     */
+    public function bindValue(Cell $cell, $value = null)
+    {
+        if (is_string($value)) {
+            $value = StringHelper::sanitizeUTF8($value);
+        }
+
+        $dataType = parent::dataTypeForValue($value);
+
+        if ($dataType === DataType::TYPE_STRING && !$value instanceof RichText) {
+            // Check for newline character "\n"
+            if (strpos($value, "\n") !== false) {
+                $cell->setValueExplicit($value, DataType::TYPE_STRING);
+                // Set style
+                $cell->getWorksheet()->getStyle($cell->getCoordinate())
+                    ->getAlignment()->setWrapText(true);
+
+                return true;
+            }
+        }
+
+        return parent::bindValue($cell, $value);
+    }
+}

--- a/src/Invoice/Renderer/AdvancedValueBinder.php
+++ b/src/Invoice/Renderer/AdvancedValueBinder.php
@@ -40,9 +40,14 @@ class AdvancedValueBinder extends DefaultValueBinder implements IValueBinder
             // Check for newline character "\n"
             if (strpos($value, "\n") !== false) {
                 $cell->setValueExplicit($value, DataType::TYPE_STRING);
-                // Set style
-                $cell->getWorksheet()->getStyle($cell->getCoordinate())
-                    ->getAlignment()->setWrapText(true);
+                $cell->getWorksheet()->getStyle($cell->getCoordinate())->getAlignment()->setWrapText(true);
+
+                $amount = substr_count($value, "\n");
+                $dimension = $cell->getWorksheet()->getRowDimension($cell->getRow());
+                if ($dimension->getRowHeight() !== -1) {
+                    $defaultHeight = $cell->getWorksheet()->getDefaultRowDimension()->getRowHeight();
+                    $dimension->setRowHeight($defaultHeight * ($amount + 1));
+                }
 
                 return true;
             }

--- a/tests/Invoice/Renderer/CsvRendererTest.php
+++ b/tests/Invoice/Renderer/CsvRendererTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\HttpFoundation\BinaryFileResponse;
  * @covers \App\Invoice\Renderer\CsvRenderer
  * @covers \App\Invoice\Renderer\AbstractRenderer
  * @covers \App\Invoice\Renderer\AbstractSpreadsheetRenderer
+ * @covers \App\Invoice\Renderer\AdvancedValueBinder
  * @group integration
  */
 class CsvRendererTest extends TestCase
@@ -64,7 +65,7 @@ class CsvRendererTest extends TestCase
         $content = file_get_contents($file->getRealPath());
 
         $this->assertStringNotContainsString('${', $content);
-        $this->assertStringContainsString(',"' . $expectedRate, $content);
+        $this->assertStringContainsString(',"' . $expectedRate . '"', $content);
         $this->assertEquals($expectedRows, substr_count($content, PHP_EOL));
         $this->assertEquals($expectedDescriptions, substr_count($content, 'activity description'));
         $this->assertEquals($expectedUser1, substr_count($content, ',"kevin",'));

--- a/tests/Invoice/Renderer/CsvRendererTest.php
+++ b/tests/Invoice/Renderer/CsvRendererTest.php
@@ -64,7 +64,7 @@ class CsvRendererTest extends TestCase
         $content = file_get_contents($file->getRealPath());
 
         $this->assertStringNotContainsString('${', $content);
-        $this->assertStringContainsString(',"' . $expectedRate . '"', $content);
+        $this->assertStringContainsString(',"' . $expectedRate, $content);
         $this->assertEquals($expectedRows, substr_count($content, PHP_EOL));
         $this->assertEquals($expectedDescriptions, substr_count($content, 'activity description'));
         $this->assertEquals($expectedUser1, substr_count($content, ',"kevin",'));

--- a/tests/Invoice/Renderer/RendererTestTrait.php
+++ b/tests/Invoice/Renderer/RendererTestTrait.php
@@ -108,6 +108,7 @@ trait RendererTestTrait
 
         $customer = new Customer();
         $customer->setName('customer,with/special#name');
+        $customer->setAddress('Foo' . PHP_EOL . 'Street' . PHP_EOL . '1111 City');
         $customer->setCurrency('EUR');
         $customer->setMetaField((new CustomerMeta())->setName('foo-customer')->setValue('bar-customer')->setIsVisible(true));
 

--- a/tests/Invoice/Renderer/XlsxRendererTest.php
+++ b/tests/Invoice/Renderer/XlsxRendererTest.php
@@ -18,6 +18,7 @@ use Symfony\Component\HttpFoundation\BinaryFileResponse;
  * @covers \App\Invoice\Renderer\XlsxRenderer
  * @covers \App\Invoice\Renderer\AbstractRenderer
  * @covers \App\Invoice\Renderer\AbstractSpreadsheetRenderer
+ * @covers \App\Invoice\Renderer\AdvancedValueBinder
  * @group integration
  */
 class XlsxRendererTest extends TestCase


### PR DESCRIPTION
## Description

Set the row height to the amount of lines. 
This will likely "break" existing templates, at least they will look strange after the update.

If a field like `${customer.address}` has 3 line breaks, the height of the row where this field is used, will be set to  **4 x height**

Fixes #1373 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer kimai:code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
