### PR TITLE
Fix serialize dates

### DIFF
--- a/src/Entity/Activity.php
+++ b/src/Entity/Activity.php
@@ -332,7 +332,7 @@ class Activity implements EntityWithMetaFields
     public function addTeam(Team $team)
     {
         if ($this->teams->contains($team)) {
-            return $this;
+            return;
         }
 
         $this->teams->add($team);

--- a/src/Entity/Customer.php
+++ b/src/Entity/Customer.php
@@ -599,7 +599,7 @@ class Customer implements EntityWithMetaFields
     public function addTeam(Team $team)
     {
         if ($this->teams->contains($team)) {
-            return $this;
+            return;
         }
 
         $this->teams->add($team);

--- a/src/Entity/Project.php
+++ b/src/Entity/Project.php
@@ -118,6 +118,9 @@ class Project implements EntityWithMetaFields
      * @Serializer\Expose()
      * @Serializer\Groups({"Project_Entity"})
      * @Serializer\Type(name="DateTime")
+     * @Serializer\Accessor(getter="getOrderDate")
+     *
+     * Attention: Accessor MUST be used, otherwise date will be serialized in UTC.
      *
      * @Exporter\Expose(label="label.orderDate", type="datetime")
      *
@@ -130,6 +133,9 @@ class Project implements EntityWithMetaFields
      * @Serializer\Expose()
      * @Serializer\Groups({"Project"})
      * @Serializer\Type(name="DateTime")
+     * @Serializer\Accessor(getter="getStart")
+     *
+     * Attention: Accessor MUST be used, otherwise date will be serialized in UTC.
      *
      * @Exporter\Expose(label="label.project_start", type="datetime")
      *
@@ -142,6 +148,9 @@ class Project implements EntityWithMetaFields
      * @Serializer\Expose()
      * @Serializer\Groups({"Project"})
      * @Serializer\Type(name="DateTime")
+     * @Serializer\Accessor(getter="getEnd")
+     *
+     * Attention: Accessor MUST be used, otherwise date will be serialized in UTC.
      *
      * @Exporter\Expose(label="label.project_end", type="datetime")
      *

--- a/src/Entity/Timesheet.php
+++ b/src/Entity/Timesheet.php
@@ -114,6 +114,9 @@ class Timesheet implements EntityWithMetaFields, ExportItemInterface
      * @Serializer\Expose()
      * @Serializer\Groups({"Default"})
      * @Serializer\Type(name="DateTime")
+     * @Serializer\Accessor(getter="getBegin")
+     *
+     * Attention: Accessor MUST be used, otherwise date will be serialized in UTC.
      *
      * @ORM\Column(name="start_time", type="datetime", nullable=false)
      * @Assert\NotNull()
@@ -125,6 +128,9 @@ class Timesheet implements EntityWithMetaFields, ExportItemInterface
      * @Serializer\Expose()
      * @Serializer\Groups({"Default"})
      * @Serializer\Type(name="DateTime")
+     * @Serializer\Accessor(getter="getEnd")
+     *
+     * Attention: Accessor MUST be used, otherwise date will be serialized in UTC.
      *
      * @ORM\Column(name="end_time", type="datetime", nullable=true)
      */


### PR DESCRIPTION
## Description

With the serializer refactoring a bug sneaked in: all localized datetimes (timesheet: start and end / project: orderDate, start and end) were returned in UTC from the API.

This ended up in #1858 where wrong dates were shown in the calendar.

This PR replaces #1879 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
