### PR TITLE
prevent spreadsheet export and invoice from breaking

### DIFF
--- a/src/Export/Base/AbstractSpreadsheetRenderer.php
+++ b/src/Export/Base/AbstractSpreadsheetRenderer.php
@@ -21,6 +21,7 @@ use App\Repository\Query\CustomerQuery;
 use App\Repository\Query\TimesheetQuery;
 use App\Twig\DateExtensions;
 use DateTime;
+use PhpOffice\PhpSpreadsheet\Cell\DataType;
 use PhpOffice\PhpSpreadsheet\Shared\Date;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Style\Border;
@@ -312,7 +313,7 @@ abstract class AbstractSpreadsheetRenderer
             $columns['description']['render'] = function (Worksheet $sheet, int $row, int $column, ExportItemInterface $entity) use (&$isColumnFormatted, $maxWidth, $wrapText) {
                 $cell = $sheet->getCellByColumnAndRow($column, $row);
 
-                $cell->setValue($entity->getDescription());
+                $cell->setValueExplicit($entity->getDescription(), DataType::TYPE_STRING);
 
                 // Apply wrap text if configured
                 if ($wrapText) {

--- a/src/Invoice/Renderer/AbstractSpreadsheetRenderer.php
+++ b/src/Invoice/Renderer/AbstractSpreadsheetRenderer.php
@@ -12,6 +12,7 @@ namespace App\Invoice\Renderer;
 use App\Entity\InvoiceDocument;
 use App\Invoice\InvoiceModel;
 use PhpOffice\PhpSpreadsheet\Cell\Cell;
+use PhpOffice\PhpSpreadsheet\Cell\DataType;
 use PhpOffice\PhpSpreadsheet\IOFactory;
 use PhpOffice\PhpSpreadsheet\Spreadsheet;
 use PhpOffice\PhpSpreadsheet\Worksheet\Worksheet;
@@ -93,7 +94,11 @@ abstract class AbstractSpreadsheetRenderer extends AbstractRenderer
                     $value = str_replace($searchKey, $content, $value);
                 }
 
-                $cell->setValue($value);
+                if (\is_string($value)) {
+                    $cell->setValueExplicit($value, DataType::TYPE_STRING);
+                } else {
+                    $cell->setValue($value);
+                }
             }
 
             if ($sheetValues !== false && $entryRow < $invoiceItemCount - 1) {

--- a/tests/Export/Renderer/AbstractRendererTest.php
+++ b/tests/Export/Renderer/AbstractRendererTest.php
@@ -140,6 +140,7 @@ abstract class AbstractRendererTest extends KernelTestCase
             ->setDuration(400)
             ->setRate(1947.99)
             ->setUser($user2)
+            ->setDescription('== jhg ljhg ') // make sure that spreadsheets don't render it as formula
             ->setActivity($activity)
             ->setProject($project)
             ->setBegin(new \DateTime())

--- a/tests/Invoice/Renderer/RendererTestTrait.php
+++ b/tests/Invoice/Renderer/RendererTestTrait.php
@@ -162,6 +162,7 @@ trait RendererTestTrait
             ->setRate(111.11)
             ->setUser($user1)
             ->setActivity($activity2)
+            ->setDescription('== jhg ljhg ') // make sure that spreadsheets don't render it as formula
             ->setProject($project2)
             ->setBegin(new \DateTime())
             ->setEnd(new \DateTime())


### PR DESCRIPTION
# Description

apply fixes to prevent export and invoice from breaking if a description starts with an `=` equal sign

Fixes #2014 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
