### PR TITLE
fix auto-stop when starting timesheet with tags

### DIFF
--- a/src/Repository/TimesheetRepository.php
+++ b/src/Repository/TimesheetRepository.php
@@ -120,6 +120,22 @@ class TimesheetRepository extends EntityRepository
         }
     }
 
+    public function begin()
+    {
+        $this->getEntityManager()->beginTransaction();
+    }
+
+    public function commit()
+    {
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->commit();
+    }
+
+    public function rollback()
+    {
+        $this->getEntityManager()->rollback();
+    }
+
     /**
      * @param Timesheet $timesheet
      * @throws \Doctrine\ORM\ORMException

--- a/tests/Timesheet/TimesheetServiceTest.php
+++ b/tests/Timesheet/TimesheetServiceTest.php
@@ -128,12 +128,14 @@ class TimesheetServiceTest extends TestCase
         $timesheet2->expects($this->once())->method('setBegin');
         $timesheet2->expects($this->once())->method('setEnd');
 
+        $newTimesheet = new Timesheet();
+
         $repository = $this->createMock(TimesheetRepository::class);
-        $repository->method('getActiveEntries')->willReturn([$timesheet1, $timesheet2]);
+        $repository->method('getActiveEntries')->willReturn([$newTimesheet, $timesheet1, $timesheet2]);
 
         $sut = $this->getSut($authorizationChecker, null, null, $repository);
 
-        $sut->saveNewTimesheet(new Timesheet());
+        $sut->saveNewTimesheet($newTimesheet);
     }
 
     public function testCannotRestartedPersistedTimesheet()


### PR DESCRIPTION
## Description

Fixes #2064 

Changes auto-stop functionality: 
- hard failure with user feedback was removed => no more user action is required
- the oldest entries are stopped until the limit is reached

This is a functional BC break, but I assume that it makes things easier for users. Plus: most users will not even notice the change.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
