### PR TITLE
allow to reassign timesheet from delete user dialog

### DIFF
--- a/src/Controller/UserController.php
+++ b/src/Controller/UserController.php
@@ -16,7 +16,9 @@ use App\Export\Spreadsheet\UserExporter;
 use App\Export\Spreadsheet\Writer\BinaryFileResponseWriter;
 use App\Export\Spreadsheet\Writer\XlsxWriter;
 use App\Form\Toolbar\UserToolbarForm;
+use App\Form\Type\UserType;
 use App\Form\UserCreateType;
+use App\Repository\Query\UserFormTypeQuery;
 use App\Repository\Query\UserQuery;
 use App\Repository\TimesheetRepository;
 use App\Repository\UserRepository;
@@ -167,6 +169,16 @@ final class UserController extends AbstractController
                     'data-msg-error' => 'action.delete.error',
                 ]
             ])
+            ->add('user', UserType::class, [
+                'query_builder' => function (UserRepository $repo) use ($userToDelete) {
+                    $query = new UserFormTypeQuery();
+                    $query->addUserToIgnore($userToDelete);
+                    $query->setUser($this->getUser());
+
+                    return $repo->getQueryBuilderForFormType($query);
+                },
+                'required' => false,
+            ])
             ->setAction($this->generateUrl('admin_user_delete', ['id' => $userToDelete->getId()]))
             ->setMethod('POST')
             ->getForm();
@@ -174,23 +186,21 @@ final class UserController extends AbstractController
         $deleteForm->handleRequest($request);
 
         if ($deleteForm->isSubmitted() && $deleteForm->isValid()) {
-            $entityManager = $this->getDoctrine()->getManager();
-            $entityManager->remove($userToDelete);
-            $entityManager->flush();
-
-            $this->flashSuccess('action.delete.success');
+            try {
+                $this->getRepository()->deleteUser($userToDelete, $deleteForm->get('user')->getData());
+                $this->flashSuccess('action.delete.success');
+            } catch (\Exception $ex) {
+                $this->flashDeleteException($ex);
+            }
 
             return $this->redirectToRoute('admin_user');
         }
 
-        return $this->render(
-            'user/delete.html.twig',
-            [
-                'user' => $userToDelete,
-                'stats' => $stats,
-                'form' => $deleteForm->createView(),
-            ]
-        );
+        return $this->render('user/delete.html.twig', [
+            'user' => $userToDelete,
+            'stats' => $stats,
+            'form' => $deleteForm->createView(),
+        ]);
     }
 
     /**

--- a/src/Repository/Query/UserFormTypeQuery.php
+++ b/src/Repository/Query/UserFormTypeQuery.php
@@ -22,6 +22,10 @@ final class UserFormTypeQuery extends BaseFormTypeQuery
      * @var User[]
      */
     private $includeUsers = [];
+    /**
+     * @var User[]
+     */
+    private $ignoredUsers = [];
 
     /**
      * Sets a list of users which must be included in the result always.
@@ -44,5 +48,28 @@ final class UserFormTypeQuery extends BaseFormTypeQuery
     public function getUsersAlwaysIncluded(): array
     {
         return $this->includeUsers;
+    }
+
+    /**
+     * Given user will be excluded from the result set.
+     *
+     * @param User $user
+     * @return $this
+     */
+    public function addUserToIgnore(User $user): UserFormTypeQuery
+    {
+        $this->ignoredUsers[] = $user;
+
+        return $this;
+    }
+
+    /**
+     * Returns the list of users that should not be loaded.
+     *
+     * @return User[]
+     */
+    public function getUsersToIgnore(): array
+    {
+        return $this->ignoredUsers;
     }
 }

--- a/templates/user/delete.html.twig
+++ b/templates/user/delete.html.twig
@@ -14,7 +14,7 @@
     } %}
 
     {{ include(app.request.xmlHttpRequest ? 'default/_form_delete_modal.html.twig' : 'default/_form_delete.html.twig', {
-        'message': "admin_user.short_stats"|trans(params),
+        'message': ("admin_user.short_stats"|trans(params) ~ "admin_entity.delete_confirm"|trans),
         'form': form,
         'used': inUse,
         'back': path('admin_user')

--- a/tests/Repository/Query/UserFormTypeQueryTest.php
+++ b/tests/Repository/Query/UserFormTypeQueryTest.php
@@ -34,5 +34,9 @@ class UserFormTypeQueryTest extends BaseFormTypeQueryTest
         self::assertEquals([], $sut->getUsersAlwaysIncluded());
         self::assertInstanceOf(UserFormTypeQuery::class, $sut->setUsersAlwaysIncluded($users));
         self::assertSame($users, $sut->getUsersAlwaysIncluded());
+
+        self::assertEquals([], $sut->getUsersToIgnore());
+        self::assertInstanceOf(UserFormTypeQuery::class, $sut->addUserToIgnore($users[0]));
+        self::assertSame([$users[0]], $sut->getUsersToIgnore());
     }
 }


### PR DESCRIPTION
## Description

Allows to choose a user account to reassign all timesheets to.
Allows reassigns the invoices, created by the user that is going to be deleted.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
