### PR TITLE
fixed sweet alerts blocking major ui elements

### DIFF
--- a/assets/js/plugins/KimaiAlert.js
+++ b/assets/js/plugins/KimaiAlert.js
@@ -43,7 +43,7 @@ export default class KimaiAlert extends KimaiPlugin {
         Swal.fire({
             timer: 2000,
             toast: true,
-            position: 'top-end',
+            position: 'top',
             showConfirmButton: false,
             type: 'success',
             title: message,

--- a/assets/sass/sweetalert.scss
+++ b/assets/sass/sweetalert.scss
@@ -1,3 +1,15 @@
 .swal2-popup {
     font-size: unset;
 }
+
+.swal2-container {
+    // never block the top two bars double-bars display (smaller displays)
+    @media only screen and (max-width: 768px) {
+        top: 110px !important;
+    }
+
+    // never block the top bar on single-bar display (larger devices)
+    @media only screen and (min-width: 768px) {
+        top: 60px !important;
+    }
+}


### PR DESCRIPTION
## Description

The current SweetAlert setup did block major UI elements for an "annoyingly" long period. The upper right part became un-usable for every notification you trigger, like starting time and wanting to stop immediately.

## Types of changes
- [ ] Moved the alert two and a half element down on mobile devices.
- [ ] Moved the alert one and a half element down on desktop devices.

## Checklist

- [ ] I verified that my code applies to the guidelines (`composer kimai:code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)

## Remarks

Did not run `composer kimai:code-check` as this is a scss change only.

## Screenshots

![medium-to-large](https://user-images.githubusercontent.com/681514/75823657-70fdfc80-5da2-11ea-8678-ab38b37adbe6.png)
![small-1](https://user-images.githubusercontent.com/681514/75823659-71969300-5da2-11ea-93b6-0d7bc931b73c.png)
![small-2](https://user-images.githubusercontent.com/681514/75823660-722f2980-5da2-11ea-85f2-574dc969a891.png)

