### PR TITLE
WIP - improve export screen for unexpected permission setups

### DIFF
--- a/src/Form/Toolbar/ExportToolbarForm.php
+++ b/src/Form/Toolbar/ExportToolbarForm.php
@@ -29,7 +29,9 @@ class ExportToolbarForm extends AbstractToolbarForm
         $this->addSearchTermInputField($builder);
         $this->addExportStateChoice($builder);
         $this->addTimesheetStateChoice($builder);
-        $this->addUsersChoice($builder);
+        if ($options['include_user']) {
+            $this->addUsersChoice($builder);
+        }
         $this->addDateRangeChoice($builder);
         $this->addCustomerMultiChoice($builder, ['start_date_param' => null, 'end_date_param' => null, 'ignore_date' => true], true);
         $this->addProjectMultiChoice($builder, ['ignore_date' => true], true, true);
@@ -61,6 +63,7 @@ class ExportToolbarForm extends AbstractToolbarForm
         $resolver->setDefaults([
             'data_class' => ExportQuery::class,
             'csrf_protection' => false,
+            'include_user' => true,
         ]);
     }
 }

--- a/templates/export/index.html.twig
+++ b/templates/export/index.html.twig
@@ -40,7 +40,9 @@
             {{ form_row(form.customers) }}
             {{ form_row(form.projects) }}
             {{ form_row(form.activities) }}
-            {{ form_row(form.users) }}
+            {% if form.users is defined %}
+                {{ form_row(form.users) }}
+            {% endif %}
             {{ form_row(form.tags) }}
             {{ form_row(form.exported) }}
             {{ form_row(form.state) }}


### PR DESCRIPTION
# Description

Fixes #1473 

prevent to select other user if create_export is allowed, but not view_other_timesheet

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [ ] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
