### PR TITLE
Fixed and added some Swedish translations

### DIFF
--- a/translations/about.sv.xlf
+++ b/translations/about.sv.xlf
@@ -32,7 +32,7 @@
             </trans-unit>
             <trans-unit id="special_thanks">
                 <source>special_thanks</source>
-                <target state="translated">Särskilt tack gå till …</target>
+                <target state="translated">Särskilt tack går till …</target>
             </trans-unit>
             <trans-unit id="library_authors">
                 <source>library_authors</source>

--- a/translations/actions.sv.xlf
+++ b/translations/actions.sv.xlf
@@ -40,15 +40,15 @@
             </trans-unit>
             <trans-unit id="customer">
                 <source>customer</source>
-                <target state="translated">Filter kunder</target>
+                <target state="translated">Filtrera kunder</target>
             </trans-unit>
             <trans-unit id="project">
                 <source>project</source>
-                <target state="translated">Filter projekt</target>
+                <target state="translated">Filtrera projekt</target>
             </trans-unit>
             <trans-unit id="activity">
                 <source>activity</source>
-                <target state="translated">Filter aktiviter</target>
+                <target state="translated">Filtrera aktiviter</target>
             </trans-unit>
             <trans-unit id="copy">
                 <source>copy</source>
@@ -68,7 +68,7 @@
             </trans-unit>
             <trans-unit id="create-timesheet">
                 <source>create-timesheet</source>
-                <target state="translated">Skapa tidsrapport</target>
+                <target state="translated">Skapa tidrapport</target>
             </trans-unit>
         </body>
     </file>

--- a/translations/daterangepicker.sv.xlf
+++ b/translations/daterangepicker.sv.xlf
@@ -16,15 +16,15 @@
             </trans-unit>
             <trans-unit id="daterangepicker.thisWeek">
                 <source>daterangepicker.thisWeek</source>
-                <target state="translated">Denna vecka</target>
+                <target state="translated">Denna veckan</target>
             </trans-unit>
             <trans-unit id="daterangepicker.lastMonth">
                 <source>daterangepicker.lastMonth</source>
-                <target state="translated">Förra måndagen</target>
+                <target state="translated">Förra månaden</target>
             </trans-unit>
             <trans-unit id="daterangepicker.thisMonth">
                 <source>daterangepicker.thisMonth</source>
-                <target state="translated">Denna Månad</target>
+                <target state="translated">Denna månaden</target>
             </trans-unit>
             <trans-unit id="daterangepicker.lastYear">
                 <source>daterangepicker.lastYear</source>
@@ -32,7 +32,7 @@
             </trans-unit>
             <trans-unit id="daterangepicker.thisYear">
                 <source>daterangepicker.thisYear</source>
-                <target state="translated">Detta år</target>
+                <target state="translated">Detta året</target>
             </trans-unit>
             <trans-unit id="daterangepicker.customRange">
                 <source>daterangepicker.customRange</source>

