### PR TITLE
add a i18n api field for the users "now" datetime

### DIFF
--- a/src/API/ConfigurationController.php
+++ b/src/API/ConfigurationController.php
@@ -81,6 +81,7 @@ final class ConfigurationController extends BaseApiController
             ->setDuration($this->formats->getDurationFormat($locale))
             ->setTime($this->formats->getTimeFormat($locale))
             ->setIs24hours($this->formats->isTwentyFourHours($locale))
+            ->setNow($this->getDateTimeFactory()->createDateTime())
         ;
 
         $view = new View($model, 200);

--- a/src/API/Model/I18nConfig.php
+++ b/src/API/Model/I18nConfig.php
@@ -88,6 +88,23 @@ final class I18nConfig
      * @Serializer\Type(name="boolean")
      */
     private $is24hours = true;
+    /**
+     * The current time of the user
+     *
+     * @var \DateTime
+     *
+     * @Serializer\Expose()
+     * @Serializer\Groups({"Default"})
+     * @Serializer\Type(name="DateTime")
+     */
+    private $now;
+
+    public function setNow(\DateTime $now): I18nConfig
+    {
+        $this->now = $now;
+
+        return $this;
+    }
 
     public function setFormDateTime(string $formDateTime): I18nConfig
     {

--- a/tests/API/ConfigurationControllerTest.php
+++ b/tests/API/ConfigurationControllerTest.php
@@ -29,13 +29,13 @@ class ConfigurationControllerTest extends APIControllerBaseTest
 
         $this->assertIsArray($result);
         $this->assertNotEmpty($result);
-        $this->assertEquals(7, \count($result));
+        $this->assertEquals(8, \count($result));
         $this->assertI18nStructure($result);
     }
 
     protected function assertI18nStructure(array $result)
     {
-        $expectedKeys = ['date', 'dateTime', 'duration', 'formDate', 'formDateTime', 'is24hours', 'time'];
+        $expectedKeys = ['date', 'dateTime', 'duration', 'formDate', 'formDateTime', 'is24hours', 'time', 'now'];
         $actual = array_keys($result);
         sort($actual);
         sort($expectedKeys);


### PR DESCRIPTION
## Description

Partially solves #1949 

Added new field `now`:

<img width="1407" alt="Bildschirmfoto 2020-09-30 um 19 09 11" src="https://user-images.githubusercontent.com/533162/94717309-6f081600-0350-11eb-8582-1c867cc85abe.png">

API result:

```json
{
    "formDateTime": "yyyy-MM-dd HH:mm",
    "formDate": "yyyy-MM-dd",
    "dateTime": "m-d H:i",
    "date": "Y-m-d",
    "time": "H:i",
    "duration": "%h:%m h",
    "is24hours": true,
    "now": "2020-10-01T05:02:11+1200"
}
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
