### PR TITLE
Execute migrations in kimai:reset-dev command

### DIFF
--- a/src/Command/ResetCommand.php
+++ b/src/Command/ResetCommand.php
@@ -92,7 +92,7 @@ EOT
         if ($this->askConfirmation($input, $output, 'Do you want to drop and re-create the schema y/N ?')) {
             try {
                 $command = $this->getApplication()->find('doctrine:schema:drop');
-                $command->run(new ArrayInput(['--force' => true]), $output);
+                $command->run(new ArrayInput(['--force' => true, '--full-database' => true]), $output);
             } catch (Exception $ex) {
                 $io->error('Failed to drop database schema: ' . $ex->getMessage());
 
@@ -100,10 +100,12 @@ EOT
             }
 
             try {
-                $command = $this->getApplication()->find('doctrine:schema:create');
-                $command->run(new ArrayInput([]), $output);
+                $command = $this->getApplication()->find('doctrine:migrations:migrate');
+                $cmdInput = new ArrayInput([]);
+                $cmdInput->setInteractive(false);
+                $command->run($cmdInput, $output);
             } catch (Exception $ex) {
-                $io->error('Failed to create database schema: ' . $ex->getMessage());
+                $io->error('Failed to execute a migration: ' . $ex->getMessage());
 
                 return 3;
             }
@@ -120,17 +122,6 @@ EOT
             return 4;
         }
 
-        try {
-            $command = $this->getApplication()->find('doctrine:migrations:version');
-            $cmdInput = new ArrayInput(['--add' => true, '--all' => true]);
-            $cmdInput->setInteractive(false);
-            $command->run($cmdInput, $output);
-        } catch (Exception $ex) {
-            $io->error('Failed to set migration status: ' . $ex->getMessage());
-
-            return 5;
-        }
-
         if (!$input->getOption('no-cache')) {
             $command = $this->getApplication()->find('cache:clear');
             try {
@@ -138,7 +129,7 @@ EOT
             } catch (Exception $ex) {
                 $io->error('Failed to clear cache: ' . $ex->getMessage());
 
-                return 6;
+                return 5;
             }
         }
 

--- a/src/Command/ResetCommand.php
+++ b/src/Command/ResetCommand.php
@@ -92,11 +92,29 @@ EOT
         if ($this->askConfirmation($input, $output, 'Do you want to drop and re-create the schema y/N ?')) {
             try {
                 $command = $this->getApplication()->find('doctrine:schema:drop');
-                $command->run(new ArrayInput(['--force' => true, '--full-database' => true]), $output);
+                $command->run(new ArrayInput(['--force' => true]), $output);
             } catch (Exception $ex) {
                 $io->error('Failed to drop database schema: ' . $ex->getMessage());
 
                 return 2;
+            }
+
+            try {
+                $command = $this->getApplication()->find('doctrine:query:sql');
+                $command->run(new ArrayInput(['sql' => 'DROP TABLE IF EXISTS migration_versions']), $output);
+            } catch (Exception $ex) {
+                $io->error('Failed to drop migration_versions table: ' . $ex->getMessage());
+
+                return 3;
+            }
+
+            try {
+                $command = $this->getApplication()->find('doctrine:query:sql');
+                $command->run(new ArrayInput(['sql' => 'DROP TABLE IF EXISTS kimai2_sessions']), $output);
+            } catch (Exception $ex) {
+                $io->error('Failed to drop kimai2_sessions table: ' . $ex->getMessage());
+
+                return 4;
             }
 
             try {
@@ -107,7 +125,7 @@ EOT
             } catch (Exception $ex) {
                 $io->error('Failed to execute a migrations: ' . $ex->getMessage());
 
-                return 3;
+                return 5;
             }
         }
 
@@ -119,7 +137,7 @@ EOT
         } catch (Exception $ex) {
             $io->error('Failed to import fixtures: ' . $ex->getMessage());
 
-            return 4;
+            return 6;
         }
 
         if (!$input->getOption('no-cache')) {
@@ -129,7 +147,7 @@ EOT
             } catch (Exception $ex) {
                 $io->error('Failed to clear cache: ' . $ex->getMessage());
 
-                return 5;
+                return 7;
             }
         }
 

--- a/src/Command/ResetCommand.php
+++ b/src/Command/ResetCommand.php
@@ -105,7 +105,7 @@ EOT
                 $cmdInput->setInteractive(false);
                 $command->run($cmdInput, $output);
             } catch (Exception $ex) {
-                $io->error('Failed to execute a migration: ' . $ex->getMessage());
+                $io->error('Failed to execute a migrations: ' . $ex->getMessage());
 
                 return 3;
             }


### PR DESCRIPTION
## Description
Following [this](https://www.kimai.org/documentation/developers.html) guide I had an error: `SQLSTATE[42S02]: Base table or view not found: 1146 Table 'kimai2.kimai2_sessions' doesn't exist`.

`kimai:reset-dev` command executes `doctrine:schema:create` wchich generates schema from entities, but schema required for SessionHandler is stored in migration. Even after this command it's imposibble to execute migrations, because `kimai:reset-dev` executes also `doctrine:migrations:version --add --all`, so we have confusing `migration_versions` table.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
