### PR TITLE
Allow just one number in the duration hours

### DIFF
--- a/src/Form/TimesheetEditForm.php
+++ b/src/Form/TimesheetEditForm.php
@@ -122,7 +122,7 @@ class TimesheetEditForm extends AbstractType
                 'required' => false,
                 'attr' => [
                     'placeholder' => '00:00',
-                    'pattern' => '[0-9]{2,3}:[0-9]{2}'
+                    'pattern' => '[0-9]{1,3}:[0-9]{2}'
                 ]
             ]);
         }


### PR DESCRIPTION
## Description
Currently when adding a new timesheet through the web UI the duration must be given in the format hh:mm. In most other systems you can enter the hours with just one number, ie. 2:30 for 2 hours 30 minutes.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [X] I verified that my code applies to the guidelines (`composer code-check`)
- [N/A] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [X] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
