### PR TITLE
added support for ordering meta fields

### DIFF
--- a/src/Entity/MetaTableTypeInterface.php
+++ b/src/Entity/MetaTableTypeInterface.php
@@ -163,4 +163,19 @@ interface MetaTableTypeInterface
      * @return array
      */
     public function getOptions(): array;
+
+    /**
+     * Sets the weight order.
+     *
+     * @param int $order
+     * @return MetaTableTypeInterface
+     */
+    public function setOrder(int $order): MetaTableTypeInterface;
+
+    /**
+     * Returns the weight order.
+     *
+     * @return int
+     */
+    public function getOrder(): int;
 }

--- a/src/Entity/MetaTableTypeTrait.php
+++ b/src/Entity/MetaTableTypeTrait.php
@@ -89,6 +89,10 @@ trait MetaTableTypeTrait
      * @var array
      */
     private $options = [];
+    /**
+     * @var int
+     */
+    private $order = 0;
 
     public function getName(): ?string
     {
@@ -216,6 +220,7 @@ trait MetaTableTypeTrait
             ->setIsVisible($meta->isVisible())
             ->setLabel($meta->getLabel())
             ->setOptions($meta->getOptions())
+            ->setOrder($meta->getOrder())
         ;
 
         return $this;
@@ -247,6 +252,18 @@ trait MetaTableTypeTrait
     public function getOptions(): array
     {
         return $this->options;
+    }
+
+    public function getOrder(): int
+    {
+        return $this->order;
+    }
+
+    public function setOrder(int $order): MetaTableTypeInterface
+    {
+        $this->order = $order;
+
+        return $this;
     }
 
     public function __clone()

--- a/templates/activity/details.html.twig
+++ b/templates/activity/details.html.twig
@@ -67,7 +67,7 @@
                         </td>
                     </tr>
                 {% endif %}
-                {% for metaField in activity.visibleMetaFields %}
+                {% for metaField in activity.visibleMetaFields|sort((a, b) => a.order <=> b.order) %}
                     <tr>
                         <th>{{ metaField.label|trans }}</th>
                         <td colspan="3">{{ widgets.form_type_value(metaField.type, metaField.value, activity) }}</td>

--- a/templates/activity/edit.html.twig
+++ b/templates/activity/edit.html.twig
@@ -36,7 +36,9 @@
             {% endif %}
             {{ form_row(form.visible) }}
             {% if form.metaFields is defined and form.metaFields is not empty %}
-                {{ form_row(form.metaFields) }}
+                {% for meta in form.metaFields|sort((a, b) => a.vars.data.order <=> b.vars.data.order) %}
+                    {{ form_row(meta) }}
+                {% endfor %}
             {% endif %}
             {% if form.create_more is defined and app.request.xmlHttpRequest %}
                 <div class="hidden">

--- a/templates/customer/details.html.twig
+++ b/templates/customer/details.html.twig
@@ -111,7 +111,7 @@
                         </tr>
                     {% endif %}
                 {% endif %}
-                {% for metaField in customer.visibleMetaFields %}
+                {% for metaField in customer.visibleMetaFields|sort((a, b) => a.order <=> b.order) %}
                     <tr>
                         <th>{{ metaField.label|trans }}</th>
                         <td>{{ widgets.form_type_value(metaField.type, metaField.value, customer) }}</td>

--- a/templates/customer/edit.html.twig
+++ b/templates/customer/edit.html.twig
@@ -79,7 +79,9 @@
             {% endif %}
             {{ form_row(form.visible) }}
             {% if form.metaFields is defined and form.metaFields is not empty %}
-                {{ form_row(form.metaFields) }}
+                {% for meta in form.metaFields|sort((a, b) => a.vars.data.order <=> b.vars.data.order) %}
+                    {{ form_row(meta) }}
+                {% endfor %}
             {% endif %}
             {{ form_widget(form) }}
         {% endblock %}

--- a/templates/project/details.html.twig
+++ b/templates/project/details.html.twig
@@ -86,7 +86,7 @@
                         </td>
                     </tr>
                 {% endif %}
-                {% for metaField in project.visibleMetaFields %}
+                {% for metaField in project.visibleMetaFields|sort((a, b) => a.order <=> b.order) %}
                     <tr>
                         <th>{{ metaField.label|trans }}</th>
                         <td colspan="3">{{ widgets.form_type_value(metaField.type, metaField.value, project) }}</td>

--- a/templates/project/edit.html.twig
+++ b/templates/project/edit.html.twig
@@ -51,7 +51,9 @@
             {% endif %}
             {{ form_row(form.visible) }}
             {% if form.metaFields is defined and form.metaFields is not empty %}
-                {{ form_row(form.metaFields) }}
+                {% for meta in form.metaFields|sort((a, b) => a.vars.data.order <=> b.vars.data.order) %}
+                    {{ form_row(meta) }}
+                {% endfor %}
             {% endif %}
             {% if form.create_more is defined and app.request.xmlHttpRequest %}
                 <div class="hidden">

--- a/tests/Entity/AbstractMetaEntityTest.php
+++ b/tests/Entity/AbstractMetaEntityTest.php
@@ -37,6 +37,7 @@ abstract class AbstractMetaEntityTest extends TestCase
         self::assertEmpty($sut->getOptions());
         self::assertFalse($sut->isVisible());
         self::assertFalse($sut->isRequired());
+        self::assertEquals(0, $sut->getOrder());
     }
 
     public function testSetterAndGetter()
@@ -64,6 +65,9 @@ abstract class AbstractMetaEntityTest extends TestCase
 
         self::assertInstanceOf(MetaTableTypeInterface::class, $sut->setType(DateTimePickerType::class));
         self::assertEquals(DateTimePickerType::class, $sut->getType());
+
+        self::assertInstanceOf(MetaTableTypeInterface::class, $sut->setOrder(7));
+        self::assertEquals(7, $sut->getOrder());
 
         self::assertInstanceOf(MetaTableTypeInterface::class, $sut->addConstraint(new Length(['max' => 10])));
         self::assertInstanceOf(MetaTableTypeInterface::class, $sut->addConstraint(new NotNull([])));
@@ -112,7 +116,8 @@ abstract class AbstractMetaEntityTest extends TestCase
             ->setType('blub2')
             ->setEntity($entity2)
             ->setIsRequired(true)
-            ->setisVisible(true)
+            ->setIsVisible(true)
+            ->setOrder(93)
             ->setConstraints([new NotBlank(), new Length(['min' => 1])])
             ->setOptions(['foo1' => 'bar1'])
         ;
@@ -123,6 +128,7 @@ abstract class AbstractMetaEntityTest extends TestCase
         self::assertEquals('bar', $meta1->getValue());
         self::assertEquals('blub2', $meta1->getType());
         self::assertEquals('TRALALA', $meta1->getLabel());
+        self::assertEquals(93, $meta1->getOrder());
         self::assertTrue($meta1->isRequired());
         self::assertTrue($meta1->isVisible());
         self::assertSame($entity1, $meta1->getEntity());


### PR DESCRIPTION
## Description

added support for ordering meta fields (via event)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
