### PR TITLE
invoice: allow to increase number, customer specific counter

### DIFF
--- a/src/Invoice/NumberGenerator/ConfigurableNumberGenerator.php
+++ b/src/Invoice/NumberGenerator/ConfigurableNumberGenerator.php
@@ -85,23 +85,6 @@ final class ConfigurableNumberGenerator implements NumberGeneratorInterface
                 }
             }
 
-            /*
-            // number format
-            if (substr_count($tmp, '+') !== 0) {
-                $parts = explode('+', $tmp);
-                $tmp = $parts[0];
-                $increaseBy = \intval($parts[1]);
-                if ((string) $formatterLength !== $parts[1]) {
-                    $formatterLength = null;
-                }
-            }
-
-            if (substr_count($tmp, ',') !== 0) {
-                $parts = explode(',', $tmp);
-                $tmp = $parts[0];
-                $formatterLength = \intval($parts[1]);
-            }
-*/
             switch ($tmp) {
                 case 'Y':
                     $partialResult = $invoiceDate->format('Y');
@@ -131,6 +114,24 @@ final class ConfigurableNumberGenerator implements NumberGeneratorInterface
                     $partialResult = $invoiceDate->format('ymd');
                     break;
 
+                // for customer
+                case 'cc':
+                    $partialResult = $this->repository->getCounterForAllTime($invoiceDate, $this->model->getCustomer()) + 1;
+                    break;
+
+                case 'ccy':
+                    $partialResult = $this->repository->getCounterForYear($invoiceDate, $this->model->getCustomer()) + 1;
+                    break;
+
+                case 'ccm':
+                    $partialResult = $this->repository->getCounterForMonth($invoiceDate, $this->model->getCustomer()) + 1;
+                    break;
+
+                case 'ccd':
+                    $partialResult = $this->repository->getCounterForDay($invoiceDate, $this->model->getCustomer()) + 1;
+                    break;
+
+                // across all invoices
                 case 'c':
                     $partialResult = $this->repository->getCounterForAllTime($invoiceDate) + $increaseBy;
                     break;

--- a/src/Repository/InvoiceRepository.php
+++ b/src/Repository/InvoiceRepository.php
@@ -9,6 +9,7 @@
 
 namespace App\Repository;
 
+use App\Entity\Customer;
 use App\Entity\Invoice;
 use App\Entity\User;
 use App\Repository\Loader\InvoiceLoader;
@@ -35,7 +36,7 @@ class InvoiceRepository extends EntityRepository
         $entityManager->flush();
     }
 
