### PR TITLE
cleanup global context

### DIFF
--- a/src/API/BaseApiController.php
+++ b/src/API/BaseApiController.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 namespace App\API;
 
 use App\Entity\User;
+use App\Timesheet\DateTimeFactory;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Form\Extension\Core\Type\DateTimeType;
 
@@ -22,4 +23,13 @@ abstract class BaseApiController extends AbstractController
 {
     public const DATE_FORMAT = DateTimeType::HTML5_FORMAT;
     public const DATE_FORMAT_PHP = 'Y-m-d\TH:i:s';
+
+    protected function getDateTimeFactory(?User $user = null): DateTimeFactory
+    {
+        if (null === $user) {
+            $user = $this->getUser();
+        }
+
+        return new DateTimeFactory(new \DateTimeZone($user->getTimezone()));
+    }
 }

--- a/src/API/ProjectController.php
+++ b/src/API/ProjectController.php
@@ -11,7 +11,6 @@ declare(strict_types=1);
 
 namespace App\API;
 
-use App\Entity\Customer;
 use App\Entity\Project;
 use App\Entity\ProjectRate;
 use App\Entity\User;
@@ -21,7 +20,6 @@ use App\Form\API\ProjectRateApiForm;
 use App\Repository\ProjectRateRepository;
 use App\Repository\ProjectRepository;
 use App\Repository\Query\ProjectQuery;
-use App\Timesheet\UserDateTimeFactory;
 use App\Utils\SearchTerm;
 use FOS\RestBundle\Controller\Annotations as Rest;
 use FOS\RestBundle\Controller\Annotations\RouteResource;
@@ -63,20 +61,15 @@ class ProjectController extends BaseApiController
      */
     private $dispatcher;
     /**
-     * @var UserDateTimeFactory
-     */
-    private $dateTime;
-    /**
      * @var ProjectRateRepository
      */
     private $projectRateRepository;
 
-    public function __construct(ViewHandlerInterface $viewHandler, ProjectRepository $repository, EventDispatcherInterface $dispatcher, UserDateTimeFactory $dateTime, ProjectRateRepository $projectRateRepository)
+    public function __construct(ViewHandlerInterface $viewHandler, ProjectRepository $repository, EventDispatcherInterface $dispatcher, ProjectRateRepository $projectRateRepository)
     {
         $this->viewHandler = $viewHandler;
         $this->repository = $repository;
         $this->dispatcher = $dispatcher;
-        $this->dateTime = $dateTime;
         $this->projectRateRepository = $projectRateRepository;
     }
 
