### PR TITLE
fix restart timesheet with meta-fields

### DIFF
--- a/src/API/TimesheetController.php
+++ b/src/API/TimesheetController.php
@@ -660,7 +660,6 @@ class TimesheetController extends BaseApiController
             ->setActivity($timesheet->getActivity())
             ->setProject($timesheet->getProject())
         ;
-        $this->service->prepareNewTimesheet($copyTimesheet);
 
         if (null !== ($copy = $paramFetcher->get('copy'))) {
             if (\in_array($copy, ['rates', 'all'])) {
@@ -685,6 +684,12 @@ class TimesheetController extends BaseApiController
                 }
             }
         }
+
+        // needs to be executed AFTER copying the values!
+        // the event triggered in prepareNewTimesheet() will add meta fields first. Afterwards
+        // setMetaField() will merge meta fields and if we merge in the existing ones from the copied record,
+        // it will fail, because they do not have a type assigned
+        $this->service->prepareNewTimesheet($copyTimesheet);
 
         $this->service->restartTimesheet($copyTimesheet, $timesheet);
 


### PR DESCRIPTION
## Description

Introduced bug with 1.10.2: restarting a timesheet with meta-fields (action "restart & copy" via dropdown behind record)  failed.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
