### PR TITLE
allow to create default team if none with the projects name exists

### DIFF
--- a/templates/embeds/teams.html.twig
+++ b/templates/embeds/teams.html.twig
@@ -10,7 +10,7 @@
 {% embed '@AdminLTE/Widgets/box-widget.html.twig' with options %}
     {% import "macros/widgets.html.twig" as widgets %}
     {% block box_tools %}
-        {% if teams|length == 0 and team is null and route_create is not null and is_granted('create_team') %}
+        {% if route_create is not null and (teams|length == 0 or team is null) and is_granted('create_team') %}
             <a class="btn-box-tool" href="{{ route_create }}" data-toggle="tooltip" data-placement="top" title="{{ 'team.create_default'|trans({}, 'teams') }}"><i class="{{ 'create'|icon }}"></i></a>
         {% endif %}
         {% if route_edit is not null %}


### PR DESCRIPTION
## Description

Fixes #1610 

If no default team exists, the button to create it will be visible (no matter if other teams exist).
Default team = team with the exact same name like the project/customer

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer kimai:code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
