### PR TITLE
the never ending group_by pagination issue

### DIFF
--- a/src/Repository/ActivityRepository.php
+++ b/src/Repository/ActivityRepository.php
@@ -261,7 +261,6 @@ class ActivityRepository extends EntityRepository
 
         $qb
             ->select('a')
-            ->distinct()
             ->from(Activity::class, 'a')
             ->leftJoin('a.project', 'p')
             ->leftJoin('p.customer', 'c')
@@ -361,6 +360,13 @@ class ActivityRepository extends EntityRepository
                 $qb->andWhere($searchAnd);
             }
         }
+
+        // this will make sure, that we do not accidentally create results with multiple rows,
+        // which would result in a wrong LIMIT with paginated results
+        $qb->addGroupBy('a');
+
+        // the second group by is needed to satisfy SQL standard (ONLY_FULL_GROUP_BY)
+        $qb->addGroupBy($orderBy);
 
         return $qb;
     }

--- a/src/Repository/CustomerRepository.php
+++ b/src/Repository/CustomerRepository.php
@@ -105,7 +105,7 @@ class CustomerRepository extends EntityRepository
 
         $qb = $this->getEntityManager()->createQueryBuilder();
         $qb
-            ->addSelect('COUNT(a.id) as activityAmount')
+            ->select('COUNT(a.id) as activityAmount')
             ->from(Activity::class, 'a')
             ->join(Project::class, 'p', Query\Expr\Join::WITH, 'a.project = p.id')
             ->andWhere('a.project = p.id')
@@ -118,7 +118,7 @@ class CustomerRepository extends EntityRepository
         }
 
         $qb = $this->getEntityManager()->createQueryBuilder();
-        $qb->addSelect('COUNT(p.id) as projectAmount')
+        $qb->select('COUNT(p.id) as projectAmount')
             ->from(Project::class, 'p')
             ->andWhere('p.customer = :customer')
         ;
@@ -165,7 +165,7 @@ class CustomerRepository extends EntityRepository
     }
 
     /**
-     * @deprecated since 1.1 - use getQueryBuilderForFormType() istead - will be removed with 2.0
+     * @deprecated since 1.1 - use getQueryBuilderForFormType() instead - will be removed with 2.0
      */
     public function builderForEntityType($customer)
     {
@@ -214,12 +214,10 @@ class CustomerRepository extends EntityRepository
 
         $qb
             ->select('c')
-            ->distinct()
             ->from(Customer::class, 'c')
         ;
 
-        $orderBy = 'c.' . $query->getOrderBy();
-        $qb->orderBy($orderBy, $query->getOrder());
+        $qb->orderBy('c.' . $query->getOrderBy(), $query->getOrder());
 
         if ($query->isShowVisible()) {
             $qb->andWhere($qb->expr()->eq('c.visible', ':visible'));
@@ -268,6 +266,10 @@ class CustomerRepository extends EntityRepository
                 $qb->andWhere($searchAnd);
             }
         }
+
+        // this will make sure, that we do not accidentally create results with multiple rows,
+        // which would result in a wrong LIMIT with paginated results
+        $qb->addGroupBy('c');
 
         return $qb;
     }

--- a/src/Repository/InvoiceRepository.php
+++ b/src/Repository/InvoiceRepository.php
@@ -137,7 +137,6 @@ class InvoiceRepository extends EntityRepository
 
         $qb
             ->select('i')
-            ->distinct()
             ->from(Invoice::class, 'i')
         ;
 
@@ -151,6 +150,13 @@ class InvoiceRepository extends EntityRepository
         $qb->addOrderBy($orderBy, $query->getOrder());
 
         $this->addPermissionCriteria($qb, $query->getCurrentUser());
+
+        // this will make sure, that we do not accidentally create results with multiple rows,
+        // which would result in a wrong LIMIT with paginated results
+        $qb->addGroupBy('i');
+
+        // the second group by is needed to satisfy SQL standard (ONLY_FULL_GROUP_BY)
+        $qb->addGroupBy($orderBy);
 
         return $qb;
     }

--- a/src/Repository/ProjectRepository.php
+++ b/src/Repository/ProjectRepository.php
@@ -255,7 +255,6 @@ class ProjectRepository extends EntityRepository
 
         $qb
             ->select('p')
-            ->distinct()
             ->from(Project::class, 'p')
             ->leftJoin('p.customer', 'c')
         ;
@@ -366,6 +365,13 @@ class ProjectRepository extends EntityRepository
                 $qb->andWhere($searchAnd);
             }
         }
+
+        // this will make sure, that we do not accidentally create results with multiple rows,
+        // which would result in a wrong LIMIT with paginated results
+        $qb->addGroupBy('p');
+
+        // the second group by is needed to satisfy SQL standard (ONLY_FULL_GROUP_BY)
+        $qb->addGroupBy($orderBy);
 
         return $qb;
     }


### PR DESCRIPTION
## Description

Once again a try to fix the issue with wrong pagination limits in joins environments with permission checks.

This is just a technical issue that should not result in any visible differences.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
