### PR TITLE
assign existing tag on timesheet import (#1877)

### DIFF
--- a/src/Command/ImportTimesheetCommand.php
+++ b/src/Command/ImportTimesheetCommand.php
@@ -318,12 +318,12 @@ class ImportTimesheetCommand extends Command
                     foreach (explode(',', $record['Tags']) as $tagName) {
                         if (empty($tagName)) {
                             continue;
-                        } 
-                        
+                        }
+
                         if (null === ($tag = $this->tagRepository->findTagByName($tagName))) {
                             $tag = (new Tag())->setName($tagName);
                         }
-                        
+
                         $timesheet->addTag($tag);
                     }
                 }

--- a/src/Command/ImportTimesheetCommand.php
+++ b/src/Command/ImportTimesheetCommand.php
@@ -320,7 +320,7 @@ class ImportTimesheetCommand extends Command
                             continue;
                         } 
                         
-                        if (null === ($tag = $this->tagRepository->findTagByName($tagName)) {
+                        if (null === ($tag = $this->tagRepository->findTagByName($tagName))) {
                             $tag = (new Tag())->setName($tagName);
                         }
                         

--- a/src/Command/ImportTimesheetCommand.php
+++ b/src/Command/ImportTimesheetCommand.php
@@ -318,11 +318,13 @@ class ImportTimesheetCommand extends Command
                     foreach (explode(',', $record['Tags']) as $tagName) {
                         if (empty($tagName)) {
                             continue;
-                        } elseif (!empty($tag = $this->tagRepository->findTagByName($tagName))) {
-                            $timesheet->addTag($tag);
-                        } else {
-                            $timesheet->addTag((new Tag())->setName($tagName));
+                        } 
+                        
+                        if (null === ($tag = $this->tagRepository->findTagByName($tagName)) {
+                            $tag = (new Tag())->setName($tagName);
                         }
+                        
+                        $timesheet->addTag($tag);
                     }
                 }
 

--- a/tests/Command/ImportTimesheetCommandTest.php
+++ b/tests/Command/ImportTimesheetCommandTest.php
@@ -14,6 +14,7 @@ use App\Configuration\FormConfiguration;
 use App\Repository\ActivityRepository;
 use App\Repository\CustomerRepository;
 use App\Repository\ProjectRepository;
+use App\Repository\TagRepository;
 use App\Repository\TimesheetRepository;
 use App\Repository\UserRepository;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
@@ -39,10 +40,11 @@ class ImportTimesheetCommandTest extends KernelTestCase
         $projects = $this->createMock(ProjectRepository::class);
         $activities = $this->createMock(ActivityRepository::class);
         $users = $this->createMock(UserRepository::class);
+        $tagRepository = $this->createMock(TagRepository::class);
         $timesheets = $this->createMock(TimesheetRepository::class);
         $configuration = $this->createMock(FormConfiguration::class);
 
-        $this->application->add(new ImportTimesheetCommand($customers, $projects, $activities, $users, $timesheets, $configuration));
+        $this->application->add(new ImportTimesheetCommand($customers, $projects, $activities, $users, $tagRepository, $timesheets, $configuration));
     }
 
     public function testCommandName()


### PR DESCRIPTION
## Description
Fix for "Import timesheets using console fails to process tags #1877"

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
