### PR TITLE
disable headings in markdown

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -16,6 +16,7 @@ Perform EACH version specific task between your version and the new one, otherwi
 - Sessions are now stored in the database (all users have to re-login after upgrade)
 - New permissions: `lockdown_grace_timesheet`, `lockdown_override_timesheet`, `view_all_data`
 - Fixed team permissions on user queries: depending on your previous team & permission setup your users might see less data (SUPER_ADMINS see all data, but new: ADMINS only see all data if they own the `view_all_data` permission)
+- Markdown does not support headings any more, text like `# foo` is not converted to `<h1 id="foo">foo</h1>` anymore
 
 ### Developer
 

--- a/src/Controller/ProfileController.php
+++ b/src/Controller/ProfileController.php
@@ -20,6 +20,7 @@ use App\Form\UserRolesType;
 use App\Form\UserTeamsType;
 use App\Repository\TeamRepository;
 use App\Repository\TimesheetRepository;
+use App\Utils\LocaleSettings;
 use Doctrine\Common\Collections\ArrayCollection;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -69,7 +70,7 @@ class ProfileController extends AbstractController
      * @Route(path="/{username}", name="user_profile", methods={"GET"})
      * @Security("is_granted('view', profile)")
      */
-    public function indexAction(User $profile, TimesheetRepository $repository)
+    public function indexAction(User $profile, TimesheetRepository $repository, LocaleSettings $localeSettings)
     {
         $userStats = $repository->getUserStatistics($profile);
         $monthlyStats = $repository->getMonthlyStats($profile);
@@ -79,6 +80,7 @@ class ProfileController extends AbstractController
             'user' => $profile,
             'stats' => $userStats,
             'years' => $monthlyStats,
+            'stat_date_format' => $localeSettings->getDatePickerFormat(),
         ];
 
         return $this->render('user/stats.html.twig', $viewVars);

--- a/src/Controller/ReportingController.php
+++ b/src/Controller/ReportingController.php
@@ -64,19 +64,21 @@ final class ReportingController extends AbstractController
         $values->setDate($this->dateTimeFactory->getStartOfMonth());
 
         $form = $this->createForm(MonthByUserForm::class, $values, [
-            'method' => 'POST',
             'include_user' => $this->isGranted('view_other_timesheet') && $user->hasTeamAssignment(),
         ]);
 
-        $form->handleRequest($request);
+        $form->submit($request->query->all(), false);
 