--- a/translations/email.sv.xlf
+++ b/translations/email.sv.xlf
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" target-language="sv" datatype="plaintext" original="email.en.xlf">
+        <body>
+            <trans-unit id="button_copy_url_to_browser">
+                <source>button_copy_url_to_browser</source>
+                <target state="translated">Om knappen inte fungerar, vänligen kopiera &amp; klistra in följande URL i din webbläsare: %url%</target>
+            </trans-unit>
+            <trans-unit id="automated_email_dont_answer">
+                <source>automated_email_dont_answer</source>
+                <target state="translated">Detta är ett auto genererat medelande. Var vänlig och svara inte, då det inte kommar att bli läst.</target>
+            </trans-unit>
+            <trans-unit id="registration.subject">
+                <source>registration.subject</source>
+                <target state="translated">Aktivera ditt konto</target>
+            </trans-unit>
+            <trans-unit id="registration.title">
+                <source>registration.title</source>
+                <target state="translated">Välkommen %username%</target>
+            </trans-unit>
+            <trans-unit id="registration.button">
+                <source>registration.button</source>
+                <target state="translated">Aktivera ditt konto</target>
+            </trans-unit>
+            <trans-unit id="registration.intro">
+                <source>registration.intro</source>
+                <target state="translated">Du har registrerat dig hos Kimai tidrapportering med mail addressen %email%. Nu behöver du aktivera ditt konto innom de närmaste timmarna, innan länken går ut och blir ogiltig.</target>
+            </trans-unit>
+            <trans-unit id="reset.subject">
+                <source>reset.subject</source>
+                <target state="translated">Återställ ditt lösenord</target>
+            </trans-unit>
+            <trans-unit id="reset.title">
+                <source>reset.title</source>
+                <target state="translated">Det kan hända ...</target>
+            </trans-unit>
+            <trans-unit id="reset.button">
+                <source>reset.button</source>
+                <target state="translated">Återställ ditt lösenord</target>
+            </trans-unit>
+            <trans-unit id="reset.intro">
+                <source>reset.intro</source>
+                <target state="translated">... så du glömde ditt lösenord? Oroa dig inte: Kimai hjälper dig att skapa ett nytt:</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/translations/exceptions.sv.xlf
+++ b/translations/exceptions.sv.xlf
@@ -4,11 +4,11 @@
         <body>
             <trans-unit id="access.denied">
                 <source>access.denied</source>
-                <target state="translated">Åtkomst nekas</target>
+                <target state="translated">Åtkomst nekad</target>
             </trans-unit>
             <trans-unit id="stacktrace">
                 <source>stacktrace</source>
-                <target state="translated">Ett problem uppstod</target>
+                <target state="translated">Ett problem uppstod här</target>
             </trans-unit>
             <trans-unit id="http_error.title">
                 <source>http_error.title</source>
@@ -21,29 +21,32 @@
             <trans-unit id="http_error.suggestion">
                 <source>http_error.suggestion</source>
                 <target state="translated">
-Ett oväntat fel inträffade, försök igen.
-                     Du kan ha hittat en bugg, så kontakta din administratör om problemet
-                     går inte bort efter att du försökt det igen.</target>
+                    Ett oväntat fel inträffade, försök igen.
+                    Om problemet kvarstår efter att du försökt igen, kontakta din administratör.
+                    Du kan ha hittat en bugg.</target>
             </trans-unit>
             <trans-unit id="http_error_404.description">
                 <source>http_error_404.description</source>
-                <target state="translated">Oj! Hittade inte sidan.</target>
+                <target state="translated">Oj! Sidan hittades inte</target>
             </trans-unit>
             <trans-unit id="http_error_404.suggestion">
                 <source>http_error_404.suggestion</source>
-                <target state="translated">Vi kunde inte hitta den sida du letade efter.
-                     Under tiden kan du återvända till din dashboard och börja om.
-</target>
+                <target state="translated">
+                    Vi kunde inte hitta sidan du letade efter.
+                    Under tiden kan du återvända till din dashboard och börja om.
+                </target>
             </trans-unit>
             <trans-unit id="http_error_403.description">
                 <source>http_error_403.description</source>
-                <target state="translated">Den här sidan är begränsad.</target>
+                <target state="translated">
+                    Den här sidan är begränsad.
+                </target>
             </trans-unit>
             <trans-unit id="http_error_403.suggestion">
                 <source>http_error_403.suggestion</source>
                 <target state="translated">
-Tyvärr, men du har inte tillräckligt med behörigheter för att se den här sidan.
-                     Snälla prata med din administratör om du tycker att det här är ett fel.</target>
+                    Tyvärr har du inte tillräckligt med behörigheter för att se den här sidan.
+                    Var vänlig och kontakta din administratör om du tycker att det här är ett fel.</target>
             </trans-unit>
         </body>
     </file>

