### PR TITLE
WIP: Updated develop docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+# The given Dockerfile is for development only and will always
+# clone a clean version from github, so we ignore everything on build.
+**

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN set -ex \
         opcache
 
 # Install Xdebug
-ARG XDEBUG=1
+ARG XDEBUG=0
 
 RUN set -ex \
     && if [ "$XDEBUG" = "1" ]; then \

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,29 @@ RUN set -ex \
         zip \
         opcache
 
+# Install Xdebug
+ARG XDEBUG=1
+
+RUN set -ex \
+    && if [ "$XDEBUG" = "1" ]; then \
+      mkdir /tmp/build \
+      && curl -sSL https://github.com/xdebug/xdebug/archive/2.9.8.tar.gz | tar -xzC /tmp/build \
+      && cd /tmp/build/xdebug-* \
+      && phpize \
+      && ./configure --enable-xdebug \
+      && make \
+      && make install \
+      && rm -rf /tmp/build \
+      && echo "zend_extension=xdebug.so" > /usr/local/etc/php/conf.d/xdebug.ini \
+      && echo "xdebug.idekey=PHPSTORM" >> /usr/local/etc/php/conf.d/xdebug.ini \
+      && echo "xdebug.remote_enable=1" >> /usr/local/etc/php/conf.d/xdebug.ini \
+      && echo "xdebug.remote_connect_back=1" >> /usr/local/etc/php/conf.d/xdebug.ini \
+      && echo "xdebug.remote_host=host.docker.internal" >> /usr/local/etc/php/conf.d/xdebug.ini \
+      && echo "xdebug.remote_port=9000" >> /usr/local/etc/php/conf.d/xdebug.ini \
+      && echo "xdebug.remote_autostart=1" >> /usr/local/etc/php/conf.d/xdebug.ini \
+      && echo "xdebug.remote_handler=dbgp" >> /usr/local/etc/php/conf.d/xdebug.ini; \
+    fi
+
 WORKDIR /var/www/html
 
 # Install composer

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,6 +92,10 @@ RUN set -ex \
     && git clone --depth 1 https://github.com/kevinpapst/kimai2.git . \
     && composer install --optimize-autoloader
 
+# Setup demo specific ENV
+ENV APP_ENV=dev \
+    DATABASE_URL=sqlite:////var/data/kimaidemo.sqlite
+
 # Create default SQLite database with a default user and compile it into the
 # image to offer some default setup to spool up incase of a demo.
 RUN set -ex \
@@ -102,10 +106,6 @@ RUN set -ex \
 RUN set -ex \
     && symfony check:requirements \
     && symfony security:check --disable-exit-code
-
-# Setup demo specific ENV
-ENV APP_ENV=dev \
-    DATABASE_URL=sqlite:///var/data/kimaidemo.sqlite
 
 EXPOSE 8001
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,6 @@
 # file that was distributed with this source code.
 FROM php:7.4.12-cli
 
-ENV APP_ENV dev
-
 # Install tools and dependencies
 RUN set -ex \
     && apt-get update \
@@ -84,11 +82,10 @@ RUN set -ex \
     && sed -i 's/;opcache.memory_consumption=128/opcache.memory_consumption=256/g' /usr/local/etc/php/php.ini \
     && sed -i 's/;opcache.max_accelerated_files=10000/opcache.max_accelerated_files=20000/g' /usr/local/etc/php/php.ini \
     && sed -i 's/log_errors_max_len = 1024/log_errors_max_len = 8192/g' /usr/local/etc/php/php.ini \
-    && chown -R www-data:www-data /var/www
+    && mkdir -p /var/data \
+    && chown -R www-data:www-data /var/www /var/data
 
 USER www-data:www-data
-
-WORKDIR /var/www/html
 
 # Create shallow clone of kimai and configure it as dev role
 RUN set -ex \
@@ -105,6 +102,10 @@ RUN set -ex \
 RUN set -ex \
     && symfony check:requirements \
     && symfony security:check --disable-exit-code
+
+# Setup demo specific ENV
+ENV APP_ENV=dev \
+    DATABASE_URL=sqlite:///var/data/kimaidemo.sqlite
 
 EXPOSE 8001
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -73,11 +73,8 @@ RUN set -ex \
 # Create default SQLite database with a default user and compile it into the
 # image to offer some default setup to spool up incase of a demo.
 RUN set -ex \
