### PR TITLE
allow html and pdf export customization with twig templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ templates/invoice/renderer/.~lock*
 !var/cache/.gitkeep
 
 /var/invoices/*
+/var/export/*
 
 /var/packages/*
 !var/packages/.gitkeep

--- a/src/DependencyInjection/AppExtension.php
+++ b/src/DependencyInjection/AppExtension.php
@@ -49,6 +49,9 @@ class AppExtension extends Extension
         $config['invoice']['documents'] = array_merge($config['invoice']['documents'], $config['invoice']['defaults']);
         unset($config['invoice']['defaults']);
 
+        $config['export']['documents'] = array_merge($config['export']['documents'], $config['export']['defaults']);
+        unset($config['export']['defaults']);
+
         // safe alternatives to %kernel.project_dir%
         $container->setParameter('kimai.data_dir', $config['data_dir']);
         $container->setParameter('kimai.plugin_dir', $config['plugin_dir']);
@@ -60,6 +63,7 @@ class AppExtension extends Extension
         $container->setParameter('kimai.dashboard', $config['dashboard']);
         $container->setParameter('kimai.widgets', $config['widgets']);
         $container->setParameter('kimai.invoice.documents', $config['invoice']['documents']);
+        $container->setParameter('kimai.export.documents', $config['export']['documents']);
         $container->setParameter('kimai.defaults', $config['defaults']);
 
         $this->createPermissionParameter($config['permissions'], $container);

--- a/src/DependencyInjection/Compiler/ExportServiceCompilerPass.php
+++ b/src/DependencyInjection/Compiler/ExportServiceCompilerPass.php
@@ -9,10 +9,14 @@
 
 namespace App\DependencyInjection\Compiler;
 
+use App\Export\Renderer\HtmlRenderer;
+use App\Export\Renderer\HtmlRendererFactory;
+use App\Export\Renderer\PdfRendererFactory;
 use App\Export\ServiceExport;
 use App\Kernel;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
 
 /**
@@ -36,6 +40,41 @@ class ExportServiceCompilerPass implements CompilerPassInterface
         $taggedExporter = $container->findTaggedServiceIds(Kernel::TAG_TIMESHEET_EXPORTER);
         foreach ($taggedExporter as $id => $tags) {
             $definition->addMethodCall('addTimesheetExporter', [new Reference($id)]);
+        }
+
+        $path = dirname(dirname(dirname(__DIR__))) . DIRECTORY_SEPARATOR;
+        foreach ($container->getParameter('kimai.export.documents') as $exportPath) {
+            if (!is_dir($path . $exportPath)) {
+                continue;
+            }
+
+            foreach (glob($path . $exportPath . '/*.html.twig') as $htmlTpl) {
+                $tplName = basename($htmlTpl);
+
+                $serviceId = 'exporter_renderer.' . str_replace('.', '_', $tplName);
+
+                $factoryDefinition = new Definition(HtmlRenderer::class);
+                $factoryDefinition->addArgument($tplName);
+                $factoryDefinition->addArgument($tplName);
+                $factoryDefinition->setFactory([new Reference(HtmlRendererFactory::class), 'create']);
+
+                $container->setDefinition($serviceId, $factoryDefinition);
+                $definition->addMethodCall('addRenderer', [new Reference($serviceId)]);
+            }
+
+            foreach (glob($path . $exportPath . '/*.pdf.twig') as $htmlTpl) {
+                $tplName = basename($htmlTpl);
+
+                $serviceId = 'exporter_renderer.' . str_replace('.', '_', $tplName);
+
+                $factoryDefinition = new Definition(HtmlRenderer::class);
+                $factoryDefinition->addArgument($tplName);
+                $factoryDefinition->addArgument($tplName);
+                $factoryDefinition->setFactory([new Reference(PdfRendererFactory::class), 'create']);
+
+                $container->setDefinition($serviceId, $factoryDefinition);
+                $definition->addMethodCall('addRenderer', [new Reference($serviceId)]);
+            }
         }
     }
 }

--- a/src/DependencyInjection/Compiler/ExportServiceCompilerPass.php
+++ b/src/DependencyInjection/Compiler/ExportServiceCompilerPass.php
@@ -62,8 +62,8 @@ class ExportServiceCompilerPass implements CompilerPassInterface
                 $definition->addMethodCall('addRenderer', [new Reference($serviceId)]);
             }
 
-            foreach (glob($path . $exportPath . '/*.pdf.twig') as $htmlTpl) {
-                $tplName = basename($htmlTpl);
+            foreach (glob($path . $exportPath . '/*.pdf.twig') as $pdfHtml) {
+                $tplName = basename($pdfHtml);
 
                 $serviceId = 'exporter_renderer.' . str_replace('.', '_', $tplName);
 

--- a/src/DependencyInjection/Compiler/TwigContextCompilerPass.php
+++ b/src/DependencyInjection/Compiler/TwigContextCompilerPass.php
@@ -32,16 +32,21 @@ class TwigContextCompilerPass implements CompilerPassInterface
         $saml = $container->getParameter('kimai.saml');
         $twig->addMethodCall('addGlobal', ['saml', $saml]);
 
-        if ($container->hasDefinition('twig.loader.native_filesystem')) {
-            $definition = $container->getDefinition('twig.loader.native_filesystem');
+        $definition = $container->getDefinition('twig.loader.native_filesystem');
 
-            $path = dirname(dirname(dirname(__DIR__))) . DIRECTORY_SEPARATOR;
-            foreach ($container->getParameter('kimai.invoice.documents') as $invoicePath) {
-                if (!is_dir($path . $invoicePath)) {
-                    continue;
-                }
-                $definition->addMethodCall('addPath', [$path . $invoicePath, 'invoice']);
+        $path = dirname(dirname(dirname(__DIR__))) . DIRECTORY_SEPARATOR;
+        foreach ($container->getParameter('kimai.invoice.documents') as $invoicePath) {
+            if (!is_dir($path . $invoicePath)) {
+                continue;
             }
+            $definition->addMethodCall('addPath', [$path . $invoicePath, 'invoice']);
+        }
+
+        foreach ($container->getParameter('kimai.export.documents') as $exportPath) {
+            if (!is_dir($path . $exportPath)) {
+                continue;
+            }
+            $definition->addMethodCall('addPath', [$path . $exportPath, 'export']);
         }
     }
 }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -57,6 +57,7 @@ class Configuration implements ConfigurationInterface
                 ->append($this->getUserNode())
                 ->append($this->getTimesheetNode())
                 ->append($this->getInvoiceNode())
+                ->append($this->getExportNode())
                 ->append($this->getLanguagesNode())
                 ->append($this->getCalendarNode())
                 ->append($this->getThemeNode())
@@ -229,6 +230,33 @@ class Configuration implements ConfigurationInterface
                 ->end()
                 ->scalarNode('number_format')
                     ->defaultValue('{Y}/{cy,3}')
+                ->end()
+            ->end()
+        ;
+
+        return $node;
+    }
+
+    protected function getExportNode()
+    {
+        $builder = new TreeBuilder('export');
+        /** @var ArrayNodeDefinition $node */
+        $node = $builder->getRootNode();
+
+        $node
+            ->addDefaultsIfNotSet()
+            ->children()
+                ->arrayNode('defaults')
+                    ->scalarPrototype()->end()
+                    ->defaultValue([
+                        'var/export/',
+                        'templates/export/renderer/'
+                    ])
+                ->end()
+                ->arrayNode('documents')
+                    ->requiresAtLeastOneElement()
+                    ->scalarPrototype()->end()
+                    ->defaultValue([])
                 ->end()
             ->end()
         ;

