### PR TITLE
Allow to recalculate rates via bulk edit

### DIFF
--- a/src/Controller/TimesheetAbstractController.php
+++ b/src/Controller/TimesheetAbstractController.php
@@ -330,14 +330,21 @@ abstract class TimesheetAbstractController extends AbstractController
                     $timesheet->setExported($dto->isExported());
                     $execute = true;
                 }
-                // setting both values allows to erase wrong
-                if (null !== $dto->getHourlyRate()) {
+
+                if ($dto->isRecalculateRates()) {
                     $timesheet->setFixedRate(null);
-                    $timesheet->setHourlyRate($dto->getHourlyRate());
+                    $timesheet->setHourlyRate(null);
+                    $timesheet->setInternalRate(null);
                     $execute = true;
                 } elseif (null !== $dto->getFixedRate()) {
                     $timesheet->setFixedRate($dto->getFixedRate());
                     $timesheet->setHourlyRate(null);
+                    $timesheet->setInternalRate(null);
+                    $execute = true;
+                } elseif (null !== $dto->getHourlyRate()) {
+                    $timesheet->setFixedRate(null);
+                    $timesheet->setInternalRate(null);
+                    $timesheet->setHourlyRate($dto->getHourlyRate());
                     $execute = true;
                 }
             }

--- a/src/Form/MultiUpdate/TimesheetMultiUpdate.php
+++ b/src/Form/MultiUpdate/TimesheetMultiUpdate.php
@@ -198,12 +198,16 @@ class TimesheetMultiUpdate extends AbstractType
 
         if ($options['include_rate']) {
             $builder
+                ->add('recalculateRates', YesNoType::class, [
+                    'label' => 'Recalculate rates', // FIXME translate me
+                ])
                 ->add('fixedRate', FixedRateType::class, [
                     'currency' => $currency,
                 ])
                 ->add('hourlyRate', HourlyRateType::class, [
                     'currency' => $currency,
-                ]);
+                ])
+            ;
         }
 
         $builder->add('entities', HiddenType::class, [

--- a/src/Form/MultiUpdate/TimesheetMultiUpdate.php
+++ b/src/Form/MultiUpdate/TimesheetMultiUpdate.php
@@ -199,7 +199,7 @@ class TimesheetMultiUpdate extends AbstractType
         if ($options['include_rate']) {
             $builder
                 ->add('recalculateRates', YesNoType::class, [
-                    'label' => 'Recalculate rates', // FIXME translate me
+                    'label' => 'label.recalculate_rates',
                 ])
                 ->add('fixedRate', FixedRateType::class, [
                     'currency' => $currency,

--- a/src/Form/MultiUpdate/TimesheetMultiUpdateDTO.php
+++ b/src/Form/MultiUpdate/TimesheetMultiUpdateDTO.php
@@ -30,6 +30,10 @@ class TimesheetMultiUpdateDTO extends MultiUpdateTableDTO
      */
     private $replaceTags = false;
     /**
+     * @var bool
+     */
+    private $recalculateRates = false;
+    /**
      * @var Customer|null
      */
     private $customer;
@@ -50,13 +54,13 @@ class TimesheetMultiUpdateDTO extends MultiUpdateTableDTO
      */
     private $exported = null;
     /**
-     * @var float
+     * @var float|null
      */
-    private $fixedRate;
+    private $fixedRate = null;
     /**
-     * @var float
+     * @var float|null
      */
-    private $hourlyRate;
+    private $hourlyRate = null;
 
     public function getCustomer(): ?Customer
     {
@@ -129,6 +133,18 @@ class TimesheetMultiUpdateDTO extends MultiUpdateTableDTO
     public function setExported(bool $exported): TimesheetMultiUpdateDTO
     {
         $this->exported = $exported;
+
+        return $this;
+    }
+
+    public function isRecalculateRates(): bool
+    {
+        return $this->recalculateRates;
+    }
+
+    public function setRecalculateRates(bool $recalculateRates): TimesheetMultiUpdateDTO
+    {
+        $this->recalculateRates = $recalculateRates;
 
         return $this;
     }

--- a/templates/export/pdf-layout.html.twig
+++ b/templates/export/pdf-layout.html.twig
@@ -278,9 +278,9 @@ mpdf-->
                         {% set entryRateInternal = '&ndash;' %}
                     {% endif %}
                     {% if showInternalRate %}
-                        <td class="cost">{{ entryRate }}</td>
+                        <td class="cost">{{ entryRateInternal }}</td>
                     {% endif %}
-                    <td class="cost">{{ entryRateInternal }}</td>
+                    <td class="cost">{{ entryRate }}</td>
                 {% endif %}
             </tr>
         {% endfor %}

--- a/translations/messages.de.xlf
+++ b/translations/messages.de.xlf
@@ -304,6 +304,10 @@
                 <source>help.rate_internal</source>
                 <target>Interner Verrechnungswert (wenn dieser nicht angegeben ist, wird der normale Satz verwendet)</target>
             </trans-unit>
+            <trans-unit id="label.recalculate_rates">
+                <source>label.recalculate_rates</source>
+                <target>Preise neu berechnen</target>
+            </trans-unit>
             <trans-unit id="label.language">
                 <source>label.language</source>
                 <target>Sprache</target>

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -304,6 +304,10 @@
                 <source>help.rate_internal</source>
                 <target>Internal costs (if this is not specified, the normal rate is used)</target>
             </trans-unit>
+            <trans-unit id="label.recalculate_rates">
+                <source>label.recalculate_rates</source>
+                <target>Recalculate rates</target>
+            </trans-unit>
             <trans-unit id="label.language">
                 <source>label.language</source>
                 <target>Language</target>


### PR DESCRIPTION
## Description

- Adds a checkbox to "Recalculate rates" for timesheets via bulk edit.
- Fixes the wrong displayed column in PDF export (internal and rate were switched for records)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I verified that my code applies to the guidelines (`composer kimai:code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [ ] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