--- a/translations/export.sv.xlf
+++ b/translations/export.sv.xlf
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" target-language="sv" datatype="plaintext" original="export.en.xlf">
+        <body>
+            <trans-unit id="default.pdf.twig">
+                <source>default.pdf.twig</source>
+                <target>Standard</target>
+            </trans-unit>
+            <trans-unit id="default-budget.pdf.twig">
+                <source>default-budget.pdf.twig</source>
+                <target>Med återstående budget</target>
+            </trans-unit>
+            <trans-unit id="default-internal.pdf.twig">
+                <source>default-internal.pdf.twig</source>
+                <target>Med interna kostnader</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/translations/flashmessages.sv.xlf
+++ b/translations/flashmessages.sv.xlf
@@ -20,15 +20,15 @@
             </trans-unit>
             <trans-unit id="timesheet.start.error">
                 <source>timesheet.start.error</source>
-                <target state="translated">Tidinspelning kunde inte startas</target>
+                <target state="translated">Tidsinspelning kunde inte startas</target>
             </trans-unit>
             <trans-unit id="timesheet.start.exceeded_limit">
                 <source>timesheet.start.exceeded_limit</source>
-                <target state="translated">Gränsen för aktiva tidsposter har uppnåtts, var god stoppa minst en körtidsmätning först.</target>
+                <target state="translated">Gränsen för aktiva tidsinspelningar har uppnåtts, var god stoppa minst en tidsinspelning först.</target>
             </trans-unit>
             <trans-unit id="timesheet.locked.warning">
                 <source>timesheet.locked.warning</source>
-                <target state="translated">Du håller på att ändra en exponerad post</target>
+                <target state="translated">Du håller på att ändra en exporterad post</target>
             </trans-unit>
             <trans-unit id="action.update.success">
                 <source>action.update.success</source>

--- a/translations/invoice-calculator.sv.xlf
+++ b/translations/invoice-calculator.sv.xlf
@@ -8,11 +8,11 @@
             </trans-unit>
             <trans-unit id="default">
                 <source>default</source>
-                <target state="translated">Ingångsbaserad - en mätning per gång per gång (standard)</target>
+                <target state="translated">Ingångsbaserad - en mätning per gång (standard)</target>
             </trans-unit>
             <trans-unit id="short">
                 <source>short</source>
-                <target state="translated">Timmar tillagd - endast en post</target>
+                <target state="translated">Timmar summerade - endast en post</target>
             </trans-unit>
             <trans-unit id="user">
                 <source>user</source>
@@ -21,6 +21,14 @@
             <trans-unit id="activity">
                 <source>activity</source>
                 <target state="translated">Aktivitet grupperad - en post per aktivitet</target>
+            </trans-unit>
+            <trans-unit id="project">
+                <source>project</source>
+                <target state="translated">Projekt grupperad - en post per projekt</target>
+            </trans-unit>
+            <trans-unit id="date">
+                <source>date</source>
+                <target state="translated">Datum grupperad - en post per dag (använder start datum)</target>
             </trans-unit>
         </body>
     </file>

--- a/translations/invoice-numbergenerator.sv.xlf
+++ b/translations/invoice-numbergenerator.sv.xlf
@@ -10,6 +10,10 @@
                 <source>date</source>
                 <target state="translated">Datum</target>
             </trans-unit>
+            <trans-unit id="default">
+                <source>default</source>
+                <target state="translated">Konfigurerat format</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/invoice-renderer.sv.xlf
+++ b/translations/invoice-renderer.sv.xlf
@@ -6,6 +6,10 @@
                 <source>label.invoice_renderer</source>
                 <target state="translated">Fakturadokument</target>
             </trans-unit>
+            <trans-unit id="help.upload">
+                <source>help.upload</source>
+                <target state="translated">Obs: redan exsiterande filer kommer att skrivas över. Tillåtna fil typer är: DOCX, ODS, XLSX.</target>
+            </trans-unit>
             <trans-unit id="default">
                 <source>default</source>
                 <target state="translated">Faktura (standard)</target>

