### PR TITLE
allow to configured database version via ENV var

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -4,6 +4,7 @@ parameters:
     # environment variables are not available yet.
     # You should not need to change this value.
     env(DATABASE_URL): ''
+    env(DATABASE_VERSION): ~
 
 doctrine:
     dbal:
@@ -14,7 +15,7 @@ doctrine:
                 driver: 'pdo_mysql'
                 # this setting prevents automatic database detection and finds a lot of false-negatives on doctrine:migrations:diff
                 # for null columns with MariaDB. Each migration tries to convert EVERY nullable column.
-                # server_version: '5.7'
+                server_version: '%env(string:DATABASE_VERSION)%'
                 charset: utf8mb4
                 default_table_options:
                     charset: utf8mb4

--- a/src/DependencyInjection/Compiler/DoctrineCompilerPass.php
+++ b/src/DependencyInjection/Compiler/DoctrineCompilerPass.php
@@ -35,28 +35,36 @@ class DoctrineCompilerPass implements CompilerPassInterface
         $engine = null;
         $databaseUrl = null;
 
-        if (null === $databaseUrl && isset($_ENV['DATABASE_URL'])) {
+        if ($databaseUrl === null && isset($_ENV['DATABASE_URL'])) {
             $databaseUrl = $_ENV['DATABASE_URL'];
         }
 
-        if (null === $databaseUrl && isset($_SERVER['DATABASE_URL'])) {
+        if ($databaseUrl === null && isset($_SERVER['DATABASE_URL'])) {
             $databaseUrl = $_SERVER['DATABASE_URL'];
         }
 
-        if (null === $databaseUrl && (false !== $envDbUrl = getenv('DATABASE_URL'))) {
-            $databaseUrl = $envDbUrl;
+        if ($databaseUrl === null) {
+            $databaseUrl = getenv('DATABASE_URL');
         }
 
-        if (null !== $databaseUrl) {
+        if ($databaseUrl !== false && !empty($databaseUrl)) {
             $urlParts = explode('://', $databaseUrl);
             $engine = $urlParts[0] ?: null;
         }
 
-        if (null === $engine) {
+        if ($engine === null && isset($_ENV['DATABASE_ENGINE'])) {
+            $engine = $_ENV['DATABASE_ENGINE'];
+        }
+
+        if ($engine === null && isset($_SERVER['DATABASE_ENGINE'])) {
+            $engine = $_SERVER['DATABASE_ENGINE'];
+        }
+
+        if ($engine === null) {
             $engine = getenv('DATABASE_ENGINE');
         }
 
-        if (empty($engine)) {
+        if ($engine === false || empty($engine)) {
             throw new \Exception(
                 'Could not detect database engine, make sure DATABASE_URL is available from $_SERVER or $_ENV. Check your .env file.'
             );

--- a/src/DependencyInjection/Compiler/DoctrineCompilerPass.php
+++ b/src/DependencyInjection/Compiler/DoctrineCompilerPass.php
@@ -26,45 +26,47 @@ class DoctrineCompilerPass implements CompilerPassInterface
         'sqlite'
     ];
 
+    private function getEnvVar(string $name): ?string
+    {
+        $envVarValue = null;
+
+        if (isset($_ENV[$name])) {
+            $envVarValue = $_ENV[$name];
+        }
+
+        if ($envVarValue === null && isset($_SERVER[$name])) {
+            $envVarValue = $_SERVER[$name];
+        }
+
+        if ($envVarValue === null) {
+            $envVarValue = getenv($name);
+        }
+
+        if ($envVarValue === false || empty($envVarValue)) {
+            return null;
+        }
+
+        return $envVarValue;
+    }
+
     /**
      * @return array|false|null|string
      * @throws \Exception
      */
-    protected function findEngine()
+    private function findEngine()
     {
         $engine = null;
-        $databaseUrl = null;
 
-        if ($databaseUrl === null && isset($_ENV['DATABASE_URL'])) {
-            $databaseUrl = $_ENV['DATABASE_URL'];
-        }
-
-        if ($databaseUrl === null && isset($_SERVER['DATABASE_URL'])) {
-            $databaseUrl = $_SERVER['DATABASE_URL'];
-        }
-
-        if ($databaseUrl === null) {
-            $databaseUrl = getenv('DATABASE_URL');
-        }
-
-        if ($databaseUrl !== false && !empty($databaseUrl)) {
+        if (null !== ($databaseUrl = $this->getEnvVar('DATABASE_URL'))) {
             $urlParts = explode('://', $databaseUrl);
             $engine = $urlParts[0] ?: null;
         }
 
-        if ($engine === null && isset($_ENV['DATABASE_ENGINE'])) {
-            $engine = $_ENV['DATABASE_ENGINE'];
-        }
-
-        if ($engine === null && isset($_SERVER['DATABASE_ENGINE'])) {
-            $engine = $_SERVER['DATABASE_ENGINE'];
+        if ($engine === null) {
+            $engine = $this->getEnvVar('DATABASE_ENGINE');
         }
 
         if ($engine === null) {
-            $engine = getenv('DATABASE_ENGINE');
-        }
-
-        if ($engine === false || empty($engine)) {
             throw new \Exception(
                 'Could not detect database engine, make sure DATABASE_URL is available from $_SERVER or $_ENV. Check your .env file.'
             );

--- a/src/DependencyInjection/Compiler/DoctrineCompilerPass.php
+++ b/src/DependencyInjection/Compiler/DoctrineCompilerPass.php
@@ -50,10 +50,10 @@ class DoctrineCompilerPass implements CompilerPassInterface
     }
 
     /**
-     * @return array|false|null|string
+     * @return string
      * @throws \Exception
      */
-    private function findEngine()
+    private function findEngine(): string
     {
         $engine = null;
 


### PR DESCRIPTION
## Description

Without configured `DATABASE_URL` it was not possible to clear/warmup cache.

It could be faked by configuring a database url with version string:
```
DATABASE_URL=mysql://anonymous@localhost?serverVersion=mariadb-10.4.13
```
or now it can also be defined via the `DATABASE_VERSION` env var:
```
DATABASE_ENGINE=mysql
DATABASE_VERSION=mariadb-10.4.13
```

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
