### PR TITLE
replace striptags with validator

### DIFF
--- a/src/Controller/SystemConfigurationController.php
+++ b/src/Controller/SystemConfigurationController.php
@@ -23,6 +23,7 @@ use App\Form\Type\TrackingModeType;
 use App\Form\Type\WeekDaysType;
 use App\Form\Type\YesNoType;
 use App\Repository\ConfigurationRepository;
+use App\Validator\Constraints\AllowedHtmlTags;
 use App\Validator\Constraints\DateTimeFormat;
 use App\Validator\Constraints\TimeFormat;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
@@ -438,12 +439,14 @@ final class SystemConfigurationController extends AbstractController
                         ->setName('theme.branding.company')
                         ->setTranslationDomain('system-configuration')
                         ->setRequired(false)
-                        ->setType(TextType::class),
+                        ->setType(TextType::class)
+                        ->setConstraints([new AllowedHtmlTags(['tags' => '<b><i><u><strong><em><img><svg>'])]),
                     (new Configuration())
                         ->setName('theme.branding.mini')
                         ->setTranslationDomain('system-configuration')
                         ->setRequired(false)
-                        ->setType(TextType::class),
+                        ->setType(TextType::class)
+                        ->setConstraints([new AllowedHtmlTags(['tags' => '<b><i><u><strong><em><img><svg>'])]),
                     (new Configuration())
                         ->setName('theme.branding.title')
                         ->setTranslationDomain('system-configuration')

