### PR TITLE
Added DateActivityInvoiceCalculator

### DIFF
--- a/src/Invoice/Calculator/DateActivityInvoiceCalculator.php
+++ b/src/Invoice/Calculator/DateActivityInvoiceCalculator.php
@@ -1,10 +1,16 @@
 <?php
 
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 namespace App\Invoice\Calculator;
 
 use App\Invoice\CalculatorInterface;
 use App\Invoice\InvoiceItemInterface;
-use App\Invoice\InvoiceItem;
 
 /**
  * Calculator for filtering activities and dates.

--- a/src/Invoice/Calculator/DateActivityInvoiceCalculator.php
+++ b/src/Invoice/Calculator/DateActivityInvoiceCalculator.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Invoice\Calculator;
+
+use App\Invoice\CalculatorInterface;
+use App\Invoice\InvoiceItemInterface;
+use App\Invoice\InvoiceItem;
+
+/**
+ * Calculator for filtering activities and dates.
+ */
+class DateActivityInvoiceCalculator extends AbstractSumInvoiceCalculator implements CalculatorInterface
+{
+    protected function calculateSumIdentifier(InvoiceItemInterface $invoiceItem): string
+    {
+        // Fetch entries from activites
+        $activity = $invoiceItem->getActivity()->getId();
+        // Splits string into array
+        $activity_array = explode(" ", $activity);
+
+        // Fetch all entries from timesheet
+        $date = $invoiceItem->getBegin()->format('Y-m-d');
+        // Splits string into array
+        $date_array = explode(" ", $date);
+
+        // Merges both arrays together
+        $activity_date_array = array_merge($date_array, $activity_array);
+        // Creates from array a readable string for Kimai
+        $activity_date_string = implode(" ", $activity_date_array);
+
+        // Returns the new created string
+        return $activity_date_string;
+    }
+
+    /**
+     * Id for creating invoice with this calculator.
+     */
+    public function getId(): string
+    {
+        return 'date-activity';
+    }
+}

--- a/translations/invoice-calculator.de.xlf
+++ b/translations/invoice-calculator.de.xlf
@@ -34,6 +34,10 @@
                 <source>weekly</source>
                 <target>Wöchentlich: ein Eintrag pro Woche (verwendet Startdatum)</target>
             </trans-unit>
+            <trans-unit id="date-activity">
+                <source>date-activity</source>
+                <target>Datum und Tätigkeit: ein Eintrag pro Aktivität und Tag (verwendet Startdatum)</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/translations/invoice-calculator.en.xlf
+++ b/translations/invoice-calculator.en.xlf
@@ -34,6 +34,10 @@
                 <source>weekly</source>
                 <target>Weekly: one entry per week (uses start date)</target>
             </trans-unit>
+            <trans-unit id="date-activity">
+                <source>date-activity</source>
+                <target>Date and Activity: one entry per activity and day (uses start date)</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
## Description
Added a DateActivityInvoiceCalculator for Invoices. It merges the logic of the ActivityInvoiceCalculator and the DateInvoiceCalculator for filtering between all activities and sum them up to one date.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [X] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