--- a/translations/messages.sv.xlf
+++ b/translations/messages.sv.xlf
@@ -50,7 +50,7 @@
             </trans-unit>
             <trans-unit id="confirm">
                 <source>confirm</source>
-                <target state="translated">Utför</target>
+                <target state="translated">Bekräfta</target>
             </trans-unit>
 
             <!--
@@ -342,7 +342,7 @@
             </trans-unit>
             <trans-unit id="modal.columns.description">
                 <source>modal.columns.description</source>
-                <target state="translated">När du sparar de kolonner som inte är markerade kommer de att döljas och den här inställningen lagras i en webbläsarkaka. Om du tar bort dina cookies kommer inställningarna att återställas.</target>
+                <target state="translated">När du sparar de kolumner som inte är markerade kommer de att döljas och den här inställningen lagras i en webbläsarkaka. Om du tar bort dina cookies kommer inställningarna att återställas.</target>
             </trans-unit>
             <trans-unit id="label.fixedRate">
                 <source>label.fixedRate</source>
@@ -447,8 +447,8 @@
             </trans-unit>
             <trans-unit id="admin_project.short_stats">
                 <source>admin_project.short_stats</source>
-                <target state="translated">Projektet %project% för kunden %customer% har %activities% för närvarande %activities% 
-                     aktiviteter och %records% time-records, som räknas upp till totalt %duration%.
+                <target state="translated">Projektet %project% för kunden %customer% har för närvarande %activities% 
+                     aktiviteter och %records% tidrapporter, som summeras till %duration%.
                 </target>
             </trans-unit>
 
@@ -462,8 +462,8 @@
             <trans-unit id="admin_activity.short_stats">
                 <source>admin_activity.short_stats</source>
                 <target state="translated">
-                     För närvarande aktiviteten %activity% i projektet %project% för kunden %customer%
-                     har %records% tidsrekord, vilket räknas upp till totalt %duration%.
+                     För närvarande har aktiviteten %activity% i projektet %project% för kunden %customer%
+                     har %records% tidrapporter, vilket summeras till %duration%.
                      </target>
             </trans-unit>
 
@@ -525,8 +525,8 @@
             <trans-unit id="admin_customer.short_stats">
                 <source>admin_customer.short_stats</source>
                 <target state="translated">
-För närvarande kunden %customer% har %project% projekt med% aktivitet% aktiviteter, som räknas upp
-                     i %activity% tidposter till totalt %duration%.
+                    För närvarande har kunden %customer% %project% projekt med %activities% aktiviteter,
+                    med %records% tidrapporter som summeras till %duration%.
                 </target>
             </trans-unit>
 
@@ -560,8 +560,8 @@ För närvarande kunden %customer% har %project% projekt med% aktivitet% aktivit
             <trans-unit id="admin_user.short_stats">
                 <source>admin_user.short_stats</source>
                 <target state="translated">
-För närvarande har %user% användare %records% tidsrekord som räknas upp till totalt %duration%.
-                     </target>
+                    För närvarande har användaren %user% %records% tidrapporter som summeras till %duration%.
+                </target>
             </trans-unit>
 
             <!--
@@ -601,19 +601,19 @@ För närvarande har %user% användare %records% tidsrekord som räknas upp till
             -->
             <trans-unit id="stats.durationToday">
                 <source>stats.durationToday</source>
-                <target state="translated">Arbetstider idag</target>
+                <target state="translated">Arbetstimmar idag</target>
             </trans-unit>
             <trans-unit id="stats.durationWeek">
                 <source>stats.durationWeek</source>
-                <target state="translated">Arbetstid i veckan</target>
+                <target state="translated">Arbetstimmar denna veckan</target>
             </trans-unit>
             <trans-unit id="stats.durationMonth">
                 <source>stats.durationMonth</source>