-    private function getCounterFor(\DateTime $start, \DateTime $end): int
+    private function getCounterFor(\DateTime $start, \DateTime $end, ?Customer $customer = null): int
     {
         $qb = $this->getEntityManager()->createQueryBuilder();
         $qb->select('count(i.createdAt) as counter')
@@ -46,6 +47,13 @@ class InvoiceRepository extends EntityRepository
             ->setParameter('end', $end)
         ;
 
+        if (null !== $customer) {
+            $qb
+                ->andWhere($qb->expr()->eq('i.customer', ':customer'))
+                ->setParameter('customer', $customer)
+            ;
+        }
+
         $result = $qb->getQuery()->getOneOrNullResult();
 
         if ($result === null) {
@@ -55,32 +63,36 @@ class InvoiceRepository extends EntityRepository
         return $result['counter'];
     }
 
-    public function getCounterForDay(\DateTime $date): int
+    public function getCounterForDay(\DateTime $date, ?Customer $customer = null): int
     {
         $start = (clone $date)->setTime(0, 0, 0);
         $end = (clone $date)->setTime(23, 59, 59);
 
-        return $this->getCounterFor($start, $end);
+        return $this->getCounterFor($start, $end, $customer);
     }
 
-    public function getCounterForMonth(\DateTime $date): int
+    public function getCounterForMonth(\DateTime $date, ?Customer $customer = null): int
     {
         $start = (clone $date)->setDate((int) $date->format('Y'), (int) $date->format('n'), 1)->setTime(0, 0, 0);
         $end = (clone $date)->setDate((int) $date->format('Y'), (int) $date->format('n'), (int) $date->format('t'))->setTime(23, 59, 59);
 
-        return $this->getCounterFor($start, $end);
+        return $this->getCounterFor($start, $end, $customer);
     }
 
-    public function getCounterForYear(\DateTime $date): int
+    public function getCounterForYear(\DateTime $date, ?Customer $customer = null): int
     {
         $start = (clone $date)->setDate((int) $date->format('Y'), 1, 1)->setTime(0, 0, 0);
         $end = (clone $date)->setDate((int) $date->format('Y'), 12, 31)->setTime(23, 59, 59);
 
-        return $this->getCounterFor($start, $end);
+        return $this->getCounterFor($start, $end, $customer);
     }
 
-    public function getCounterForAllTime(\DateTime $date): int
+    public function getCounterForAllTime(\DateTime $date, ?Customer $customer = null): int
     {
+        if (null !== $customer) {
+            return $this->count(['customer' => $customer]);
+        }
+
         return $this->count([]);
     }
 

--- a/tests/Invoice/NumberGenerator/ConfigurableNumberGeneratorTest.php
+++ b/tests/Invoice/NumberGenerator/ConfigurableNumberGeneratorTest.php
@@ -10,6 +10,7 @@
 namespace App\Tests\Invoice\NumberGenerator;
 
 use App\Configuration\SystemConfiguration;
+use App\Entity\Customer;
 use App\Invoice\InvoiceModel;
 use App\Invoice\NumberGenerator\ConfigurableNumberGenerator;
 use App\Repository\InvoiceRepository;
@@ -74,12 +75,19 @@ class ConfigurableNumberGeneratorTest extends TestCase
             ['{M,3}', '0' . $invoiceDate->format('m'), $invoiceDate],
             ['{M,#}', $invoiceDate->format('m'), $invoiceDate], // invalid formatter length
             ['{D,3}', '0' . $invoiceDate->format('d'), $invoiceDate],
+            // counter across all invoices
             ['{c,2}', '02', $invoiceDate],
             ['{cy,2}', '02', $invoiceDate],
             ['{cm,2}', '02', $invoiceDate],
             ['{cd,2}', '02', $invoiceDate],
+            // customer specific
+            ['{cc,2}', '02', $invoiceDate],
+            ['{ccy,2}', '02', $invoiceDate],
+            ['{ccm,2}', '02', $invoiceDate],
+            ['{ccd,2}', '02', $invoiceDate],
+            // with incrementing counter
             ['{c+13,2}', '14', $invoiceDate],
-            ['{cy+1,2}', '02', $invoiceDate],
+            ['{ccy+1,2}', '02', $invoiceDate],
             ['{cm+-1,2}', '02', $invoiceDate], // negative is not allowed and set to 1
             ['{cm+0,2}', '02', $invoiceDate], // zero is not allowed and set to 1
             ['{cd+111,2}', '112', $invoiceDate],
@@ -106,6 +114,7 @@ class ConfigurableNumberGeneratorTest extends TestCase
         $sut = $this->getSut($format);
         $model = new InvoiceModel(new DebugFormatter());
         $model->setInvoiceDate($invoiceDate);
+        $model->setCustomer(new Customer());
         $sut->setModel($model);
 
         $this->assertEquals($expectedInvoiceNumber, $sut->getInvoiceNumber());

--- a/tests/Invoice/NumberGenerator/ConfigurableNumberGeneratorTest.php
+++ b/tests/Invoice/NumberGenerator/ConfigurableNumberGeneratorTest.php
@@ -55,6 +55,7 @@ class ConfigurableNumberGeneratorTest extends TestCase
 
         return [
             // simple tests for single calls
+            ['my-{date} is+cool,really', 'my-' . $invoiceDate->format('ymd') . ' is+cool,really', $invoiceDate],
             ['{date}', $invoiceDate->format('ymd'), $invoiceDate],
             ['{Y}', $invoiceDate->format('Y'), $invoiceDate],
             ['{y}', $invoiceDate->format('y'), $invoiceDate],
@@ -77,6 +78,16 @@ class ConfigurableNumberGeneratorTest extends TestCase
             ['{cy,2}', '02', $invoiceDate],
             ['{cm,2}', '02', $invoiceDate],
             ['{cd,2}', '02', $invoiceDate],
+            ['{c+13,2}', '14', $invoiceDate],
+            ['{cy+1,2}', '02', $invoiceDate],
+            ['{cm+-1,2}', '02', $invoiceDate], // negative is not allowed and set to 1
+            ['{cm+0,2}', '02', $invoiceDate], // zero is not allowed and set to 1
+            ['{cd+111,2}', '112', $invoiceDate],
+            ['{c+13}', '14', $invoiceDate],
+            ['{cy+1}', '2', $invoiceDate],
+            ['{cm+-1}', '2', $invoiceDate], // negative is not allowed and set to 1
+            ['{cm+0}', '2', $invoiceDate], // zero is not allowed and set to 1
+            ['{cd+111}', '112', $invoiceDate],
             // mixing identifiers
             ['{Y}{cy}', $invoiceDate->format('Y') . '2', $invoiceDate],
             ['{Y}{cy}{m}', $invoiceDate->format('Y') . '2' . $invoiceDate->format('n'), $invoiceDate],


### PR DESCRIPTION
## Description

Added customer specific counter variables: 
- `{cc}` - customer counter all time
- `{ccy}` - customer counter for this year
- `{ccm}` - customer counter for this month
- `{ccd}` - customer counter for this day

Fixes #1554

Allow to add a increment to the calculated invoice number.
Works for `c` and `cy` and `cm` and `cd` and `cc` and `ccy` and `ccm` and `ccd`.
You can add a `+x` eg `+73` to the format: `{cy+73}` or formatted `{cy+73,3}`.

Fixes #1673 


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [x] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
