### PR TITLE
open create form for activity/project/customer in modals

### DIFF
--- a/src/Controller/ProjectController.php
+++ b/src/Controller/ProjectController.php
@@ -165,14 +165,7 @@ final class ProjectController extends AbstractController
                 $this->projectService->saveNewProject($project);
                 $this->flashSuccess('action.update.success');
 
-                if ($editForm->has('create_more') && $editForm->get('create_more')->getData() === true) {
-                    $newProject = $this->projectService->createNewProject($project->getCustomer());
-                    $editForm = $this->createEditForm($newProject);
-                    $editForm->get('create_more')->setData(true);
-                    $project = $newProject;
-                } else {
-                    return $this->redirectToRoute('project_details', ['id' => $project->getId()]);
-                }
+                return $this->redirectToRoute('project_details', ['id' => $project->getId()]);
             } catch (\Exception $ex) {
                 $this->flashUpdateException($ex);
             }
@@ -530,7 +523,6 @@ final class ProjectController extends AbstractController
             'action' => $url,
             'method' => 'POST',
             'currency' => $currency,
-            'create_more' => true,
             'include_budget' => $this->isGranted('budget', $project)
         ]);
     }

--- a/src/Form/API/ActivityApiEditForm.php
+++ b/src/Form/API/ActivityApiEditForm.php
@@ -34,7 +34,6 @@ class ActivityApiEditForm extends ActivityEditForm
 
         $resolver->setDefaults([
             'csrf_protection' => false,
-            'create_more' => false,
         ]);
     }
 }

--- a/src/Form/API/ProjectApiEditForm.php
+++ b/src/Form/API/ProjectApiEditForm.php
@@ -34,7 +34,6 @@ class ProjectApiEditForm extends ProjectEditForm
 
         $resolver->setDefaults([
             'csrf_protection' => false,
-            'create_more' => false,
         ]);
     }
 }

--- a/src/Form/ActivityEditForm.php
+++ b/src/Form/ActivityEditForm.php
@@ -115,10 +115,6 @@ class ActivityEditForm extends AbstractType
         );
 
         $this->addCommonFields($builder, $options);