-        if ($form->isSubmitted() && !$form->isValid()) {
+        if ($values->getUser() === null) {
             $values->setUser($user);
-            $values->setDate($this->dateTimeFactory->getStartOfMonth());
         }
 
         if ($user !== $values->getUser() && !$this->isGranted('view_other_timesheet')) {
             throw new AccessDeniedException('User is not allowed to see other users timesheet');
+        }
+
+        if ($values->getDate() === null) {
+            $values->setDate($this->dateTimeFactory->getStartOfMonth());
         }
 
         $start = $values->getDate();
@@ -124,13 +126,15 @@ final class ReportingController extends AbstractController
         $values = new MonthlyUserList();
         $values->setDate($this->dateTimeFactory->getStartOfMonth());
 
-        $form = $this->createForm(MonthlyUserListForm::class, $values, [
-            'method' => 'POST',
-        ]);
+        $form = $this->createForm(MonthlyUserListForm::class, $values, []);
 
-        $form->handleRequest($request);
+        $form->submit($request->query->all(), false);
 
         if ($form->isSubmitted() && !$form->isValid()) {
+            $values->setDate($this->dateTimeFactory->getStartOfMonth());
+        }
+
+        if ($values->getDate() === null) {
             $values->setDate($this->dateTimeFactory->getStartOfMonth());
         }
 

--- a/src/Form/Type/MonthPickerType.php
+++ b/src/Form/Type/MonthPickerType.php
@@ -20,6 +20,8 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Custom form field type to select a month via picker and select previous and next month.
+ *
+ * Always falls back to the current month if none or an invalid date is given.
  */
 final class MonthPickerType extends AbstractType
 {
@@ -67,6 +69,7 @@ final class MonthPickerType extends AbstractType
             $date = $this->dateTime->getStartOfMonth();
         }
 
+        $view->vars['month'] = $date;
         $view->vars['previousMonth'] = (clone $date)->modify('-1 month');
         $view->vars['nextMonth'] = (clone $date)->modify('+1 month');
         $view->vars['momentFormat'] = (new MomentFormatConverter())->convert($this->localeSettings->getDateTypeFormat());

--- a/src/Reporting/MonthByUserForm.php
+++ b/src/Reporting/MonthByUserForm.php
@@ -18,6 +18,16 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class MonthByUserForm extends AbstractType
 {
     /**
+     * Simplify cross linking between pages by removing the block prefix.
+     *
+     * @return null|string
+     */
+    public function getBlockPrefix()
+    {
+        return null;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
@@ -37,6 +47,8 @@ class MonthByUserForm extends AbstractType
         $resolver->setDefaults([
             'data_class' => MonthByUser::class,
             'include_user' => false,
+            'csrf_protection' => false,
+            'method' => 'GET',
         ]);
     }
 }

--- a/src/Reporting/MonthlyUserListForm.php
+++ b/src/Reporting/MonthlyUserListForm.php
@@ -17,6 +17,16 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 class MonthlyUserListForm extends AbstractType
 {
     /**
+     * Simplify cross linking between pages by removing the block prefix.
+     *
+     * @return null|string
+     */
+    public function getBlockPrefix()
+    {
+        return null;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function buildForm(FormBuilderInterface $builder, array $options)
@@ -31,6 +41,8 @@ class MonthlyUserListForm extends AbstractType
     {
         $resolver->setDefaults([
             'data_class' => MonthlyUserList::class,
+            'csrf_protection' => false,
+            'method' => 'GET',
         ]);
     }
 }

--- a/src/Utils/LocaleHelper.php
+++ b/src/Utils/LocaleHelper.php
@@ -137,13 +137,18 @@ final class LocaleHelper
         if (null === $this->moneyFormatterNoCurrency) {
             // if anyone knows a better way of achieving this, please let me know!
             $this->moneyFormatterNoCurrency = new NumberFormatter($this->locale, NumberFormatter::CURRENCY);
-            $pattern = $this->moneyFormatterNoCurrency->getPattern();
-            $pattern = str_replace('¤ ', '¤', $pattern);
-            $pattern = str_replace(' ¤', '¤', $pattern);
-            $this->moneyFormatterNoCurrency->setPattern($pattern);
-            $this->moneyFormatterNoCurrency->setSymbol(NumberFormatter::CURRENCY_SYMBOL, '');
-            $this->moneyFormatterNoCurrency->setSymbol(NumberFormatter::CURRENCY_CODE, '');
+
+            $this->moneyFormatterNoCurrency->setTextAttribute(NumberFormatter::CURRENCY_CODE, '');
             $this->moneyFormatterNoCurrency->setSymbol(NumberFormatter::INTL_CURRENCY_SYMBOL, '');
+            $this->moneyFormatterNoCurrency->setSymbol(NumberFormatter::CURRENCY_SYMBOL, '');
+
+            // don't understand why this is needed, I'd say this shouldn't be necessary after the above calls
+            // even worse: the logic changes either between PHP/ICU versions
+            $pattern = $this->moneyFormatterNoCurrency->getPattern();
+            $pattern = str_replace(['¤ ', ' ¤', '-¤', ' XXX', 'XXX '], '¤', $pattern);
+            $pattern = str_replace('XXX', '¤', $pattern);
+            $pattern = str_replace('¤', '', $pattern);
+            $this->moneyFormatterNoCurrency->setPattern($pattern);
         }
 
         return $this->moneyFormatterNoCurrency;

--- a/src/Utils/ParsedownExtension.php
+++ b/src/Utils/ParsedownExtension.php
@@ -20,8 +20,6 @@ class ParsedownExtension extends \Parsedown
      * Overwritten to prevent # to show up as headings for two reasons:
      * - Hashes are often used to cross link issues in other systems
      * - Headings should not occur in time record listings
-     *
-     * @var \string[][]
      */
     protected $BlockTypes = [
         '*' => ['Rule', 'List'],
@@ -50,8 +48,6 @@ class ParsedownExtension extends \Parsedown
 
     /**
      * Overwritten to add support for file:///
-     *
-     * @var string[]
      */
     protected $safeLinksWhitelist = [
         'file:///',

--- a/src/Utils/ParsedownExtension.php
+++ b/src/Utils/ParsedownExtension.php
@@ -17,7 +17,41 @@ class ParsedownExtension extends \Parsedown
     private $ids = [];
 
     /**
+     * Overwritten to prevent # to show up as headings for two reasons:
+     * - Hashes are often used to cross link issues in other systems
+     * - Headings should not occur in time record listings
+     *
+     * @var \string[][]
+     */
+    protected $BlockTypes = [
+        '*' => ['Rule', 'List'],
+        '+' => ['List'],
+        '-' => ['SetextHeader', 'Table', 'Rule', 'List'],
+        '0' => ['List'],
+        '1' => ['List'],
+        '2' => ['List'],
+        '3' => ['List'],
+        '4' => ['List'],
+        '5' => ['List'],
+        '6' => ['List'],
+        '7' => ['List'],
+        '8' => ['List'],
+        '9' => ['List'],
+        ':' => ['Table'],
+        '<' => ['Comment', 'Markup'],
+        '=' => ['SetextHeader'],
+        '>' => ['Quote'],
+        '[' => ['Reference'],
+        '_' => ['Rule'],
+        '`' => ['FencedCode'],
+        '|' => ['Table'],
+        '~' => ['FencedCode'],
+    ];
+
+    /**
      * Overwritten to add support for file:///
+     *
+     * @var string[]
      */
     protected $safeLinksWhitelist = [
         'file:///',

--- a/templates/form/kimai-theme.html.twig
+++ b/templates/form/kimai-theme.html.twig
@@ -52,7 +52,7 @@
             <i class="{{ 'left'|icon }}"></i>
         </a>
         <a class="btn btn-default" href="#" onclick="return false;">
-            <span id="{{ form.vars.id }}_month_name">{{ data|month_name|trans ~ ' '  ~ data|date_format('Y') }}</span>
+            <span id="{{ form.vars.id }}_month_name">{{ month|month_name|trans ~ ' '  ~ month|date_format('Y') }}</span>
         </a>
         <a class="btn btn-default btn-right" href="#" onclick="$('#{{ form.vars.id }}').val('{{nextMonth|date_short}}').change()">
             <i class="{{ 'right'|icon }}"></i>

--- a/templates/user/actions.html.twig
+++ b/templates/user/actions.html.twig
@@ -58,6 +58,7 @@
     {% set actions = {} %}
 
     {% if user.id is not empty %}
+        {% set view_other = is_granted('view_other_timesheet') %}
         {% if is_granted('view', user) %}
             {% set actions = actions|merge({'profile-stats': {'url': path('user_profile', {'username' : user.username})}}) %}
         {% endif %}
@@ -70,7 +71,12 @@
         {% if actions|length > 0 %}
             {% set actions = actions|merge({'divider': null}) %}
         {% endif %}
-        {% if is_granted('view_other_timesheet') and user.enabled %}
+        {% if is_granted('view_reporting') %}
+            {% if view_other or app.user.id == user.id %}
+                {% set actions = actions|merge({'report': path('report_user_month', {'user': user.id})}) %}
+            {% endif %}
+        {% endif %}
+        {% if view_other and user.enabled %}
             {% set actions = actions|merge({'timesheet': path('admin_timesheet', {'users': [user.id]})}) %}
         {% endif %}
         {% if view == 'index' and is_granted('delete', user) %}

--- a/templates/user/stats.html.twig
+++ b/templates/user/stats.html.twig
@@ -49,6 +49,16 @@
                         }
                     }
                 }
+                {%- if is_granted('view_reporting') and (app.user.id == user.id or is_granted('view_other_timesheet')) -%}
+                ,
+                onClick: function(event, elements) {
+                    var element = elements[0];
+                    var month = this.data.datasets[0].monthData[element._index];
+                    var formattedMonth = moment(month).format('{{ stat_date_format }}');
+                    var reportUrl = '{{ path('report_user_month', {'user': user.id, 'date': 'XXXXX'})|raw }}'.replace('XXXXX', formattedMonth);
+                    document.location = reportUrl;
+                }
+            {% endif %}
             };
         }
     </script>