--- a/src/Validator/Constraints/AllowedHtmlTags.php
+++ b/src/Validator/Constraints/AllowedHtmlTags.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+
+class AllowedHtmlTags extends Constraint
+{
+    public const DISALLOWED_TAGS_FOUND = 'kimai-allowed-html-tags-00';
+
+    public $tags;
+
+    protected static $errorNames = [
+        self::DISALLOWED_TAGS_FOUND => 'The given value contains disallowed HTML tags.',
+    ];
+
+    public $message = 'This string contains invalid HTML tags.';
+
+    public function getTargets()
+    {
+        return self::PROPERTY_CONSTRAINT;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getDefaultOption()
+    {
+        return 'tags';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getRequiredOptions()
+    {
+        return ['tags'];
+    }
+}

--- a/src/Validator/Constraints/AllowedHtmlTags.php
+++ b/src/Validator/Constraints/AllowedHtmlTags.php
@@ -11,6 +11,10 @@ namespace App\Validator\Constraints;
 
 use Symfony\Component\Validator\Constraint;
 
+/**
+ * @Annotation
+ * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
+ */
 class AllowedHtmlTags extends Constraint
 {
     public const DISALLOWED_TAGS_FOUND = 'kimai-allowed-html-tags-00';
@@ -22,11 +26,6 @@ class AllowedHtmlTags extends Constraint
     ];
 
     public $message = 'This string contains invalid HTML tags.';
-
-    public function getTargets()
-    {
-        return self::PROPERTY_CONSTRAINT;
-    }
 
     /**
      * {@inheritdoc}

--- a/src/Validator/Constraints/AllowedHtmlTagsValidator.php
+++ b/src/Validator/Constraints/AllowedHtmlTagsValidator.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Exception\UnexpectedValueException;
+
+class AllowedHtmlTagsValidator extends ConstraintValidator
+{
+    /**
+     * @param string|mixed $value
+     * @param Constraint $constraint
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        if (!($constraint instanceof AllowedHtmlTags)) {
+            throw new UnexpectedTypeException($constraint, __NAMESPACE__ . '\AllowedHtmlTags');
+        }
+
+        if (null === $value || '' === $value) {
+            return;
+        }
+
+        if (!is_scalar($value) && !(\is_object($value) && method_exists($value, '__toString'))) {
+            throw new UnexpectedValueException($value, 'string');
+        }
+
+        $value = (string) $value;
+
+        if (strip_tags($value, $constraint->tags) !== $value) {
+            $this->context->buildViolation('This string contains invalid HTML tags.')
+                ->setTranslationDomain('validators')
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode(AllowedHtmlTags::DISALLOWED_TAGS_FOUND)
+                ->addViolation();
+        }
+    }
+}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -72,7 +72,7 @@
 
 {% block logo_mini %}
     {% if not kimai_context.branding.mini is empty %}
-        {{ kimai_context.branding.mini|striptags('<b><i><u><strong><em>')|raw }}
+        {{ kimai_context.branding.mini|raw }}
     {% else %}
         <b>K</b>TT
     {% endif %}
@@ -80,7 +80,7 @@
 
 {% block logo_large %}
     {% if not kimai_context.branding.company is empty %}
-        {{ kimai_context.branding.company|striptags('<b><i><u><strong><em>')|raw }}
+        {{ kimai_context.branding.company|raw }}
     {% else %}
         <b>Kimai</b> - Time Tracking
     {% endif %}

--- a/tests/Validator/Constraints/AllowedHtmlTagsTest.php
+++ b/tests/Validator/Constraints/AllowedHtmlTagsTest.php
@@ -17,6 +17,7 @@ use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 
 /**
  * @covers \App\Validator\Constraints\AllowedHtmlTags
+ * @covers \App\Validator\Constraints\AllowedHtmlTagsValidator
  */
 class AllowedHtmlTagsTest extends ConstraintValidatorTestCase
 {
@@ -55,7 +56,9 @@ class AllowedHtmlTagsTest extends ConstraintValidatorTestCase
     {
         return [
             ['', 'foo'],
+            ['', ''],
             ['<i>', 'foo<i>kjhg</i>'],
+            ['<i>', 'foo<I>kjhg</I>'],
             ['<u><i>', 'foo<i>kj<u>h</u>g</i><u>kjhgk</u>'],
         ];
     }

--- a/tests/Validator/Constraints/AllowedHtmlTagsTest.php
+++ b/tests/Validator/Constraints/AllowedHtmlTagsTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Validator\Constraints;
+
+use App\Validator\Constraints\AllowedHtmlTags;
+use App\Validator\Constraints\AllowedHtmlTagsValidator;
+use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Exception\UnexpectedTypeException;
+use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
+
+/**
+ * @covers \App\Validator\Constraints\AllowedHtmlTags
+ */
+class AllowedHtmlTagsTest extends ConstraintValidatorTestCase
+{
+    protected function createValidator()
+    {
+        return new AllowedHtmlTagsValidator();
+    }
+
+    public function testConstraintIsInvalid()
+    {
+        $this->expectException(UnexpectedTypeException::class);
+
+        $this->validator->validate('foo', new NotBlank());
+    }
+
+    /**
+     * @dataProvider getValidValues
+     * @param string $role
+     */
+    public function testConstraintWithValidValue(string $allowedTags, string $testString)
+    {
+        $constraint = new AllowedHtmlTags(['tags' => $allowedTags]);
+        $this->validator->validate($testString, $constraint);
+        $this->assertNoViolation();
+    }
+
+    public function testNullIsInvalid()
+    {
+        $this->validator->validate(null, new AllowedHtmlTags(['tags' => '<i>', 'message' => 'myMessage']));
+
+        $this->assertNoViolation();
+    }
+
+    public function getValidValues()
+    {
+        return [
+            ['', 'foo'],
+            ['<i>', 'foo<i>kjhg</i>'],
+            ['<u><i>', 'foo<i>kj<u>h</u>g</i><u>kjhgk</u>'],
+        ];
+    }
+
+    public function getInvalidValues()
+    {
+        return [
+            ['', 'foo<i>kjhg</i>'],
+            ['<u>', 'foo<i>kjhg</i>'],
+            ['<i>', 'foo<u>kjhg</u>'],
+        ];
+    }
+
+    /**
+     * @dataProvider getInvalidValues
+     * @param mixed $role
+     */
+    public function testValidationError(string $allowedTags, string $testString)
+    {
+        $constraint = new AllowedHtmlTags([
+            'tags' => $allowedTags,
+        ]);
+
+        $this->validator->validate($testString, $constraint);
+
+        $this->buildViolation('This string contains invalid HTML tags.')
+            ->setParameter('{{ value }}', '"' . $testString . '"')
+            ->setCode(AllowedHtmlTags::DISALLOWED_TAGS_FOUND)
+            ->assertRaised();
+    }
+}

--- a/tests/Validator/Constraints/AllowedHtmlTagsTest.php
+++ b/tests/Validator/Constraints/AllowedHtmlTagsTest.php
@@ -34,7 +34,8 @@ class AllowedHtmlTagsTest extends ConstraintValidatorTestCase
 
     /**
      * @dataProvider getValidValues
-     * @param string $role
+     * @param string $allowedTags
+     * @param string $testString
      */
     public function testConstraintWithValidValue(string $allowedTags, string $testString)
     {
@@ -70,7 +71,8 @@ class AllowedHtmlTagsTest extends ConstraintValidatorTestCase
 
     /**
      * @dataProvider getInvalidValues
-     * @param mixed $role
+     * @param string $allowedTags
+     * @param string $testString
      */
     public function testValidationError(string $allowedTags, string $testString)
     {

--- a/tests/Validator/Constraints/AllowedHtmlTagsTest.php
+++ b/tests/Validator/Constraints/AllowedHtmlTagsTest.php
@@ -33,6 +33,14 @@ class AllowedHtmlTagsTest extends ConstraintValidatorTestCase
         $this->validator->validate('foo', new NotBlank());
     }
 
+    public function testConstraintIsInvalidObject()
+    {
+        $this->expectException(UnexpectedTypeException::class);
+
+        $constraint = new AllowedHtmlTags(['tags' => '']);
+        $this->validator->validate(new \stdClass(), $constraint);
+    }
+
     /**
      * @dataProvider getValidValues
      * @param string $allowedTags


### PR DESCRIPTION
## Description

Instead of using strip tags twice during each run, only validate config during update

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
