### PR TITLE
[BUGFIX] Escape distinguished name in ldap search

### DIFF
--- a/src/Ldap/LdapManager.php
+++ b/src/Ldap/LdapManager.php
@@ -157,7 +157,7 @@ class LdapManager
 
         return $this->driver->search(
             $roleParameter['baseDn'],
-            sprintf('(&%s(%s=%s))', $filter, $roleParameter['userDnAttribute'], $dn),
+            sprintf('(&%s(%s=%s))', $filter, $roleParameter['userDnAttribute'], ldap_escape($dn, null, LDAP_ESCAPE_FILTER)),
             [$roleParameter['nameAttribute']]
         );
     }

--- a/tests/Ldap/LdapManagerTest.php
+++ b/tests/Ldap/LdapManagerTest.php
@@ -356,11 +356,11 @@ class LdapManagerTest extends TestCase
                         'dn' => 'blub',
                         'uid' => ['Karl-Heinz'],
                         // just some rubbish data
-                        'blub' => ['dfsdfsdf'],
+                        'blub' => ['foo'],
                         'foo' => ['count' => 1, 'bar'],
                         'bar' => ['count' => 1, 'foo', 'xxx'],
                         'xxxxxxxx' => ['https://www.example.com'],
-                        'blub1' => ['dfsdfsdf'],
+                        'blub1' => ['foo(bar)'],
                     ],
                     'count' => 1,
                 ],
@@ -376,7 +376,7 @@ class LdapManagerTest extends TestCase
                         ['ldap_value' => 'group4', 'role' => 'ROLE_SUPER_ADMIN'],
                     ],
                 ],
-                '(&(memberuid=dfsdfsdf))'
+                '(&(memberuid=foo\28bar\29))'
             ],
         ];
     }


### PR DESCRIPTION
## Description
If you use special characters in the ldap "Distinguished Name" the search with a filter will break. 
We need to escape this before.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I verified that my code applies to the guidelines (`composer kimai:code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
