### PR TITLE
allow to change PDF export layout via code

### DIFF
--- a/templates/export/pdf-layout.html.twig
+++ b/templates/export/pdf-layout.html.twig
@@ -1,9 +1,9 @@
-{% set showUserColumn = showUserColumn|default(true) %}
-{% set showInternalRate = showInternalRate|default(false) %}
-{% set showRateColumn = showRateColumn|default(true) %}
-{% set showRateBudget = showRateBudget|default(false) %}
-{% set showTimeBudget = showTimeBudget|default(false) %}
-{% set decimal = decimal|default(false) %}
+{% set showUserColumn = showUserColumn ?? true %}
+{% set showInternalRate = showInternalRate ?? false %}
+{% set showRateColumn = showRateColumn ?? true %}
+{% set showRateBudget = showRateBudget ?? false %}
+{% set showTimeBudget = showTimeBudget ?? false %}
+{% set decimal = decimal ?? false %}
 {% if query.user %}
     {# this is only triggered, if a user exports from his personal timesheet screen #}
     {% set showUserColumn = false %}
@@ -80,7 +80,7 @@
 <tr>
     <td align="left">
     {{ 'export.page_of'|trans({'%page%': '{PAGENO}', '%pages%': '{nb}'}) }}
-    {% if not showUserColumn %}
+    {% if not showUserColumn and query.user %}
         &ndash;
         {{ 'label.user'|trans }}: {{ query.user.displayName }} 
     {% endif %}


### PR DESCRIPTION
## Description

PDF export templates can change layout settings via eg.
```
{% set showUserColumn = false %}
```

Previously only worked when overwritten templates used `true` for a setting.
Bug with `false` and the `|default()` filter .

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer kimai:code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