-                <target state="translated">Arbetstid i den här månaden</target>
+                <target state="translated">Arbetstimmar denna månaden</target>
             </trans-unit>
             <trans-unit id="stats.durationYear">
                 <source>stats.durationYear</source>
-                <target state="translated">Arbetstid i det här året</target>
+                <target state="translated">Arbetstimmar detta  året</target>
             </trans-unit>
             <trans-unit id="stats.durationTotal">
                 <source>stats.durationTotal</source>
@@ -741,7 +741,7 @@ För närvarande har %user% användare %records% tidsrekord som räknas upp till
             </trans-unit>
             <trans-unit id="invoice.subtotal">
                 <source>invoice.subtotal</source>
-                <target>Subtotal</target>
+                <target>Nettobelopp</target>
             </trans-unit>
             <trans-unit id="invoice.tax">
                 <source>invoice.tax</source>
@@ -753,7 +753,7 @@ För närvarande har %user% användare %records% tidsrekord som räknas upp till
             </trans-unit>
             <trans-unit id="invoice.service_date">
                 <source>invoice.service_date</source>
-                <target state="translated">Inventaredatum</target>
+                <target state="translated">Arbetstillfälle</target>
             </trans-unit>
             <trans-unit id="label.amount">
                 <source>label.amount</source>
@@ -761,7 +761,7 @@ För närvarande har %user% användare %records% tidsrekord som räknas upp till
             </trans-unit>
             <trans-unit id="label.total_rate">
                 <source>label.total_rate</source>
-                <target state="translated">Totaleres</target>
+                <target state="translated">Belopp</target>
             </trans-unit>
             <trans-unit id="label.unit_price">
                 <source>label.unit_price</source>
@@ -777,11 +777,11 @@ För närvarande har %user% användare %records% tidsrekord som räknas upp till
             </trans-unit>
             <trans-unit id="invoice.signature_customer">
                 <source>invoice.signature_customer</source>
-                <target state="translated">Bekräftelse: Datum / Kunden namn / Signatur</target>
+                <target state="translated">Bekräftelse: Datum / Kundens namn / Signatur</target>
             </trans-unit>
             <trans-unit id="invoice.total_working_time">
                 <source>invoice.total_working_time</source>            
-                <target state="translated">Total varaktighet</target>
+                <target state="translated">Total arbetstid</target>
             </trans-unit>
             <trans-unit id="label.orderNumber">
                 <source>label.orderNumber</source>
@@ -805,7 +805,7 @@ För närvarande har %user% användare %records% tidsrekord som räknas upp till
             </trans-unit>
             <trans-unit id="export.subtitle">
                 <source>export.subtitle</source>
-                <target state="translated">Exportera tidsrapport till olika format</target>
+                <target state="translated">Exportera tidrapport till olika format</target>
             </trans-unit>
             <trans-unit id="export.period">
                 <source>export.period</source>
@@ -813,7 +813,7 @@ För närvarande har %user% användare %records% tidsrekord som räknas upp till
             </trans-unit>
             <trans-unit id="export.document_title">
                 <source>export.document_title</source>
-                <target state="translated">Förteckning över utgifter</target>
+                <target state="translated">Export av tidrapporter</target>
             </trans-unit>
             <trans-unit id="export.full_list">
                 <source>export.full_list</source>
@@ -905,7 +905,7 @@ För närvarande har %user% användare %records% tidsrekord som räknas upp till
             </trans-unit>
             <trans-unit id="timesheet.start">
                 <source>timesheet.start</source>
-                <target state="translated">Skapa ny tidpost</target>
+                <target state="translated">Skapa ny tidrapport</target>
             </trans-unit>
 
             <!--
@@ -925,7 +925,7 @@ För närvarande har %user% användare %records% tidsrekord som räknas upp till
             </trans-unit>
             <trans-unit id="entryState.exported">
                 <source>entryState.exported</source>
