### PR TITLE
fixing money formatting issues for money without currency

### DIFF
--- a/src/Utils/LocaleHelper.php
+++ b/src/Utils/LocaleHelper.php
@@ -130,29 +130,18 @@ final class LocaleHelper
 
     private function getMoneyFormatter(bool $withCurrency = true): NumberFormatter
     {
-        if (null === $this->moneyFormatter) {
-            $this->moneyFormatter = new NumberFormatter($this->locale, NumberFormatter::CURRENCY);
-        }
-
         if ($withCurrency) {
+            if (null === $this->moneyFormatter) {
+                $this->moneyFormatter = new NumberFormatter($this->locale, NumberFormatter::CURRENCY);
+            }
+
             return $this->moneyFormatter;
         }
 
         if (null === $this->moneyFormatterNoCurrency) {
-            // if anyone knows a better way of achieving this, please let me know!
             $this->moneyFormatterNoCurrency = new NumberFormatter($this->locale, NumberFormatter::CURRENCY);
-
-            $this->moneyFormatterNoCurrency->setTextAttribute(NumberFormatter::CURRENCY_CODE, '');
-            $this->moneyFormatterNoCurrency->setSymbol(NumberFormatter::INTL_CURRENCY_SYMBOL, '');
-            $this->moneyFormatterNoCurrency->setSymbol(NumberFormatter::CURRENCY_SYMBOL, '');
-
-            // don't understand why this is needed, I'd say this shouldn't be necessary after the above calls
-            // even worse: the logic changes between PHP/ICU versions
-            $pattern = $this->moneyFormatterNoCurrency->getPattern();
-            $pattern = str_replace(['¤ ', ' ¤', '-¤', ' XXX', 'XXX '], '¤', $pattern);
-            $pattern = str_replace('XXX', '¤', $pattern);
-            $pattern = str_replace('¤', '', $pattern);
-            $this->moneyFormatterNoCurrency->setPattern($pattern);
+            $this->moneyFormatterNoCurrency->setTextAttribute(NumberFormatter::POSITIVE_PREFIX, '');
+            $this->moneyFormatterNoCurrency->setTextAttribute(NumberFormatter::POSITIVE_SUFFIX, '');
         }
 
         return $this->moneyFormatterNoCurrency;

--- a/src/Utils/LocaleHelper.php
+++ b/src/Utils/LocaleHelper.php
@@ -112,6 +112,10 @@ final class LocaleHelper
             $withCurrency = false;
         }
 
+        if (false === $withCurrency) {
+            return $this->getMoneyFormatter($withCurrency)->format($amount, NumberFormatter::TYPE_DEFAULT);
+        }
+
         return $this->getMoneyFormatter($withCurrency)->formatCurrency($amount, $currency);
     }
 
@@ -143,7 +147,7 @@ final class LocaleHelper
             $this->moneyFormatterNoCurrency->setSymbol(NumberFormatter::CURRENCY_SYMBOL, '');
 
             // don't understand why this is needed, I'd say this shouldn't be necessary after the above calls
-            // even worse: the logic changes either between PHP/ICU versions
+            // even worse: the logic changes between PHP/ICU versions
             $pattern = $this->moneyFormatterNoCurrency->getPattern();
             $pattern = str_replace(['¤ ', ' ¤', '-¤', ' XXX', 'XXX '], '¤', $pattern);
             $pattern = str_replace('XXX', '¤', $pattern);


### PR DESCRIPTION
## Description

Fixes #1923 

Seems to happen only on some (maybe older) ICU versions.
All money fields without currency (dashboard revenue and user profile) were empty.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