--- a/src/Export/Base/HtmlRenderer.php
+++ b/src/Export/Base/HtmlRenderer.php
@@ -40,6 +40,14 @@ class HtmlRenderer
      * @var ProjectRepository
      */
     private $projectRepository;
+    /**
+     * @var string
+     */
+    private $id = 'html';
+    /**
+     * @var string
+     */
+    private $template = 'default.html.twig';
 
     public function __construct(Environment $twig, EventDispatcherInterface $dispatcher, ProjectRepository $projectRepository)
     {
@@ -95,7 +103,7 @@ class HtmlRenderer
 
         $summary = $this->calculateSummary($timesheets);
 
-        $content = $this->twig->render('export/renderer/default.html.twig', array_merge([
+        $content = $this->twig->render($this->getTemplate(), array_merge([
             'entries' => $timesheets,
             'query' => $query,
             'summaries' => $summary,
@@ -113,8 +121,27 @@ class HtmlRenderer
         return $response;
     }
 
+    protected function getTemplate(): string
+    {
+        return '@export/' . $this->template;
+    }
+
+    public function setTemplate(string $filename): HtmlRenderer
+    {
+        $this->template = $filename;
+
+        return $this;
+    }
+
+    public function setId(string $id): HtmlRenderer
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
     public function getId(): string
     {
-        return 'html';
+        return $this->id;
     }
 }

--- a/src/Export/Base/HtmlRenderer.php
+++ b/src/Export/Base/HtmlRenderer.php
@@ -17,6 +17,7 @@ use App\Event\ProjectMetaDisplayEvent;
 use App\Event\TimesheetMetaDisplayEvent;
 use App\Event\UserPreferenceDisplayEvent;
 use App\Export\ExportItemInterface;
+use App\Repository\ProjectRepository;
 use App\Repository\Query\CustomerQuery;
 use App\Repository\Query\TimesheetQuery;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -35,11 +36,16 @@ class HtmlRenderer
      * @var EventDispatcherInterface
      */
     protected $dispatcher;
+    /**
+     * @var ProjectRepository
+     */
+    private $projectRepository;
 
-    public function __construct(Environment $twig, EventDispatcherInterface $dispatcher)
+    public function __construct(Environment $twig, EventDispatcherInterface $dispatcher, ProjectRepository $projectRepository)
     {
         $this->twig = $twig;
         $this->dispatcher = $dispatcher;
+        $this->projectRepository = $projectRepository;
     }
 
     /**
@@ -87,10 +93,13 @@ class HtmlRenderer
         $this->dispatcher->dispatch($event);
         $userPreferences = $event->getPreferences();
 
+        $summary = $this->calculateSummary($timesheets);
+
         $content = $this->twig->render('export/renderer/default.html.twig', array_merge([
             'entries' => $timesheets,
             'query' => $query,
-            'summaries' => $this->calculateSummary($timesheets),
+            'summaries' => $summary,
+            'budgets' => $this->calculateProjectBudget($timesheets, $query, $this->projectRepository),
             'timesheetMetaFields' => $timesheetMetaFields,
             'customerMetaFields' => $customerMetaFields,
             'projectMetaFields' => $projectMetaFields,

--- a/src/Export/Base/PDFRenderer.php
+++ b/src/Export/Base/PDFRenderer.php
@@ -38,6 +38,14 @@ class PDFRenderer
      * @var ProjectRepository
      */
     private $projectRepository;
+    /**
+     * @var string
+     */
+    private $id = 'pdf';
+    /**
+     * @var string
+     */
+    private $template = 'default.pdf.twig';
 
     public function __construct(Environment $twig, UserDateTimeFactory $dateTime, HtmlToPdfConverter $converter, ProjectRepository $projectRepository)
     {
@@ -49,7 +57,7 @@ class PDFRenderer
 
     protected function getTemplate(): string
     {
-        return 'export/renderer/pdf.html.twig';
+        return '@export/' . $this->template;
     }
 
     protected function getOptions(TimesheetQuery $query): array
@@ -96,8 +104,22 @@ class PDFRenderer
         return $response;
     }
 
+    public function setTemplate(string $filename): PDFRenderer
+    {
+        $this->template = $filename;
+
+        return $this;
+    }
+
+    public function setId(string $id): PDFRenderer
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
     public function getId(): string
     {
-        return 'pdf';
+        return $this->id;
     }
 }

--- a/src/Export/ExportRendererInterface.php
+++ b/src/Export/ExportRendererInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Export;
+
+use App\Repository\Query\TimesheetQuery;
+use Symfony\Component\HttpFoundation\Response;
+
+interface ExportRendererInterface
+{
+    /**
+     * @param ExportItemInterface[] $exportItems
+     * @param TimesheetQuery $query
+     * @return Response
+     */
+    public function render(array $exportItems, TimesheetQuery $query): Response;
+
+    /**
+     * @return string
+     */
+    public function getId(): string;
+
+    /**
+     * @return string
+     */
+    public function getIcon(): string;
+
+    /**
+     * @return string
+     */
+    public function getTitle(): string;
+}

--- a/src/Export/Renderer/HtmlRenderer.php
+++ b/src/Export/Renderer/HtmlRenderer.php
@@ -10,9 +10,9 @@
 namespace App\Export\Renderer;
 
 use App\Export\Base\HtmlRenderer as BaseHtmlRenderer;
-use App\Export\RendererInterface;
+use App\Export\ExportRendererInterface;
 
-final class HtmlRenderer extends BaseHtmlRenderer implements RendererInterface
+final class HtmlRenderer extends BaseHtmlRenderer implements ExportRendererInterface
 {
     public function getIcon(): string
     {

--- a/src/Export/Renderer/HtmlRendererFactory.php
+++ b/src/Export/Renderer/HtmlRendererFactory.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Export\Renderer;
+
+use App\Repository\ProjectRepository;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Twig\Environment;
+
+final class HtmlRendererFactory
+{
+    /**
+     * @var Environment
+     */
+    private $twig;
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $dispatcher;
+    /**
+     * @var ProjectRepository
+     */
+    private $projectRepository;
+
+    public function __construct(Environment $twig, EventDispatcherInterface $dispatcher, ProjectRepository $projectRepository)
+    {
+        $this->twig = $twig;
+        $this->dispatcher = $dispatcher;
+        $this->projectRepository = $projectRepository;
+    }
+
+    public function create(string $id, string $template): HtmlRenderer
+    {
+        $renderer = new HtmlRenderer($this->twig, $this->dispatcher, $this->projectRepository);
+        $renderer->setId($id);
+        $renderer->setTemplate($template);
+
+        return $renderer;
+    }
+}

--- a/src/Export/Renderer/PDFRenderer.php
+++ b/src/Export/Renderer/PDFRenderer.php
@@ -10,9 +10,9 @@
 namespace App\Export\Renderer;
 
 use App\Export\Base\PDFRenderer as BasePDFRenderer;
-use App\Export\RendererInterface;
+use App\Export\ExportRendererInterface;
 
-final class PDFRenderer extends BasePDFRenderer implements RendererInterface
+final class PDFRenderer extends BasePDFRenderer implements ExportRendererInterface
 {
     public function getIcon(): string
     {

--- a/src/Export/Renderer/PdfRendererFactory.php
+++ b/src/Export/Renderer/PdfRendererFactory.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Export\Renderer;
+
+use App\Repository\ProjectRepository;
+use App\Timesheet\UserDateTimeFactory;
+use App\Utils\HtmlToPdfConverter;
+use Twig\Environment;
+
+final class PdfRendererFactory
+{
+    /**
+     * @var Environment
+     */
+    private $twig;
+    /**
+     * @var UserDateTimeFactory
+     */
+    private $dateTime;
+    /**
+     * @var HtmlToPdfConverter
+     */
+    private $converter;
+    /**
+     * @var ProjectRepository
+     */
+    private $projectRepository;
+
+    public function __construct(Environment $twig, UserDateTimeFactory $dateTime, HtmlToPdfConverter $converter, ProjectRepository $projectRepository)
+    {
+        $this->twig = $twig;
+        $this->dateTime = $dateTime;
+        $this->converter = $converter;
+        $this->projectRepository = $projectRepository;
+    }
+
+    public function create(string $id, string $template): PDFRenderer
+    {
+        $renderer = new PDFRenderer($this->twig, $this->dateTime, $this->converter, $this->projectRepository);
+        $renderer->setId($id);
+        $renderer->setTemplate($template);
+
+        return $renderer;
+    }
+}

--- a/src/Export/RendererInterface.php
+++ b/src/Export/RendererInterface.php
@@ -9,30 +9,6 @@
 
 namespace App\Export;
 
-use App\Repository\Query\TimesheetQuery;
-use Symfony\Component\HttpFoundation\Response;
-
-interface RendererInterface
+interface RendererInterface extends ExportRendererInterface
 {
-    /**
-     * @param ExportItemInterface[] $exportItems
-     * @param TimesheetQuery $query
-     * @return Response
-     */
-    public function render(array $exportItems, TimesheetQuery $query): Response;
-
-    /**
-     * @return string
-     */
-    public function getId(): string;
-
-    /**
-     * @return string
-     */
-    public function getIcon(): string;
-
-    /**
-     * @return string
-     */
-    public function getTitle(): string;
 }

--- a/src/Export/ServiceExport.php
+++ b/src/Export/ServiceExport.php
@@ -12,7 +12,7 @@ namespace App\Export;
 final class ServiceExport
 {
     /**
-     * @var RendererInterface[]
+     * @var ExportRendererInterface[]
      */
     private $renderer = [];
 
@@ -21,7 +21,7 @@ final class ServiceExport
      */
     private $exporter = [];
 
-    public function addRenderer(RendererInterface $renderer): ServiceExport
+    public function addRenderer(ExportRendererInterface $renderer): ServiceExport
     {
         $this->renderer[] = $renderer;
 
@@ -29,14 +29,14 @@ final class ServiceExport
     }
 
     /**
-     * @return RendererInterface[]
+     * @return ExportRendererInterface[]
      */
     public function getRenderer(): array
     {
         return $this->renderer;
     }
 
-    public function getRendererById(string $id): ?RendererInterface
+    public function getRendererById(string $id): ?ExportRendererInterface
     {
         foreach ($this->renderer as $renderer) {
             if ($renderer->getId() === $id) {

--- a/templates/export/index.html.twig
+++ b/templates/export/index.html.twig
@@ -42,11 +42,35 @@
             {{ form_row(form.markAsExported) }}
         {% endblock %}
         {% block box_footer%}
+            {% set buttons = {} %}
+            {% for button in renderer %}
+                {% set title = button.title %}
+                {% set group = [] %}
+                {% if buttons[(title)] is defined %}
+                    {% set group = buttons[(title)] %}
+                {% endif %}
+                {% set group = group|merge([button]) %}
+                {% set buttons = buttons|merge({(title): group}) %}
+            {% endfor %}
             <div class="btn-group" id="export-buttons" role="group">
-                {% for button in renderer %}
-                    <button type="button" id="export-{{ button.id }}-button" class="btn btn-success startExportBtn" data-type="{{ button.id }}">
-                        {{ ('button.' ~ button.title)|trans }}
-                    </button>
+                {% for group in buttons %}
+                    {% set button = group.0 %}
+                    {% if group|length == 1 %}
+                        <button type="button" id="export-{{ button.id }}-button" class="btn btn-success startExportBtn" data-type="{{ button.id }}">
+                            {{ ('button.' ~ button.title)|trans }}
+                        </button>
+                    {% elseif group|length > 1 %}
+                        <div class="btn-group">
+                            <button type="button" class="btn btn-success dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                {{ ('button.' ~ button.title)|trans }} <span class="caret"></span>
+                            </button>
+                            <ul class="dropdown-menu">
+                            {% for button in group %}
+                                <li><a href="#" class="startExportBtn" data-type="{{ button.id }}">{{ (button.id)|trans({}, 'export') }}</a></li>
+                            {% endfor %}
+                            </ul>
+                        </div>
+                    {% endif %}
                 {% endfor %}
             </div>
             {{ form_widget(form.preview) }}

--- a/templates/export/renderer/default-budget.pdf.twig
+++ b/templates/export/renderer/default-budget.pdf.twig
@@ -1,0 +1,12 @@
+{% extends 'export/renderer/default.pdf.twig' %}
+{% block summary %}
+    {% for budget in budgets %}
+        {% if budget.money_left > 0 %}
+            {% set showRateBudget = true %}
+        {% endif %}
+        {% if budget.time_left > 0 %}
+            {% set showTimeBudget = true %}
+        {% endif %}
+    {% endfor %}
+    {{ parent() }}
+{% endblock %}

--- a/templates/export/renderer/default.html.twig
+++ b/templates/export/renderer/default.html.twig
@@ -2,6 +2,17 @@
 {% import "macros/datatables.html.twig" as tables %}
 {% extends 'export/layout.html.twig' %}
 
+{% set showRateBudget = false %}
+{% set showTimeBudget = false %}
+{% for budget in budgets %}
+    {% if budget.money_left > 0 %}
+        {% set showRateBudget = true %}
+    {% endif %}
+    {% if budget.time_left > 0 %}
+        {% set showTimeBudget = true %}
+    {% endif %}
+{% endfor %}
+
 {% set decimal = decimal|default(false) %}
 {% set columnTitles = {} %}
 {% set columns = {
@@ -14,6 +25,15 @@
     'exported': false,
     'tags': false,
 } %}
+
+{% for budget in budgets %}
+    {% if budget.money_left > 0 %}
+        {% set showRateBudget = true %}
+    {% endif %}
+    {% if budget.time_left > 0 %}
+        {% set showTimeBudget = true %}
+    {% endif %}
+{% endfor %}
 
 {% for id, field in timesheetMetaFields %}
     {% set columns = columns|merge({ ('t_' ~ field.name): true}) %}
@@ -51,6 +71,18 @@
         });
         document.getElementById('summary-show').addEventListener('click', function(event) {
             document.getElementById('export-summary').style.display = event.target.checked ? 'block' : 'none';
+        });
+        document.getElementById('summary-timeBudget').addEventListener('click', function(event) {
+            var cells = document.getElementsByClassName('export-timeBudget');
+            for (var columnCell of cells) {
+                columnCell.style.display = event.target.checked ? 'table-cell' : 'none';
+            }
+        });
+        document.getElementById('summary-budget').addEventListener('click', function(event) {
+            var cells = document.getElementsByClassName('export-budget');
+            for (var columnCell of cells) {
+                columnCell.style.display = event.target.checked ? 'table-cell' : 'none';
+            }
         });
         document.getElementById('summary-duration').addEventListener('click', function(event) {
             if (!document.getElementById('summary-rate').checked) {
@@ -131,6 +163,23 @@
                         {{ 'label.activity'|trans }}
                     </label>
                 </div>
+                {% if showTimeBudget %}
+                <div class="form-group">
+                    <label class="control-label" for="summary-timeBudget">
+                        <input type="checkbox" id="summary-timeBudget" name="summary-timeBudget" checked>
+                        {{ 'label.timeBudget'|trans }}
+                    </label>
+                </div>
+                {% endif %}
+                {% if showRateBudget %}
+                <div class="form-group">
+                    <label class="control-label" for="summary-budget">
+                        <input type="checkbox" id="summary-budget" name="summary-budget" checked>
+                        {{ 'label.budget'|trans }}
+                    </label>
+                </div>
+                {% endif %}
+
                 <div class="form-group">
                     <label class="control-label" for="summary-duration">
                         <input type="checkbox" id="summary-duration" name="summary-duration" checked>
@@ -185,6 +234,12 @@
                 <tr>
                     <th>{{ 'label.customer'|trans }}</th>
                     <th>{{ 'label.project'|trans }}</th>
+                    {% if showTimeBudget %}
+                        <th class="center export-timeBudget">{{ 'label.timeBudget'|trans }}</th>
+                    {% endif %}
+                    {% if showRateBudget %}
+                        <th class="center export-budget">{{ 'label.budget'|trans }}</th>
+                    {% endif %}
                     <th class="duration summary-duration">{{ 'label.duration'|trans }}</th>
                     <th class="cost summary-rate">{{ 'label.rate'|trans }}</th>
                 </tr>
@@ -194,7 +249,7 @@
                 {% set customerDuration = 0 %}
                 {% set customerRate = 0 %}
                 {% set customerCurrency = null %}
-                {% for summary in summaries %}
+                {% for id, summary in summaries %}
                     {% if customer is same as(null) %}
                         {% set customer = summary.customer %}
                         {% set customerCurrency = summary.currency %}
@@ -202,6 +257,12 @@
                     {% if customer is not same as(summary.customer) %}
                         <tr class="summary">
                             <td colspan="2"></td>
+                            {% if showTimeBudget %}
+                                <td class="export-timeBudget"></td>
+                            {% endif %}
+                            {% if showRateBudget %}
+                                <td class="export-budget"></td>
+                            {% endif %}
                             <td class="totals duration summary-duration">{{ customerDuration|duration(decimal) }}</td>
                             <td class="totals cost summary-rate">{{ customerRate|money(customerCurrency) }}</td>
                         </tr>
@@ -213,6 +274,20 @@
                     <tr>
                         <td>{{ summary.customer }}</td>
                         <td>{{ summary.project }}</td>
+                        {% if showTimeBudget %}
+                            <td class="center export-timeBudget">
+                                {% if budgets[id] is defined and budgets[id].time_left > 0 %}
+                                    {{ budgets[id].time_left|duration(decimal) }}
+                                {% endif %}
+                            </td>
+                        {% endif %}
+                        {% if showRateBudget %}
+                            <td class="center export-budget">
+                                {% if budgets[id] is defined and budgets[id].money_left > 0 %}
+                                    {{ budgets[id].money_left|money(summary.currency) }}
+                                {% endif %}
+                            </td>
+                        {% endif %}
                         <td class="duration summary-duration">{{ summary.duration|duration(decimal) }}</td>
                         <td class="cost summary-rate">{{ summary.rate|money(summary.currency) }}</td>
                     </tr>
@@ -222,6 +297,12 @@
                 {% if customer is not same as(null) %}
                     <tr class="summary">
                         <td colspan="2"></td>
+                        {% if showTimeBudget %}
+                            <td class="export-timeBudget"></td>
+                        {% endif %}
+                        {% if showRateBudget %}
+                            <td class="export-budget"></td>
+                        {% endif %}
                         <td class="totals duration summary-duration">{{ customerDuration|duration(decimal) }}</td>
                         <td class="totals cost summary-rate">{{ customerRate|money(customerCurrency) }}</td>
                     </tr>

--- a/templates/export/renderer/default.html.twig
+++ b/templates/export/renderer/default.html.twig
@@ -26,15 +26,6 @@
     'tags': false,
 } %}
 
-{% for budget in budgets %}
-    {% if budget.money_left > 0 %}
-        {% set showRateBudget = true %}
-    {% endif %}
-    {% if budget.time_left > 0 %}
-        {% set showTimeBudget = true %}
-    {% endif %}
-{% endfor %}
-
 {% for id, field in timesheetMetaFields %}
     {% set columns = columns|merge({ ('t_' ~ field.name): true}) %}
     {% set columnTitles = columnTitles|merge({ ('t_' ~ field.name): (field.label)}) %}

--- a/templates/export/renderer/default.pdf.twig
+++ b/templates/export/renderer/default.pdf.twig
@@ -92,19 +92,12 @@
 </htmlpagefooter>
 <sethtmlpagefooter name="myfooter" value="on" />
 mpdf-->
+{% block summary %}
 <h2 style="margin-bottom: 0; padding-bottom: 0">{{ 'export.document_title'|trans }}</h2>
 <p>
     {{ 'export.period'|trans }}:
     {{ query.begin|date_short }} - {{ query.end|date_short }}
 </p>
-{% for budget in budgets %}
-    {% if budget.money_left > 0 %}
-        {% set showRateBudget = true %}
-    {% endif %}
-    {% if budget.time_left > 0 %}
-        {% set showTimeBudget = true %}
-    {% endif %}
-{% endfor %}
 <h3>{{ 'export.summary'|trans }}</h3>
 <table class="items">
     <thead>
@@ -201,6 +194,9 @@ mpdf-->
 
 <pagebreak>
 
+{% endblock %}
+
+{% block summary %}
 <h3>{{ 'export.full_list'|trans }}</h3>
 
 {% set duration = 0 %}
@@ -273,5 +269,6 @@ mpdf-->
     </tr>
     </tbody>
 </table>
+{% endblock %}
 </body>
 </html>

--- a/templates/export/renderer/default.pdf.twig
+++ b/templates/export/renderer/default.pdf.twig
@@ -93,182 +93,182 @@
 <sethtmlpagefooter name="myfooter" value="on" />
 mpdf-->
 {% block summary %}
-<h2 style="margin-bottom: 0; padding-bottom: 0">{{ 'export.document_title'|trans }}</h2>
-<p>
-    {{ 'export.period'|trans }}:
-    {{ query.begin|date_short }} - {{ query.end|date_short }}
-</p>
-<h3>{{ 'export.summary'|trans }}</h3>
-<table class="items">
-    <thead>
-    <tr>
-        <th>{{ 'label.customer'|trans }}</th>
-        <th>{{ 'label.project'|trans }}</th>
-        {% if showTimeBudget %}
-        <th class="center">{{ 'label.timeBudget'|trans }}</th>
-        {% endif %}
-        {% if showRateBudget %}
-        <th class="center">{{ 'label.budget'|trans }}</th>
-        {% endif %}
-        <th class="center">{{ 'label.duration'|trans }}</th>
-        {% if showRateColumn %}
-        <th class="center">{{ 'label.rate'|trans }}</th>
-        {% endif %}
-    </tr>
-    </thead>
-    <tbody>
-    {% set customer = null %}
-    {% set customerDuration = 0 %}
-    {% set customerRate = 0 %}
-    {% set customerCurrency = null %}
-    {% set customerCount = 0 %}
-    {% for id, summary in summaries %}
-        {% if customer is same as(null) %}
-            {% set customer = summary.customer %}
-            {% set customerCurrency = summary.currency %}
-        {% endif %}
-        {% if customer is not same as(summary.customer) %}
-                <tr class="summary">
-                    <td colspan="2">
-                    </td>
-                    {% if showTimeBudget %}
-                        <td></td>
-                    {% endif %}
-                    {% if showRateBudget %}
-                        <td></td>
-                    {% endif %}
-                    <td class="totals duration">{{ customerDuration|duration(decimal) }}</td>
-                    {% if showRateColumn %}
-                    <td class="totals cost">{{ customerRate|money(customerCurrency) }}</td>
-                    {% endif %}
-                </tr>
-            {% set customerCurrency = summary.currency %}
-            {% set customer = summary.customer %}
-            {% set customerDuration = 0 %}
-            {% set customerRate = 0 %}
-            {% set customerCount = 0 %}
-        {% endif %}
-        <tr class="{{ cycle(['odd', 'even'], customerCount) }}">
-            <td>{{ summary.customer }}</td>
-            <td>{{ summary.project }}</td>
+    <h2 style="margin-bottom: 0; padding-bottom: 0">{{ 'export.document_title'|trans }}</h2>
+    <p>
+        {{ 'export.period'|trans }}:
+        {{ query.begin|date_short }} - {{ query.end|date_short }}
+    </p>
+    <h3>{{ 'export.summary'|trans }}</h3>
+    <table class="items">
+        <thead>
+        <tr>
+            <th>{{ 'label.customer'|trans }}</th>
+            <th>{{ 'label.project'|trans }}</th>
             {% if showTimeBudget %}
-                <td class="center">
-                    {% if budgets[id] is defined and budgets[id].time_left > 0 %}
-                        {{ budgets[id].time_left|duration(decimal) }}
-                    {% endif %}
-                </td>
+            <th class="center">{{ 'label.timeBudget'|trans }}</th>
             {% endif %}
             {% if showRateBudget %}
-                <td class="center">
-                    {% if budgets[id] is defined and budgets[id].money_left > 0 %}
-                        {{ budgets[id].money_left|money(summary.currency) }}
+            <th class="center">{{ 'label.budget'|trans }}</th>
+            {% endif %}
+            <th class="center">{{ 'label.duration'|trans }}</th>
+            {% if showRateColumn %}
+            <th class="center">{{ 'label.rate'|trans }}</th>
+            {% endif %}
+        </tr>
+        </thead>
+        <tbody>
+        {% set customer = null %}
+        {% set customerDuration = 0 %}
+        {% set customerRate = 0 %}
+        {% set customerCurrency = null %}
+        {% set customerCount = 0 %}
+        {% for id, summary in summaries %}
+            {% if customer is same as(null) %}
+                {% set customer = summary.customer %}
+                {% set customerCurrency = summary.currency %}
+            {% endif %}
+            {% if customer is not same as(summary.customer) %}
+                    <tr class="summary">
+                        <td colspan="2">
+                        </td>
+                        {% if showTimeBudget %}
+                            <td></td>
+                        {% endif %}
+                        {% if showRateBudget %}
+                            <td></td>
+                        {% endif %}
+                        <td class="totals duration">{{ customerDuration|duration(decimal) }}</td>
+                        {% if showRateColumn %}
+                        <td class="totals cost">{{ customerRate|money(customerCurrency) }}</td>
+                        {% endif %}
+                    </tr>
+                {% set customerCurrency = summary.currency %}
+                {% set customer = summary.customer %}
+                {% set customerDuration = 0 %}
+                {% set customerRate = 0 %}
+                {% set customerCount = 0 %}
+            {% endif %}
+            <tr class="{{ cycle(['odd', 'even'], customerCount) }}">
+                <td>{{ summary.customer }}</td>
+                <td>{{ summary.project }}</td>
+                {% if showTimeBudget %}
+                    <td class="center">
+                        {% if budgets[id] is defined and budgets[id].time_left > 0 %}
+                            {{ budgets[id].time_left|duration(decimal) }}
+                        {% endif %}
+                    </td>
+                {% endif %}
+                {% if showRateBudget %}
+                    <td class="center">
+                        {% if budgets[id] is defined and budgets[id].money_left > 0 %}
+                            {{ budgets[id].money_left|money(summary.currency) }}
+                        {% endif %}
+                    </td>
+                {% endif %}
+                <td class="duration">{{ summary.duration|duration(decimal) }}</td>
+                {% if showRateColumn %}
+                <td class="cost">{{ summary.rate|money(summary.currency) }}</td>
+                {% endif %}
+            </tr>
+            {% set customerDuration = customerDuration + summary.duration %}
+            {% set customerRate = customerRate + summary.rate %}
+            {% set customerCount = customerCount + 1 %}
+        {% endfor %}
+        {% if customer is not same as(null) %}
+        <tr class="summary">
+            <td colspan="2"></td>
+            {% if showTimeBudget %}
+                <td></td>
+            {% endif %}
+            {% if showRateBudget %}
+                <td></td>
+            {% endif %}
+            <td class="totals duration">{{ customerDuration|duration(decimal) }}</td>
+            {% if showRateColumn %}
+            <td class="totals cost">{{ customerRate|money(customerCurrency) }}</td>
+            {% endif %}
+        </tr>
+        {% endif %}
+        </tbody>
+    </table>
+
+    <pagebreak>
+{% endblock %}
+
+{% block items %}
+    <h3>{{ 'export.full_list'|trans }}</h3>
+
+    {% set duration = 0 %}
+    {% set rate = 0 %}
+    {% set currency = false %}
+    <table class="items">
+        <thead>
+        <tr>
+            <th>{{ 'label.date'|trans }}</th>
+            {% if showUserColumn %}
+            <th>{{ 'label.user'|trans }}</th>
+            {% endif %}
+            <th>{{ 'label.description'|trans }}</th>
+            <th class="center">{{ 'label.duration'|trans }}</th>
+            {% if showRateColumn %}
+            <th class="center">{{ 'label.rate'|trans }}</th>
+            {% endif %}
+        </tr>
+        </thead>
+        <tbody>
+        {% for entry in entries %}
+            {% set duration = duration + entry.duration %}
+            {% if currency is same as(false) %}
+                {% set currency = entry.project.customer.currency %}
+            {% endif %}
+            {% if currency is not same as(entry.project.customer.currency) %}
+                {% set currency = null %}
+            {% endif %}
+            <tr class="{{ cycle(['odd', 'even'], loop.index0) }}">
+                <td class="text-nowrap">
+                    {{ entry.begin|date_time }}
+                    {% if entry.end %}
+                        <br>
+                        {{ entry.end|date_time }}
                     {% endif %}
                 </td>
-            {% endif %}
-            <td class="duration">{{ summary.duration|duration(decimal) }}</td>
-            {% if showRateColumn %}
-            <td class="cost">{{ summary.rate|money(summary.currency) }}</td>
-            {% endif %}
-        </tr>
-        {% set customerDuration = customerDuration + summary.duration %}
-        {% set customerRate = customerRate + summary.rate %}
-        {% set customerCount = customerCount + 1 %}
-    {% endfor %}
-    {% if customer is not same as(null) %}
-    <tr class="summary">
-        <td colspan="2"></td>
-        {% if showTimeBudget %}
-            <td></td>
-        {% endif %}
-        {% if showRateBudget %}
-            <td></td>
-        {% endif %}
-        <td class="totals duration">{{ customerDuration|duration(decimal) }}</td>
-        {% if showRateColumn %}
-        <td class="totals cost">{{ customerRate|money(customerCurrency) }}</td>
-        {% endif %}
-    </tr>
-    {% endif %}
-    </tbody>
-</table>
-
-<pagebreak>
-
-{% endblock %}
-
-{% block summary %}
-<h3>{{ 'export.full_list'|trans }}</h3>
-
-{% set duration = 0 %}
-{% set rate = 0 %}
-{% set currency = false %}
-<table class="items">
-    <thead>
-    <tr>
-        <th>{{ 'label.date'|trans }}</th>
-        {% if showUserColumn %}
-        <th>{{ 'label.user'|trans }}</th>
-        {% endif %}
-        <th>{{ 'label.description'|trans }}</th>
-        <th class="center">{{ 'label.duration'|trans }}</th>
-        {% if showRateColumn %}
-        <th class="center">{{ 'label.rate'|trans }}</th>
-        {% endif %}
-    </tr>
-    </thead>
-    <tbody>
-    {% for entry in entries %}
-        {% set duration = duration + entry.duration %}
-        {% if currency is same as(false) %}
-            {% set currency = entry.project.customer.currency %}
-        {% endif %}
-        {% if currency is not same as(entry.project.customer.currency) %}
-            {% set currency = null %}
-        {% endif %}
-        <tr class="{{ cycle(['odd', 'even'], loop.index0) }}">
-            <td class="text-nowrap">
-                {{ entry.begin|date_time }}
-                {% if entry.end %}
-                    <br>
-                    {{ entry.end|date_time }}
+                {% if showUserColumn %}
+                    <td>{{ entry.user.displayName }}</td>
                 {% endif %}
-            </td>
+                <td>
+                    {{ entry.project.customer.name }} - {{ entry.project.name }}{% if entry.activity is not null %} - {{ entry.activity.name }}{% endif %}
+                    {% if entry.description is not empty %}
+                        <br>
+                        <i>{{ entry.description|escape|desc2html }}</i>
+                    {% endif %}
+                </td>
+                <td class="duration">{{ entry.duration|duration(decimal) }}</td>
+                {% if showRateColumn %}
+                <td class="cost">
+                    {% if is_granted('view_rate', entry) %}
+                    {% set rate = rate + entry.rate %}
+                    {{ entry.rate|money(entry.project.customer.currency) }}
+                    {% else %}
+                        &ndash;
+                    {% endif %}
+                </td>
+                {% endif %}
+            </tr>
+        {% endfor %}
+        <tr class="summary">
             {% if showUserColumn %}
-                <td>{{ entry.user.displayName }}</td>
+                <td colspan="3"></td>
+            {% else %}
+            <td colspan="2"></td>
             {% endif %}
-            <td>
-                {{ entry.project.customer.name }} - {{ entry.project.name }}{% if entry.activity is not null %} - {{ entry.activity.name }}{% endif %}
-                {% if entry.description is not empty %}
-                    <br>
-                    <i>{{ entry.description|escape|desc2html }}</i>
-                {% endif %}
-            </td>
-            <td class="duration">{{ entry.duration|duration(decimal) }}</td>
+            <td class="totals duration">{{ duration|duration(decimal) }}</td>
             {% if showRateColumn %}
-            <td class="cost">
-                {% if is_granted('view_rate', entry) %}
-                {% set rate = rate + entry.rate %}
-                {{ entry.rate|money(entry.project.customer.currency) }}
-                {% else %}
-                    &ndash;
-                {% endif %}
-            </td>
+            <td class="totals cost">{% if currency is not null %}{{ rate|money(currency) }}{% endif %}</td>
             {% endif %}
         </tr>
-    {% endfor %}
-    <tr class="summary">
-        {% if showUserColumn %}
-            <td colspan="3"></td>
-        {% else %}
-        <td colspan="2"></td>
-        {% endif %}
-        <td class="totals duration">{{ duration|duration(decimal) }}</td>
-        {% if showRateColumn %}
-        <td class="totals cost">{% if currency is not null %}{{ rate|money(currency) }}{% endif %}</td>
-        {% endif %}
-    </tr>
-    </tbody>
-</table>
+        </tbody>
+    </table>
 {% endblock %}
+
 </body>
 </html>

--- a/templates/export/renderer/pdf.html.twig
+++ b/templates/export/renderer/pdf.html.twig
@@ -1,6 +1,8 @@
 {% set showUserColumn = true %}
 {% set showRateColumn = true %}
 {% set decimal = decimal|default(false) %}
+{% set showRateBudget = false %}
+{% set showTimeBudget = false %}
 {% if query.user %}
     {# this is only triggered, if a user exports from his personal timesheet screen#}
     {% set showUserColumn = false %}
@@ -95,13 +97,26 @@ mpdf-->
     {{ 'export.period'|trans }}:
     {{ query.begin|date_short }} - {{ query.end|date_short }}
 </p>
-
+{% for budget in budgets %}
+    {% if budget.money_left > 0 %}
+        {% set showRateBudget = true %}
+    {% endif %}
+    {% if budget.time_left > 0 %}
+        {% set showTimeBudget = true %}
+    {% endif %}
+{% endfor %}
 <h3>{{ 'export.summary'|trans }}</h3>
 <table class="items">
     <thead>
     <tr>
         <th>{{ 'label.customer'|trans }}</th>
         <th>{{ 'label.project'|trans }}</th>
+        {% if showTimeBudget %}
+        <th class="center">{{ 'label.timeBudget'|trans }}</th>
+        {% endif %}
+        {% if showRateBudget %}
+        <th class="center">{{ 'label.budget'|trans }}</th>
+        {% endif %}
         <th class="center">{{ 'label.duration'|trans }}</th>
         {% if showRateColumn %}
         <th class="center">{{ 'label.rate'|trans }}</th>
@@ -114,14 +129,21 @@ mpdf-->
     {% set customerRate = 0 %}
     {% set customerCurrency = null %}
     {% set customerCount = 0 %}
-    {% for summary in summaries %}
+    {% for id, summary in summaries %}
         {% if customer is same as(null) %}
             {% set customer = summary.customer %}
             {% set customerCurrency = summary.currency %}
         {% endif %}
         {% if customer is not same as(summary.customer) %}
                 <tr class="summary">
-                    <td colspan="2"></td>
+                    <td colspan="2">
+                    </td>
+                    {% if showTimeBudget %}
+                        <td></td>
+                    {% endif %}
+                    {% if showRateBudget %}
+                        <td></td>
+                    {% endif %}
                     <td class="totals duration">{{ customerDuration|duration(decimal) }}</td>
                     {% if showRateColumn %}
                     <td class="totals cost">{{ customerRate|money(customerCurrency) }}</td>
@@ -136,6 +158,20 @@ mpdf-->
         <tr class="{{ cycle(['odd', 'even'], customerCount) }}">
             <td>{{ summary.customer }}</td>
             <td>{{ summary.project }}</td>
+            {% if showTimeBudget %}
+                <td class="center">
+                    {% if budgets[id] is defined and budgets[id].time_left > 0 %}
+                        {{ budgets[id].time_left|duration(decimal) }}
+                    {% endif %}
+                </td>
+            {% endif %}
+            {% if showRateBudget %}
+                <td class="center">
+                    {% if budgets[id] is defined and budgets[id].money_left > 0 %}
+                        {{ budgets[id].money_left|money(summary.currency) }}
+                    {% endif %}
+                </td>
+            {% endif %}
             <td class="duration">{{ summary.duration|duration(decimal) }}</td>
             {% if showRateColumn %}
             <td class="cost">{{ summary.rate|money(summary.currency) }}</td>
@@ -148,6 +184,12 @@ mpdf-->
     {% if customer is not same as(null) %}
     <tr class="summary">
         <td colspan="2"></td>
+        {% if showTimeBudget %}
+            <td></td>
+        {% endif %}
+        {% if showRateBudget %}
+            <td></td>
+        {% endif %}
         <td class="totals duration">{{ customerDuration|duration(decimal) }}</td>
         {% if showRateColumn %}
         <td class="totals cost">{{ customerRate|money(customerCurrency) }}</td>

--- a/tests/Controller/ExportControllerTest.php
+++ b/tests/Controller/ExportControllerTest.php
@@ -88,8 +88,8 @@ class ExportControllerTest extends ControllerBaseTest
         $this->assertDataTableRowCount($client, 'datatable_export', 23);
 
         // assert export type buttons are available
-        $expected = ['csv', 'html', 'pdf', 'xlsx'];
-        $node = $client->getCrawler()->filter('#export-buttons button');
+        $expected = ['csv', 'default.html.twig', 'default-budget.pdf.twig', 'default.pdf.twig', 'xlsx'];
+        $node = $client->getCrawler()->filter('#export-buttons .startExportBtn');
         $this->assertEquals(count($expected), $node->count());
         /** @var \DOMElement $button */
         foreach ($node->getIterator() as $button) {
@@ -140,8 +140,8 @@ class ExportControllerTest extends ControllerBaseTest
         $this->assertDataTableRowCount($client, 'datatable_export', 3);
 
         // assert export type buttons are available
-        $expected = ['csv', 'html', 'pdf', 'xlsx'];
-        $node = $client->getCrawler()->filter('#export-buttons button');
+        $expected = ['csv', 'default.html.twig', 'default-budget.pdf.twig', 'default.pdf.twig', 'xlsx'];
+        $node = $client->getCrawler()->filter('#export-buttons .startExportBtn');
         $this->assertEquals(count($expected), $node->count());
         /** @var \DOMElement $button */
         foreach ($node->getIterator() as $button) {
@@ -208,7 +208,7 @@ class ExportControllerTest extends ControllerBaseTest
 
         // don't add daterange to make sure the current month is the default range
         $client->submit($form, [
-            'type' => 'html',
+            'type' => 'default.html.twig',
             'markAsExported' => 1
         ]);
 

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -292,6 +292,14 @@ class ConfigurationTest extends TestCase
                 'simple_form' => true,
                 'number_format' => '{Y}/{cy,3}',
             ],
+            'export' => [
+                'documents' => [
+                ],
+                'defaults' => [
+                    0 => 'var/export/',
+                    1 => 'templates/export/renderer/',
+                ],
+            ],
             'languages' => [],
             'calendar' => [
                 'week_numbers' => true,

--- a/tests/Export/Renderer/AbstractRendererTest.php
+++ b/tests/Export/Renderer/AbstractRendererTest.php
@@ -25,6 +25,7 @@ use App\Event\ActivityMetaDisplayEvent;
 use App\Event\CustomerMetaDisplayEvent;
 use App\Event\ProjectMetaDisplayEvent;
 use App\Event\TimesheetMetaDisplayEvent;
+use App\Export\ExportRendererInterface;
 use App\Export\RendererInterface;
 use App\Repository\Query\TimesheetQuery;
 use App\Twig\DateExtensions;
@@ -74,10 +75,10 @@ abstract class AbstractRendererTest extends KernelTestCase
     }
 
     /**
-     * @param RendererInterface $renderer
+     * @param ExportRendererInterface $renderer
      * @return \Symfony\Component\HttpFoundation\Response
      */
-    protected function render(RendererInterface $renderer)
+    protected function render(ExportRendererInterface $renderer)
     {
         $customer = new Customer();
         $customer->setName('Customer Name');

--- a/tests/Export/Renderer/HtmlRendererFactoryTest.php
+++ b/tests/Export/Renderer/HtmlRendererFactoryTest.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Export\Renderer;
+
+use App\Export\Renderer\HtmlRenderer;
+use App\Export\Renderer\HtmlRendererFactory;
+use App\Repository\ProjectRepository;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Twig\Environment;
+
+/**
+ * @covers \App\Export\Renderer\HtmlRendererFactory
+ */
+class HtmlRendererFactoryTest extends TestCase
+{
+    public function testCreate()
+    {
+        $sut = new HtmlRendererFactory(
+            $this->createMock(Environment::class),
+            $this->createMock(EventDispatcherInterface::class),
+            $this->createMock(ProjectRepository::class)
+        );
+
+        /** @var HtmlRenderer $renderer */
+        $renderer = $sut->create('foo', 'bar.html.twig');
+
+        self::assertInstanceOf(HtmlRenderer::class, $renderer);
+        self::assertEquals('foo', $renderer->getId());
+    }
+}

--- a/tests/Export/Renderer/HtmlRendererTest.php
+++ b/tests/Export/Renderer/HtmlRendererTest.php
@@ -10,6 +10,7 @@
 namespace App\Tests\Export\Renderer;
 
 use App\Export\Renderer\HtmlRenderer;
+use App\Repository\ProjectRepository;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\HttpFoundation\Request;
 use Twig\Environment;
@@ -26,7 +27,8 @@ class HtmlRendererTest extends AbstractRendererTest
     {
         $sut = new HtmlRenderer(
             $this->createMock(Environment::class),
-            new EventDispatcher()
+            new EventDispatcher(),
+            $this->createMock(ProjectRepository::class)
         );
 
         $this->assertEquals('html', $sut->getId());
@@ -44,7 +46,7 @@ class HtmlRendererTest extends AbstractRendererTest
         $request->setLocale('en');
         $stack->push($request);
 
-        $sut = new HtmlRenderer($twig, new EventDispatcher());
+        $sut = new HtmlRenderer($twig, new EventDispatcher(), $this->createMock(ProjectRepository::class));
 
         $response = $this->render($sut);
 

--- a/tests/Export/Renderer/PdfRendererFactoryTest.php
+++ b/tests/Export/Renderer/PdfRendererFactoryTest.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Export\Renderer;
+
+use App\Export\Renderer\HtmlRenderer;
+use App\Export\Renderer\PDFRenderer;
+use App\Export\Renderer\PdfRendererFactory;
+use App\Repository\ProjectRepository;
+use App\Timesheet\UserDateTimeFactory;
+use App\Utils\HtmlToPdfConverter;
+use PHPUnit\Framework\TestCase;
+use Twig\Environment;
+
+/**
+ * @covers \App\Export\Renderer\PdfRendererFactory
+ */
+class PdfRendererFactoryTest extends TestCase
+{
+    public function testCreate()
+    {
+        $sut = new PdfRendererFactory(
+            $this->createMock(Environment::class),
+            $this->createMock(UserDateTimeFactory::class),
+            $this->createMock(HtmlToPdfConverter::class),
+            $this->createMock(ProjectRepository::class)
+        );
+
+        /** @var HtmlRenderer $renderer */
+        $renderer = $sut->create('foo', 'bar.pdf.twig');
+
+        self::assertInstanceOf(PDFRenderer::class, $renderer);
+        self::assertEquals('foo', $renderer->getId());
+    }
+}

--- a/tests/Export/Renderer/PdfRendererTest.php
+++ b/tests/Export/Renderer/PdfRendererTest.php
@@ -10,6 +10,7 @@
 namespace App\Tests\Export\Renderer;
 
 use App\Export\Renderer\PDFRenderer;
+use App\Repository\ProjectRepository;
 use App\Tests\Mocks\Security\UserDateTimeFactoryFactory;
 use App\Utils\HtmlToPdfConverter;
 use App\Utils\MPdfConverter;
@@ -34,7 +35,8 @@ class PdfRendererTest extends AbstractRendererTest
         $sut = new PDFRenderer(
             $this->createMock(Environment::class),
             $this->getDateTimeFactory(),
-            $this->createMock(HtmlToPdfConverter::class)
+            $this->createMock(HtmlToPdfConverter::class),
+            $this->createMock(ProjectRepository::class)
         );
 
         $this->assertEquals('pdf', $sut->getId());
@@ -54,7 +56,7 @@ class PdfRendererTest extends AbstractRendererTest
         $request->setLocale('en');
         $stack->push($request);
 
-        $sut = new PDFRenderer($twig, $this->getDateTimeFactory(), $converter);
+        $sut = new PDFRenderer($twig, $this->getDateTimeFactory(), $converter, $this->createMock(ProjectRepository::class));
 
         $response = $this->render($sut);
 

--- a/tests/Export/ServiceExportTest.php
+++ b/tests/Export/ServiceExportTest.php
@@ -12,6 +12,7 @@ namespace App\Tests\Export;
 use App\Export\Renderer\HtmlRenderer;
 use App\Export\ServiceExport;
 use App\Export\Timesheet\HtmlRenderer as HtmlExporter;
+use App\Repository\ProjectRepository;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Twig\Environment;
@@ -36,7 +37,7 @@ class ServiceExportTest extends TestCase
     {
         $sut = new ServiceExport();
 
-        $renderer = new HtmlRenderer($this->createMock(Environment::class), new EventDispatcher());
+        $renderer = new HtmlRenderer($this->createMock(Environment::class), new EventDispatcher(), $this->createMock(ProjectRepository::class));
         $sut->addRenderer($renderer);
 
         self::assertEquals(1, count($sut->getRenderer()));

--- a/tests/Export/Timesheet/PdfRendererTest.php
+++ b/tests/Export/Timesheet/PdfRendererTest.php
@@ -10,6 +10,7 @@
 namespace App\Tests\Export\Timesheet;
 
 use App\Export\Timesheet\PDFRenderer;
+use App\Repository\ProjectRepository;
 use App\Tests\Mocks\Security\UserDateTimeFactoryFactory;
 use App\Utils\HtmlToPdfConverter;
 use App\Utils\MPdfConverter;
@@ -32,9 +33,10 @@ class PdfRendererTest extends AbstractRendererTest
     public function testConfiguration()
     {
         $sut = new PDFRenderer(
-            $this->getMockBuilder(Environment::class)->disableOriginalConstructor()->getMock(),
+            $this->createMock(Environment::class),
             $this->getDateTimeFactory(),
-            $this->getMockBuilder(HtmlToPdfConverter::class)->getMock()
+            $this->createMock(HtmlToPdfConverter::class),
+            $this->createMock(ProjectRepository::class)
         );
 
         $this->assertEquals('pdf', $sut->getId());
@@ -52,7 +54,7 @@ class PdfRendererTest extends AbstractRendererTest
         $request->setLocale('en');
         $stack->push($request);
 
-        $sut = new PDFRenderer($twig, $this->getDateTimeFactory(), $converter);
+        $sut = new PDFRenderer($twig, $this->getDateTimeFactory(), $converter, $this->createMock(ProjectRepository::class));
 
         $response = $this->render($sut);
 

--- a/translations/export.de.xlf
+++ b/translations/export.de.xlf
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" target-language="de" datatype="plaintext" original="export.en.xlf">
+        <body>
+            <trans-unit id="default.pdf.twig">
+                <source>default.pdf.twig</source>
+                <target>Standard</target>
+            </trans-unit>
+            <trans-unit id="default-budget.pdf.twig">
+                <source>default-budget.pdf.twig</source>
+                <target>Inkl. Restbudget</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/translations/export.en.xlf
+++ b/translations/export.en.xlf
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" target-language="en" datatype="plaintext" original="export.en.xlf">
+        <body>
+            <trans-unit id="default.pdf.twig">
+                <source>default.pdf.twig</source>
+                <target>Standard</target>
+            </trans-unit>
+            <trans-unit id="default-budget.pdf.twig">
+                <source>default-budget.pdf.twig</source>
+                <target>With remaining budget</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>


### PR DESCRIPTION
## Description

- adds new directory `var/export/` where `*.html.twig` and `*.pdf.twig` can be placed for simple adding of new HTML and PDF exports
- added new PDF template, which includes remaining project budget
- added remaining project budget to project summary in html export

**TODO**
- [x] documentation!

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer kimai:code-check`)
- [x] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