-                <target state="translated">Rennrad</target>
+                <target state="translated">Rensad</target>
             </trans-unit>
             <trans-unit id="entryState.not_exported">
                 <source>entryState.not_exported</source>

--- a/translations/plugins.sv.xlf
+++ b/translations/plugins.sv.xlf
@@ -4,7 +4,7 @@
         <body>
             <trans-unit id="plugins.title">
                 <source>plugins.title</source>
-                <target state="translated">Pluginer</target>
+                <target state="translated">Plugins</target>
             </trans-unit>
             <trans-unit id="plugins.subtitle">
                 <source>plugins.subtitle</source>
@@ -12,7 +12,7 @@
             </trans-unit>
             <trans-unit id="plugin.none_installed">
                 <source>plugin.none_installed</source>
-                <target state="translated">Du har inget plugin installerat än.</target>
+                <target state="translated">Du har inga plugin installerade än.</target>
             </trans-unit>
             <trans-unit id="plugin.marketplace">
                 <source>plugin.marketplace</source>

--- a/translations/system-configuration.sv.xlf
+++ b/translations/system-configuration.sv.xlf
@@ -8,7 +8,7 @@
             </trans-unit>
             <trans-unit id="subtitle">
                 <source>subtitle</source>
-                <target state="translated">Ändra globala konfigurationer av din tidsredovisning</target>
+                <target state="translated">Ändra globala konfigurationer för din tidsredovisning</target>
             </trans-unit>
             <trans-unit id="timesheet">
                 <source>timesheet</source>
@@ -40,7 +40,7 @@
             </trans-unit>
             <trans-unit id="label.timesheet.mode_duration_only">
                 <source>label.timesheet.mode_duration_only</source>
-                <target state="translated">Endast varaktighet: ersätter slutdatumsfältet med en ingång för varaktighet</target>
+                <target state="translated">Endast varaktighet: ersätter slutdatumsfältet med ett fält för varaktighet</target>
             </trans-unit>
             <trans-unit id="label.timesheet.mode_duration_fixed_begin">
                 <source>label.timesheet.mode_duration_fixed_begin</source>
@@ -48,7 +48,7 @@
             </trans-unit>
             <trans-unit id="label.timesheet.mode_punch">
                 <source>label.timesheet.mode_punch</source>
-                <target state="translated">[Tidsklocka] -användaren kan starta och stoppa poster, men inte redigera tiderna eller varaktigheten</target>
+                <target state="translated">[Tidsklocka] -användaren kan starta och stoppa tidsinspelningar, men inte redigera tiderna eller varaktigheten</target>
             </trans-unit>
             <trans-unit id="label.timesheet.rules.allow_future_times">
                 <source>label.timesheet.rules.allow_future_times</source>
@@ -56,11 +56,11 @@
             </trans-unit>
             <trans-unit id="label.timesheet.active_entries.hard_limit">
                 <source>label.timesheet.active_entries.hard_limit</source>
-                <target state="translated">Tillåtet antal samtidiga körtidsposter</target>
+                <target state="translated">Tillåtet antal aktiva tidsinspelningar</target>
             </trans-unit>
             <trans-unit id="label.timesheet.active_entries.soft_limit">
                 <source>label.timesheet.active_entries.soft_limit</source>
-                <target state="translated">Antal körtidsposter från vilka en varning visas</target>
+                <target state="translated">Antal aktiva tidsinspelningar då en varning ska visas</target>
             </trans-unit>
             <trans-unit id="label.calendar.week_numbers">
                 <source>label.calendar.week_numbers</source>
@@ -85,6 +85,34 @@
             <trans-unit id="label.calendar.visibleHours.end">
                 <source>label.calendar.visibleHours.end</source>
                 <target state="translated">Slut på synligt tidsintervall</target>