-    && bin/console doctrine:database:create -n \
-    && bin/console doctrine:migrations:migrate -n  \
-    && bin/console doctrine:schema:update -n --force \
-    && bin/console cache:warmup -n \
-    && bin/console kimai:create-user admin admin@kimai.local ROLE_SUPER_ADMIN adminpassword
+    && bin/console kimai:install -n \
+    && bin/console kimai:create-user admin admin@example.com ROLE_SUPER_ADMIN password
 
 # Perform basic sanity checks
 RUN set -ex \

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,19 +40,21 @@ RUN set -ex \
         zip \
         opcache
 
+WORKDIR /var/www/html
+
 # Install composer
 ENV COMPOSER_MEMORY_LIMIT=-1
 
 RUN set -ex \
-    && curl -sSL https://getcomposer.org/download/1.10.17/composer.phar -o /usr/local/bin/composer \
+    && curl -sS https://getcomposer.org/composer-stable.phar -o /usr/local/bin/composer \
     && chmod +x /usr/local/bin/composer
 
 # Install symfony cli
 RUN set -ex \
-    && curl -sSL https://github.com/symfony/cli/releases/download/v4.20.1/symfony_linux_amd64 -o /usr/local/bin/symfony \
-    && chmod +x /usr/local/bin/symfony
+    && curl -sS https://get.symfony.com/cli/installer | bash \
+    && mv /root/.symfony/bin/symfony /usr/local/bin/symfony
 
-# Install production php.ini and some tweaks
+# Install production php.ini and make sore there is a folder to hold the demo database
 RUN set -ex \
     && cp /usr/local/etc/php/php.ini-development /usr/local/etc/php/php.ini \
     && sed -i 's/memory_limit = 128M/memory_limit = 512M/g' /usr/local/etc/php/php.ini \


### PR DESCRIPTION
## Description

Current development docker image does no longer work due to missing php-extensions, missing and deprecated webserver-bundle approach and changes to default security requirements. Related issue #2057.

Things I had to change:

- `/opt/kimai` to `/var/www/html`, as this is the default location for many images like the apache ones and the symfony-cli commands.
- Change the default password for the demo `admin` account, the one mentioned in the docs fails as it's not 8 chars or more long.

Things I updated:

- Upgrade to PHP 7.4.12
- Added XSL/XML, opcache and freetype support
- Added symfony cli, as webserver-bundle is no longer included and this is the 5.x way of spooling up dev servers easily.
- Used fixed versions for composer, symfony-cli and PHP to avoid build cache conflicts.
- Added a default user to the basic SQLite setup with `admin` and `adminpassword`.
- Removed the composer memory limit
- Forced the port to stay at 8001, through symfony-cli uses 8000 as default.
- Disabled optional CA/tls support offered by symfony-cli, not important for development.
- Added `symfony check-requirements` and `symfony security:check` on build to give a hint if anything is missing.
- Added some optimizations that are also useful to dev from https://symfony.com/doc/current/performance.html

Things I'm unsure about:

- The current approach has a minor drawback: Once you mount `/var/www/html`, the default sqlite database setup will vanish, as it will try to search a non-existant on the docker host. Maybe put the sqlite default-empty-database somewhere else, so you can mount the source and still be ready to develop?

Things to mention:

`d:schema:create`, then `d:migrations:version --add` no longer works. It's missing kimai2_sessions. Flipping it
to `d:migrations:migrate` first, then `d:schema:update` leads to alot(!) of changes that are not captured by the migrations.
Sadly this is the price paid with doctrine and their "we support many drivers, but hopefully you're on mysql" behaviour,
same situation on PostgreSQL where you can end up in a schema state that will never migrate fully. The database
will never be in sync with SQLite due to how doctrine inspection always leads to a diff.

How to spool up a demo instance:

```bash
docker build -t kimai/kimai2:dev .
docker run --rm -it -p 8001:8001 kimai/kimai2:dev
```

Related todos:

- [ ] Need to update the [documentation](https://www.kimai.org/documentation/docker.html)
- [ ] Documentation should mention the image is for dev purposes only and will expose sensitive system information to the public, including database credentials and other related system information.
- [ ] Fix [CVE-2020-15094](https://symfony.com/cve-2020-15094)
