### PR TITLE
#2139: Allow both duration and end fields to be used in API

### DIFF
--- a/src/Form/API/TimesheetApiEditForm.php
+++ b/src/Form/API/TimesheetApiEditForm.php
@@ -49,7 +49,8 @@ class TimesheetApiEditForm extends TimesheetEditForm
 
         $resolver->setDefaults([
             'csrf_protection' => false,
-            'allow_duration' => false,
+            'allow_duration' => true,
+            'allow_end_datetime' => true,
             // overwritten and changed to default "true",
             // because the docs are cached without these fields otherwise
             'include_user' => true,

--- a/src/Form/TimesheetEditForm.php
+++ b/src/Form/TimesheetEditForm.php
@@ -113,7 +113,8 @@ class TimesheetEditForm extends AbstractType
 
         if ($options['allow_duration']) {
             $this->addDuration($builder);
-        } elseif ($options['allow_end_datetime']) {
+        }
+        if ($options['allow_end_datetime']) {
             $this->addEnd($builder, $dateTimeOptions);
         }
 
@@ -202,12 +203,11 @@ class TimesheetEditForm extends AbstractType
                 /** @var Timesheet $data */
                 $data = $event->getData();
                 $duration = $data->getDuration();
-                $end = null;
-                if (null !== $duration) {
+                if (!empty($duration)) {
                     $end = clone $data->getBegin();
                     $end->modify('+ ' . $duration . 'seconds');
+                    $data->setEnd($end);
                 }
-                $data->setEnd($end);
             }
         );
     }


### PR DESCRIPTION
## Description
I stumbled again on the duration field not working in the API the way I think it should when creating a SailfishOS client for Kimai. Here's an attempt at fixing the issue. Let me know what you think! This should allow using both the duration and end field in the API and in my tests seemed to work perfectly both in API and in the web UI.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [X] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)

Fixes #2139.