@@ -143,16 +136,17 @@ class ProjectController extends BaseApiController
         }
 
         if (!$ignoreDates) {
+            $factory = $this->getDateTimeFactory();
             if (null !== ($begin = $paramFetcher->get('start')) && !empty($begin)) {
-                $query->setProjectStart($this->dateTime->createDateTime($begin));
+                $query->setProjectStart($factory->createDateTime($begin));
             }
 
             if (null !== ($end = $paramFetcher->get('end')) && !empty($end)) {
-                $query->setProjectEnd($this->dateTime->createDateTime($end));
+                $query->setProjectEnd($factory->createDateTime($end));
             }
 
             if (empty($begin) && empty($end)) {
-                $now = $this->dateTime->createDateTime();
+                $now = $factory->createDateTime();
                 $query->setProjectStart($now);
                 $query->setProjectEnd($now);
             }

--- a/src/Controller/CalendarController.php
+++ b/src/Controller/CalendarController.php
@@ -13,7 +13,6 @@ use App\Calendar\Google;
 use App\Calendar\Source;
 use App\Configuration\CalendarConfiguration;
 use App\Timesheet\TrackingModeService;
-use App\Timesheet\UserDateTimeFactory;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\Routing\Annotation\Route;
 
@@ -28,14 +27,14 @@ class CalendarController extends AbstractController
     /**
      * @Route(path="/", name="calendar", methods={"GET"})
      */
-    public function userCalendar(CalendarConfiguration $configuration, UserDateTimeFactory $dateTime, TrackingModeService $service)
+    public function userCalendar(CalendarConfiguration $configuration, TrackingModeService $service)
     {
         $mode = $service->getActiveMode();
 
         return $this->render('calendar/user.html.twig', [
             'config' => $configuration,
             'google' => $this->getGoogleSources($configuration),
-            'now' => $dateTime->createDateTime(),
+            'now' => $this->getDateTimeFactory()->createDateTime(),
             'is_punch_mode' => !$mode->canEditDuration() && !$mode->canEditBegin() && !$mode->canEditEnd()
         ]);
     }

--- a/src/Controller/InvoiceController.php
+++ b/src/Controller/InvoiceController.php
@@ -22,7 +22,6 @@ use App\Repository\InvoiceRepository;
 use App\Repository\InvoiceTemplateRepository;
 use App\Repository\Query\BaseQuery;
 use App\Repository\Query\InvoiceQuery;
-use App\Timesheet\UserDateTimeFactory;
 use Exception;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\Form\FormInterface;
@@ -50,10 +49,6 @@ final class InvoiceController extends AbstractController
      */
     private $templateRepository;
     /**
-     * @var UserDateTimeFactory
-     */
-    private $dateTimeFactory;
-    /**
      * @var InvoiceRepository
      */
     private $invoiceRepository;
@@ -62,12 +57,11 @@ final class InvoiceController extends AbstractController
      */
     private $dispatcher;
 
-    public function __construct(ServiceInvoice $service, InvoiceTemplateRepository $templateRepository, InvoiceRepository $invoiceRepository, UserDateTimeFactory $dateTimeFactory, EventDispatcherInterface $dispatcher)
+    public function __construct(ServiceInvoice $service, InvoiceTemplateRepository $templateRepository, InvoiceRepository $invoiceRepository, EventDispatcherInterface $dispatcher)
     {
         $this->service = $service;
         $this->templateRepository = $templateRepository;
         $this->invoiceRepository = $invoiceRepository;
-        $this->dateTimeFactory = $dateTimeFactory;
         $this->dispatcher = $dispatcher;
     }
 
@@ -139,8 +133,9 @@ final class InvoiceController extends AbstractController
 
     protected function getDefaultQuery(): InvoiceQuery
     {
-        $begin = $this->dateTimeFactory->createDateTime('first day of this month');
-        $end = $this->dateTimeFactory->createDateTime('last day of this month');
+        $factory = $this->getDateTimeFactory();
+        $begin = $factory->getStartOfMonth();
+        $end = $factory->getEndOfMonth();
 
         $query = new InvoiceQuery();
         $query->setOrder(InvoiceQuery::ORDER_ASC);

--- a/src/Form/Extension/UserExtension.php
+++ b/src/Form/Extension/UserExtension.php
@@ -32,13 +32,10 @@ final class UserExtension extends AbstractTypeExtension
         return [FormType::class];
     }
 
-    /**
-     * @param OptionsResolver $resolver
-     */
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefined(['user']);
-        // null needs to be allowed, as there is no user for anonymoud forms (like "forgot password" and "registration")
+        // null needs to be allowed, as there is no user for anonymous forms (like "forgot password" and "registration")
         $resolver->setAllowedTypes('user', [User::class, 'null']);
         $resolver->setDefault('user', $this->user->getUser());
     }

--- a/tests/Invoice/ServiceInvoiceTest.php
+++ b/tests/Invoice/ServiceInvoiceTest.php
@@ -20,7 +20,6 @@ use App\Invoice\ServiceInvoice;
 use App\Repository\InvoiceDocumentRepository;
 use App\Repository\InvoiceRepository;
 use App\Repository\Query\InvoiceQuery;
-use App\Tests\Mocks\Security\UserDateTimeFactoryFactory;
 use App\Utils\FileHelper;
 use PHPUnit\Framework\TestCase;
 use Twig\Environment;
@@ -44,9 +43,8 @@ class ServiceInvoiceTest extends TestCase
 
         $repo = new InvoiceDocumentRepository($paths);
         $invoiceRepo = $this->createMock(InvoiceRepository::class);
-        $userDateTime = (new UserDateTimeFactoryFactory($this))->create();
 
-        return new ServiceInvoice($repo, new FileHelper(realpath(__DIR__ . '/../../var/data/')), $invoiceRepo, $userDateTime, $formattings);
+        return new ServiceInvoice($repo, new FileHelper(realpath(__DIR__ . '/../../var/data/')), $invoiceRepo, $formattings);
     }
 
     public function testInvalidExceptionOnChangeState()


### PR DESCRIPTION
## Description

This PR adds further code cleanup.

Previously there were some objects used, which were using the global context from Symfony. 
These have to be removed one-by-one and will replaced with runtime code.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