+            </trans-unit>
+            <trans-unit id="Monday">
+                <source>Monday</source>
+                <target state="translated">Måndag</target>
+            </trans-unit>
+            <trans-unit id="Tuesday">
+                <source>Tuesday</source>
+                <target state="translated">Tisdag</target>
+            </trans-unit>
+            <trans-unit id="Wednesday">
+                <source>Wednesday</source>
+                <target state="translated">Onsdag</target>
+            </trans-unit>
+            <trans-unit id="Thursday">
+                <source>Thursday</source>
+                <target state="translated">Torsdag</target>
+            </trans-unit>
+            <trans-unit id="Friday">
+                <source>Friday</source>
+                <target state="translated">Fredag</target>
+            </trans-unit>
+            <trans-unit id="Saturday">
+                <source>Saturday</source>
+                <target state="translated">Lördag</target>
+            </trans-unit>
+            <trans-unit id="Sunday">
+                <source>Sunday</source>
+                <target state="translated">Söndag</target>
             </trans-unit>
 
         </body>

--- a/translations/teams.sv.xlf
+++ b/translations/teams.sv.xlf
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" target-language="sv" datatype="plaintext" original="teams.en.xlf">
+        <body>
+            <trans-unit id="teams.title">
+                <source>teams.title</source>
+                <target state="translated">Arbetslag</target>
+            </trans-unit>
+            <trans-unit id="teams.project_access">
+                <source>teams.project_access</source>
+                <target state="translated">Tillåt åtkomst till projekt</target>
+            </trans-unit>
+            <trans-unit id="teams.customer_access">
+                <source>teams.customer_access</source>
+                <target state="translated">Tillåt åtkomst till kunder</target>
+            </trans-unit>
+            <trans-unit id="team.visibility_global">
+                <source>team.visibility_global</source>
+                <target state="translated">Synlig för alla, efter som inget arbetslag är tilldelat än.</target>
+            </trans-unit>
+            <trans-unit id="team.visibility_restricted">
+                <source>team.visibility_restricted</source>
+                <target state="translated">Bara synlig för följande arbetslag och alla administratörer.</target>
+            </trans-unit>
+            <trans-unit id="team.project_visibility_inherited">
+                <source>team.project_visibility_inherited</source>
+                <target state="translated">Projektet har begränsad tillgång, eftersom arbetslags behörigheter är inställda för kunden.</target>
+            </trans-unit>
+            <trans-unit id="team.create_default">
+                <source>team.create_default</source>
+                <target state="translated">Skapa ett nytt arbetslag för att begränsa tillgång</target>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/translations/validators.sv.xlf
+++ b/translations/validators.sv.xlf
@@ -4,7 +4,7 @@
         <body>
             <trans-unit id="This value is not a valid role.">
                 <source>This value is not a valid role.</source>
-                <target state="translated">Detta värde är inte en giltig roll.</target>
+                <target state="translated">Detta värdet är inte en giltig roll.</target>
             </trans-unit>
             <trans-unit id="End date must not be earlier then start date.">
                 <source>End date must not be earlier then start date.</source>
@@ -12,7 +12,11 @@
             </trans-unit>
             <trans-unit id="The begin date cannot be in the future.">
                 <source>The begin date cannot be in the future.</source>
-                <target state="translated">Slutdatumet får inte vara tidigare än startdatumet.</target>
+                <target state="translated">Startdatumet får inte vara i framtiden.</target>
+            </trans-unit>
+            <trans-unit id="You must select at least one user or team.">
+                <source>You must select at least one user or team.</source>
+                <target state="translated">Du måste välja minst en anändare eller arbetslag</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
Hi!

I noticed that some of the Swedish translations for Kimai where a bit weird, so i have looked over the translations and fixed some errors.
I have also added some missing translations , for example I have translated the English email.en.xlf file to Swedish.


## Description
I have looked over the Swedish translations for Kimai2 and added some new translations

## Types of changes
- [x] Fixed weird Swedish translations
- [x] Added some missing translations

## Checklist
- [x] I verified that my code applies to the guidelines (`composer kimai:code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
