### PR TITLE
Re-order search form

### DIFF
--- a/src/Form/Toolbar/TimesheetToolbarForm.php
+++ b/src/Form/Toolbar/TimesheetToolbarForm.php
@@ -29,14 +29,14 @@ class TimesheetToolbarForm extends AbstractToolbarForm
         }
 
         $this->addSearchTermInputField($builder);
-        if ($options['include_user']) {
-            $this->addUsersChoice($builder);
-        }
         $this->addDateRangeChoice($builder);
         $this->addCustomerMultiChoice($builder, $newOptions, true);
         $this->addProjectMultiChoice($builder, $newOptions, true, true);
         $this->addActivityMultiChoice($builder, [], true);
         $this->addTagInputField($builder);
+        if ($options['include_user']) {
+            $this->addUsersChoice($builder);
+        }
         $this->addTimesheetStateChoice($builder);
         $this->addExportStateChoice($builder);
         $this->addPageSizeChoice($builder);

--- a/templates/export/index.html.twig
+++ b/templates/export/index.html.twig
@@ -40,8 +40,8 @@
             {{ form_row(form.customers) }}
             {{ form_row(form.projects) }}
             {{ form_row(form.activities) }}
-            {{ form_row(form.users) }}
             {{ form_row(form.tags) }}
+            {{ form_row(form.users) }}
             {{ form_row(form.exported) }}
             {{ form_row(form.state) }}
             {{ form_row(form.markAsExported) }}

--- a/templates/invoice/index.html.twig
+++ b/templates/invoice/index.html.twig
@@ -42,11 +42,11 @@
                 {% if form.activities is defined %}
                     {{ form_row(form.activities) }}
                 {% endif %}
-                {% if form.users is defined %}
-                    {{ form_row(form.users) }}
-                {% endif %}
                 {% if form.tags is defined %}
                     {{ form_row(form.tags) }}
+                {% endif %}
+                {% if form.users is defined %}
+                    {{ form_row(form.users) }}
                 {% endif %}
                 {% if form.exported is defined %}
                     {{ form_row(form.exported) }}


### PR DESCRIPTION
## Description

Unify order of user/tags fields in search form:

- timesheet admin
- invoice
- export

Fixes #2118 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
