### PR TITLE
hide multi-update-form for tags if delete_tag permission is missing

### DIFF
--- a/src/Controller/TagController.php
+++ b/src/Controller/TagController.php
@@ -51,12 +51,16 @@ class TagController extends AbstractController
         }
 
         $tags = $repository->getTagCount($query);
+        $multiUpdateForm = $this->getMultiUpdateForm($repository);
+        if ($multiUpdateForm !== null) {
+            $multiUpdateForm = $multiUpdateForm->createView();
+        }
 
         return $this->render('tags/index.html.twig', [
             'tags' => $tags,
             'query' => $query,
             'toolbarForm' => $form->createView(),
-            'multiUpdateForm' => $this->getMultiUpdateForm($repository)->createView(),
+            'multiUpdateForm' => $multiUpdateForm,
         ]);
     }
 
@@ -145,10 +149,16 @@ class TagController extends AbstractController
         return $this->redirectToRoute('tags');
     }
 
-    protected function getMultiUpdateForm(TagRepository $repository): FormInterface
+    protected function getMultiUpdateForm(TagRepository $repository): ?FormInterface
     {
         $dto = new MultiUpdateTableDTO();
-        $dto->addDelete($this->generateUrl('tags_multi_delete'));
+        if ($this->isGranted('delete_tag')) {
+            $dto->addDelete($this->generateUrl('tags_multi_delete'));
+        }
+
+        if (!$dto->hasAction()) {
+            return null;
+        }
 
         return $this->createForm(MultiUpdateTable::class, $dto, [
             'action' => $this->generateUrl('tags'),

--- a/src/Form/MultiUpdate/MultiUpdateTableDTO.php
+++ b/src/Form/MultiUpdate/MultiUpdateTableDTO.php
@@ -51,6 +51,11 @@ class MultiUpdateTableDTO
         return $this->actions;
     }
 
+    public function hasAction(): bool
+    {
+        return \count($this->actions) > 1;
+    }
+
     public function addAction(string $label, string $url): MultiUpdateTableDTO
     {
         $this->actions[$label] = $url;

--- a/templates/tags/index.html.twig
+++ b/templates/tags/index.html.twig
@@ -14,12 +14,19 @@
         {{ widgets.nothing_found('kimai.tagUpdate') }}
     {% else %}
 
-        {% set columns = {
-            'id': {'class': 'alwaysVisible multiCheckbox', 'orderBy': false, 'title': false, 'html_before': tables.datatable_multiupdate_all()},
+        {% set columns = {} %}
+
+        {% if multiUpdateForm is not null %}
+            {% set columns = columns|merge({
+                'id': {'class': 'alwaysVisible multiCheckbox', 'orderBy': false, 'title': false, 'html_before': tables.datatable_multiupdate_all()},
+            }) %}
+        {% endif %}
+
+        {% set columns = columns|merge({
             'name': {'class': 'alwaysVisible'},
             'amount': {'class': 'text-center w-min'},
             'actions': {'class': 'actions alwaysVisible'},
-        } %}
+        }) %}
 
         {% set tableName = 'admin_tags' %}
         {% set manageAllowed = is_granted('manage_tag') %}
@@ -32,7 +39,11 @@
             {% endif %}
 
             <tr{% if manageAllowed %} class="modal-ajax-form open-edit" data-href="{{ path('tags_edit', {'id': tag.id}) }}"{% endif %}>
-                <td class="text-nowrap">{{ tables.datatable_multiupdate_row(tag.id) }}</td>
+                {% if multiUpdateForm is not null %}
+                    <td class="text-nowrap">
+                        {{ tables.datatable_multiupdate_row(tag.id) }}
+                    </td>
+                {% endif %}
                 <td class="{{ tables.data_table_column_class(tableName, columns, 'name') }}">
                     {{ widgets.label_color_dot('tag', true, tag.name, null, tag.color|default('#00a65a')) }}
                 </td>

--- a/tests/Form/MultiUpdate/MultiUpdateTableDTOTest.php
+++ b/tests/Form/MultiUpdate/MultiUpdateTableDTOTest.php
@@ -28,6 +28,7 @@ class MultiUpdateTableDTOTest extends TestCase
         self::assertEmpty($sut->getEntities());
         self::assertEquals(['' => ''], $sut->getActions());
         self::assertNull($sut->getAction());
+        self::assertFalse($sut->hasAction());
     }
 
     public function testSetterAndGetter()
@@ -35,6 +36,7 @@ class MultiUpdateTableDTOTest extends TestCase
         $sut = new MultiUpdateTableDTO();
 
         self::assertInstanceOf(MultiUpdateTableDTO::class, $sut->addUpdate('foo'));
+        self::assertTrue($sut->hasAction());
         self::assertInstanceOf(MultiUpdateTableDTO::class, $sut->addDelete('bar'));
         self::assertInstanceOf(MultiUpdateTableDTO::class, $sut->addAction('test', 'hello/world'));
         self::assertEquals(


### PR DESCRIPTION
## Description

hide multi-update-form for tags if delete_tag permission is missing

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