-
-        if (null === $id && $options['create_more']) {
-            $this->addCreateMore($builder);
-        }
     }
 
     /**
@@ -131,7 +127,6 @@ class ActivityEditForm extends AbstractType
             'csrf_protection' => true,
             'csrf_field_name' => '_token',
             'csrf_token_id' => 'admin_activity_edit',
-            'create_more' => false,
             'customer' => false,
             'currency' => Customer::DEFAULT_CURRENCY,
             'include_budget' => false,

--- a/src/Form/ProjectEditForm.php
+++ b/src/Form/ProjectEditForm.php
@@ -88,10 +88,6 @@ class ProjectEditForm extends AbstractType
             ]);
 
         $this->addCommonFields($builder, $options);
-
-        if (null === $id && $options['create_more']) {
-            $this->addCreateMore($builder);
-        }
     }
 
     /**
@@ -107,7 +103,6 @@ class ProjectEditForm extends AbstractType
             'currency' => Customer::DEFAULT_CURRENCY,
             'date_format' => null,
             'include_budget' => false,
-            'create_more' => false,
             'attr' => [
                 'data-form-event' => 'kimai.projectUpdate'
             ],

--- a/templates/activity/actions.html.twig
+++ b/templates/activity/actions.html.twig
@@ -6,7 +6,7 @@
     {% set actions = actions|merge({'download': {'url': path('activity_export'), 'class': 'toolbar-action'}}) %}
 
     {% if is_granted('create_activity') %}
-        {% set actions = actions|merge({'create': path('admin_activity_create')}) %}
+        {% set actions = actions|merge({'create': {'url': path('admin_activity_create'), 'class': 'modal-ajax-form'}}) %}
     {% endif %}
 
     {% set actions = actions|merge({'help': {'url': 'activity.html'|docu_link, 'target': '_blank'}}) %}

--- a/templates/activity/edit.html.twig
+++ b/templates/activity/edit.html.twig
@@ -40,11 +40,6 @@
                     {{ form_row(meta) }}
                 {% endfor %}
             {% endif %}
-            {% if form.create_more is defined and app.request.xmlHttpRequest %}
-                <div class="hidden">
-                {{ form_row(form.create_more) }}
-                </div>
-            {% endif %}
             {{ form_widget(form) }}
         {% endblock %}
     {% endembed %}

--- a/templates/activity/edit.html.twig
+++ b/templates/activity/edit.html.twig
@@ -7,7 +7,7 @@
 {% block main %}
     {% set formEditTemplate = app.request.xmlHttpRequest ? 'default/_form_modal.html.twig' : 'default/_form.html.twig' %}
     {% set formOptions = {
-        'title': activity.name|default('create-activity'|trans({}, 'actions')),
+        'title': (activity.id is null ? 'create'|trans : 'edit'|trans({}, 'actions')),
         'form': form,
         'back': path('admin_activity')
     } %}

--- a/templates/customer/actions.html.twig
+++ b/templates/customer/actions.html.twig
@@ -6,7 +6,7 @@
     {% set actions = actions|merge({'download': {'url': path('customer_export'), 'class': 'toolbar-action'}}) %}
 
     {% if is_granted('create_customer') %}
-        {% set actions = actions|merge({'create': path('admin_customer_create')}) %}
+        {% set actions = actions|merge({'create': {'url': path('admin_customer_create'), 'class': 'modal-ajax-form'}}) %}
     {% endif %}
 
     {% set actions = actions|merge({'help': {'url': 'customer.html'|docu_link, 'target': '_blank'}}) %}

--- a/templates/customer/edit.html.twig
+++ b/templates/customer/edit.html.twig
@@ -7,7 +7,7 @@
 {% block main %}
     {% set formEditTemplate = app.request.xmlHttpRequest ? 'default/_form_modal.html.twig' : 'default/_form.html.twig' %}
     {% set formOptions = {
-        'title': customer.name|default('create'|trans),
+        'title': (customer.id is null ? 'create'|trans : 'edit'|trans({}, 'actions')),
         'form': form,
         'back': path('admin_customer')
     } %}

--- a/templates/project/actions.html.twig
+++ b/templates/project/actions.html.twig
@@ -6,7 +6,7 @@
     {% set actions = actions|merge({'download': {'url': path('project_export'), 'class': 'toolbar-action'}}) %}
 
     {% if is_granted('create_project') %}
-        {% set actions = actions|merge({'create': path('admin_project_create')}) %}
+        {% set actions = actions|merge({'create': {'url': path('admin_project_create'), 'class': 'modal-ajax-form'}}) %}
     {% endif %}
 
     {% set actions = actions|merge({'help': {'url': 'project.html'|docu_link, 'target': '_blank'}}) %}

--- a/templates/project/edit.html.twig
+++ b/templates/project/edit.html.twig
@@ -7,7 +7,7 @@
 {% block main %}
     {% set formEditTemplate = app.request.xmlHttpRequest ? 'default/_form_modal.html.twig' : 'default/_form.html.twig' %}
     {% set formOptions = {
-        'title': project.name|default('create-project'|trans({}, 'actions')),
+        'title': (project.id is null ? 'create'|trans : 'edit'|trans({}, 'actions')),
         'form': form,
         'back': path('admin_project')
     } %}

--- a/templates/project/edit.html.twig
+++ b/templates/project/edit.html.twig
@@ -55,11 +55,6 @@
                     {{ form_row(meta) }}
                 {% endfor %}
             {% endif %}
-            {% if form.create_more is defined and app.request.xmlHttpRequest %}
-                <div class="hidden">
-                    {{ form_row(form.create_more) }}
-                </div>
-            {% endif %}
             {{ form_widget(form) }}
         {% endblock %}
     {% endembed %}

--- a/templates/user/actions.html.twig
+++ b/templates/user/actions.html.twig
@@ -16,7 +16,7 @@
     {% endif %}
 
     {% if is_granted('create_user') %}
-        {% set actions = actions|merge({'create': path('admin_user_create')}) %}
+        {% set actions = actions|merge({'create': {'url': path('admin_user_create')}}) %}
     {% endif %}
 
     {% if view == 'index' %}

--- a/templates/user/edit.html.twig
+++ b/templates/user/edit.html.twig
@@ -3,9 +3,15 @@
 {% block page_title %}{{ 'admin_user.title'|trans }}{% endblock %}
 
 {% block main %}
-    {{ include('default/_form.html.twig', {
+    {% set formEditTemplate = app.request.xmlHttpRequest ? 'default/_form_modal.html.twig' : 'default/_form.html.twig' %}
+    {% set formOptions = {
         'title': 'create'|trans,
         'form': form,
         'back': path('admin_user')
-    }) }}
+    } %}
+    {% embed formEditTemplate with formOptions %}
+        {% block form_body %}
+            {{ form_widget(form) }}
+        {% endblock %}
+    {% endembed %}
 {% endblock %}

--- a/tests/Controller/CustomerControllerTest.php
+++ b/tests/Controller/CustomerControllerTest.php
@@ -300,7 +300,6 @@ class CustomerControllerTest extends ControllerBaseTest
         $client = $this->getClientForAuthenticatedUser(User::ROLE_ADMIN);
         $this->assertAccessIsGranted($client, '/admin/customer/1/edit');
         $form = $client->getCrawler()->filter('form[name=customer_edit_form]')->form();
-        $this->assertFalse($form->has('customer_edit_form[create_more]'));
         $this->assertEquals('Test', $form->get('customer_edit_form[name]')->getValue());
         $client->submit($form, [
             'customer_edit_form' => [

--- a/tests/Controller/ProjectControllerTest.php
+++ b/tests/Controller/ProjectControllerTest.php
@@ -19,7 +19,6 @@ use App\Entity\Team;
 use App\Entity\Timesheet;
 use App\Entity\User;
 use App\Tests\DataFixtures\ActivityFixtures;
-use App\Tests\DataFixtures\CustomerFixtures;
 use App\Tests\DataFixtures\ProjectFixtures;
 use App\Tests\DataFixtures\TeamFixtures;
 use App\Tests\DataFixtures\TimesheetFixtures;
@@ -341,8 +340,6 @@ class ProjectControllerTest extends ControllerBaseTest
         $client = $this->getClientForAuthenticatedUser(User::ROLE_ADMIN);
         $this->assertAccessIsGranted($client, '/admin/project/create');
         $form = $client->getCrawler()->filter('form[name=project_edit_form]')->form();
-        $this->assertTrue($form->has('project_edit_form[create_more]'));
-        $this->assertFalse($form->get('project_edit_form[create_more]')->hasValue());
         $client->submit($form, [
             'project_edit_form' => [
                 'name' => 'Test 2',
@@ -366,45 +363,11 @@ class ProjectControllerTest extends ControllerBaseTest
         $this->assertFalse($form->has('project_edit_form[metaFields][1][value]'));
     }
 
-    public function testCreateActionWithCreateMore()
-    {
-        $client = $this->getClientForAuthenticatedUser(User::ROLE_ADMIN);
-
-        $fixture = new CustomerFixtures();
-        $fixture->setAmount(10);
-        $this->importFixture($fixture);
-
-        $this->assertAccessIsGranted($client, '/admin/project/create');
-        $form = $client->getCrawler()->filter('form[name=project_edit_form]')->form();
-        $this->assertTrue($form->has('project_edit_form[create_more]'));
-
-        /** @var \Symfony\Component\DomCrawler\Field\ChoiceFormField $customer */
-        $customer = $form->get('project_edit_form[customer]');
-        $options = $customer->availableOptionValues();
-        $selectedCustomer = $options[array_rand($options)];
-
-        $client->submit($form, [
-            'project_edit_form' => [
-                'name' => 'Test create more',
-                'create_more' => true,
-                'customer' => $selectedCustomer
-            ]
-        ]);
-        $this->assertFalse($client->getResponse()->isRedirect());
-        $this->assertTrue($client->getResponse()->isSuccessful());
-        $form = $client->getCrawler()->filter('form[name=project_edit_form]')->form();
-        $this->assertTrue($form->has('project_edit_form[create_more]'));
-        $this->assertTrue($form->get('project_edit_form[create_more]')->hasValue());
-        $this->assertEquals(1, $form->get('project_edit_form[create_more]')->getValue());
-        $this->assertEquals($selectedCustomer, $form->get('project_edit_form[customer]')->getValue());
-    }
-
     public function testEditAction()
     {
         $client = $this->getClientForAuthenticatedUser(User::ROLE_ADMIN);
         $this->assertAccessIsGranted($client, '/admin/project/1/edit');
         $form = $client->getCrawler()->filter('form[name=project_edit_form]')->form();
-        $this->assertFalse($form->has('project_edit_form[create_more]'));
         $this->assertEquals('Test', $form->get('project_edit_form[name]')->getValue());
         $client->submit($form, [
             'project_edit_form' => ['name' => 'Test 2']


### PR DESCRIPTION
## Description

- open create forms for activity/project/customer in modals
- remove "create more" for activity and project

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
