### PR TITLE
Fix Czech translation

### DIFF
--- a/translations/flashmessages.cs.xlf
+++ b/translations/flashmessages.cs.xlf
@@ -32,7 +32,7 @@
             </trans-unit>
             <trans-unit id="action.update.success">
                 <source>action.update.success</source>
-                <target>Uložit změny</target>
+                <target>Změny uložené</target>
             </trans-unit>
             <trans-unit id="action.update.error">
                 <source>action.update.error</source>

--- a/translations/messages.cs.xlf
+++ b/translations/messages.cs.xlf
@@ -166,11 +166,11 @@
             </trans-unit>
             <trans-unit id="label.starttime">
                 <source>label.starttime</source>
-                <target>Začít</target>
+                <target>Začátek</target>
             </trans-unit>
             <trans-unit id="label.endtime">
                 <source>label.endtime</source>
-                <target>Ukončit</target>
+                <target>Konec</target>
             </trans-unit>
             <trans-unit id="label.duration">
                 <source>label.duration</source>
@@ -246,7 +246,7 @@
             </trans-unit>
             <trans-unit id="label.rate">
                 <source>label.rate</source>
-                <target>Hodnotit</target>
+                <target>Sazba</target>
             </trans-unit>
             <trans-unit id="label.language">
                 <source>label.language</source>
@@ -418,7 +418,7 @@
             </trans-unit>
             <trans-unit id="profile.preferences">
                 <source>profile.preferences</source>
-                <target>Priorita</target>
+                <target>Předvolby</target>
             </trans-unit>
             <trans-unit id="label.theme.collapsed_sidebar">
                 <source>label.theme.collapsed_sidebar</source>

--- a/translations/system-configuration.cs.xlf
+++ b/translations/system-configuration.cs.xlf
@@ -4,7 +4,7 @@
         <body>
             <trans-unit id="title">
                 <source>title</source>
-                <target>Nastaven</target>
+                <target>Nastavení</target>
             </trans-unit>
             <trans-unit id="subtitle">
                 <source>subtitle</source>


### PR DESCRIPTION
## Description

Fix of Czech translation. There was used verbs, where should be used nouns. Another issues are probably because of lack of context.

Fixed by @KuboF, reviewed by native Czech speaker.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I verified that my code applies to the guidelines (`composer kimai:code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
