### PR TITLE
xlsx improvements (#1512)

### DIFF
--- a/src/DataFixtures/TimesheetFixtures.php
+++ b/src/DataFixtures/TimesheetFixtures.php
@@ -41,7 +41,7 @@ class TimesheetFixtures extends Fixture implements DependentFixtureInterface
     public const MIN_MINUTES_PER_ENTRY = 15;
     public const MAX_MINUTES_PER_ENTRY = 840; // 14h
     public const MAX_TAG_PER_ENTRY = 3;
-    public const MAX_DESCRIPTION_LENGTH = 50;
+    public const MAX_DESCRIPTION_LENGTH = 500;
 
     public const BATCH_SIZE = 100;
 

--- a/src/Export/Base/AbstractSpreadsheetRenderer.php
+++ b/src/Export/Base/AbstractSpreadsheetRenderer.php
@@ -464,6 +464,12 @@ abstract class AbstractSpreadsheetRenderer
         $spreadsheet = new Spreadsheet();
         $sheet = $spreadsheet->getActiveSheet();
 
+        // Set default row height to automatic, so we can specify wrap text columns later on
+        // without bloating the output file as we would need to store stylesheet info for every cell.
+        // LibreOffice is still not considering this flag, @see https://github.com/PHPOffice/PHPExcel/issues/588
+        // with no solution implemented so nothing we can do about it there.
+        $sheet->getDefaultRowDimension()->setRowHeight(-1);
+
         $recordsHeaderColumn = 1;
         $recordsHeaderRow = 1;
 

--- a/src/Export/Base/AbstractSpreadsheetRenderer.php
+++ b/src/Export/Base/AbstractSpreadsheetRenderer.php
@@ -288,7 +288,7 @@ abstract class AbstractSpreadsheetRenderer
                 if (!$isColumnFormatted) {
                     if (null !== $maxWidth) {
                         $sheet->getColumnDimensionByColumn($column)
-                            ->setWidth(40);
+                            ->setWidth($maxWidth);
                     }
                     $isColumnFormatted = true;
                 }

--- a/src/Export/Base/XlsxRenderer.php
+++ b/src/Export/Base/XlsxRenderer.php
@@ -39,6 +39,18 @@ class XlsxRenderer extends AbstractSpreadsheetRenderer
             throw new \Exception('Could not open temporary file');
         }
 
+        // Enable auto filter
+        $sheet = $spreadsheet->getActiveSheet();
+        $sheet->setAutoFilter('A1:' . $sheet->getHighestColumn() . '1');
+
+        // Freeze first row
+        $sheet->freezePane('B2');
+
+        // Auto size columns to fit at least the headers
+        foreach (range('A', $sheet->getHighestColumn()) as $column) {
+            $sheet->getColumnDimension($column)->setAutoSize(true);
+        }
+
         $writer = IOFactory::createWriter($spreadsheet, 'Xlsx');
         $writer->save($filename);
 


### PR DESCRIPTION
## Description

Small improvements for the xlsx export as in part requested in #1512. Changes should be fitting to every export that contains a single header row.

## Types of changes

- [ ] Feature: Activated "Auto Filter" feature (as #1512 misnamed it as "table format")
- [ ] Feature: Freeze first row and column for scrolling through larger reports.
- [ ] Feature: Auto size the columns so content fits on screen.

## Checklist

- [x] I verified that my code applies to the guidelines (`composer kimai:code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)

## Remarks

The `composer kimai:code-check` command did not complete successful:

- `phpstan` did reach the memory limit during execution and had to be run with parameter `--memory-limit=512M`. Error message was `PHPStan crashed in the previous run probably because of excessive memory consumption. It consumed around 110 MB of memory.`
- `phpunit` did fail due to `Remaining self deprecation notices (35)` and `Remaining direct deprecation notices (9)`.

after that point I skipped running the code-check.