### PR TITLE
helper function for invoice templates

### DIFF
--- a/src/Invoice/InvoiceItem.php
+++ b/src/Invoice/InvoiceItem.php
@@ -88,6 +88,15 @@ final class InvoiceItem
         return $this->additionalFields;
     }
 
+    public function getAdditionalField(string $name, $default = null)
+    {
+        if (isset($this->additionalFields[$name])) {
+            return $this->additionalFields[$name];
+        }
+
+        return $default;
+    }
+
     public function getActivity(): ?Activity
     {
         return $this->activity;

--- a/tests/Invoice/InvoiceItemTest.php
+++ b/tests/Invoice/InvoiceItemTest.php
@@ -30,6 +30,10 @@ class InvoiceItemTest extends TestCase
         self::assertNull($sut->getProject());
         self::assertIsArray($sut->getAdditionalFields());
         self::assertEmpty($sut->getAdditionalFields());
+        self::assertNull($sut->getAdditionalField('foo'));
+        self::assertEquals('bar', $sut->getAdditionalField('foo', 'bar'));
+        self::assertInstanceOf(InvoiceItem::class, $sut->addAdditionalField('foo', 'bar2'));
+        self::assertEquals('bar2', $sut->getAdditionalField('foo'));
         self::assertEquals(0, $sut->getAmount());
         self::assertNull($sut->getBegin());
         self::assertNull($sut->getActivity());


### PR DESCRIPTION
## Description

Allow to render meta fields in twig invoice templates

Previously: 
```
                        {% if entry.additionalFields['language'] is defined %}
                            {{ entry.additionalFields['language'] }}
                        {% endif %}
```
Afterwards:
```
                            {{ entry.additionalField('language') }}
```
## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