@@ -58,7 +68,6 @@
         {% embed '@AdminLTE/Widgets/box-widget.html.twig' %}
             {% block box_title %}{{ year }}{% endblock %}
             {% block box_body %}
-
                 <div class="chart">
                     <canvas id="userProfileChart{{ year }}" style="height: {{ kimai_context.chart.height }}px;"></canvas>
                 </div>
@@ -77,20 +86,24 @@
                                         {% if not loop.last %},{% endif %}
                                         {% endfor %}
                                     ],
-                                    realData        : [
+                                    realData: [
                                         {% for month in yearStat.months %}
                                         '{{ month.totalDuration|duration }}'
                                         {% if not loop.last %},{% endif %}
                                         {% endfor %}
-                                    ]
+                                    ],
+                                    monthData: [
+                                        {% for month in yearStat.months %}
+                                        '{{ yearStat.year }}-{{ month.month|length == 1 ? '0'~ month.month : month.month }}-01'
+                                        {% if not loop.last %},{% endif %}
+                                        {% endfor %}
+                                    ],
                                 }
                             ]
                         };
 
-                        var userProfileChartCanvas{{ year }} = $("#userProfileChart{{ year }}").get(0).getContext("2d");
-
                         var userProfileChart{{ year }} = new Chart(
-                            userProfileChartCanvas{{ year }}, {
+                            $("#userProfileChart{{ year }}").get(0).getContext("2d"), {
                                 type: 'bar',
                                 data: userProfileChartData{{ year }},
                                 options: userProfileChartOptions()

--- a/tests/Twig/MarkdownExtensionTest.php
+++ b/tests/Twig/MarkdownExtensionTest.php
@@ -38,7 +38,7 @@ class MarkdownExtensionTest extends TestCase
         $config = new TimesheetConfiguration($loader, ['markdown_content' => true]);
         $sut = new MarkdownExtension(new Markdown(), $config);
         $this->assertEquals('<p><em>test</em></p>', $sut->markdownToHtml('*test*'));
-        $this->assertEquals('<h1 id="foobar">foobar</h1>', $sut->markdownToHtml('# foobar'));
+        $this->assertEquals('<p># foobar</p>', $sut->markdownToHtml('# foobar'));
     }
 
     public function testTimesheetContent()

--- a/tests/Utils/MarkdownTest.php
+++ b/tests/Utils/MarkdownTest.php
@@ -36,7 +36,7 @@ class MarkdownTest extends TestCase
 <a href="file:///home/kimai/images/beautiful-flower.png" target="_blank">file:///home/kimai/images/beautiful-flower.png</a></p>
 <p>sdfsdf <a href="#test-1">asdfasdf</a> asdfasdf</p>
 <h1 id="test-1">test</h1>
-<p>aasdfasdf<br />
+ <p>aasdfasdf<br />
 1111<br />
 222</p>
 EOT;

--- a/tests/Utils/MarkdownTest.php
+++ b/tests/Utils/MarkdownTest.php
@@ -22,21 +22,21 @@ class MarkdownTest extends TestCase
     {
         $sut = new Markdown();
         $this->assertEquals('<p><em>test</em></p>', $sut->toHtml('*test*'));
-        $this->assertEquals('<h1 id="foobar">foobar</h1>', $sut->toHtml('# foobar'));
+        $this->assertEquals('<p># foobar</p>', $sut->toHtml('# foobar'));
         $html = <<<'EOT'
 <p>foo bar</p>
 <ul>
 <li>sdfasdfasdf</li>
 <li>asdfasdfasdf</li>
 </ul>
-<h1 id="test">test</h1>
-<p>asdfasdfa</p>
+<p># test<br />
+asdfasdfa</p>
 <pre><code>ssdfsdf</code></pre>
 <p><a href="http://example.com/foo-bar.html" target="_blank">http://example.com/foo-bar.html</a><br />
 <a href="file:///home/kimai/images/beautiful-flower.png" target="_blank">file:///home/kimai/images/beautiful-flower.png</a></p>
 <p>sdfsdf <a href="#test-1">asdfasdf</a> asdfasdf</p>
-<h1 id="test-1">test</h1>
- <p>aasdfasdf<br />
+<p># test<br />
+aasdfasdf<br />
 1111<br />
 222</p>
 EOT;
@@ -70,10 +70,10 @@ EOT;
         $sut = new Markdown();
 
         $html = <<<'EOT'
-<h1 id="test">test</h1>
-<h2 id="test-1">test</h2>
-<h3 id="test-2">test</h3>
-<h1 id="test-3">test</h1>
+<p># test<br />
+## test<br />
+### test<br />
+# test</p>
 EOT;
 
         $markdown = <<<EOT


### PR DESCRIPTION
## Description

Do not allow heading like `# foo`, `## foo` or `### foo` in all markdown fields.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
