### PR TITLE
do not break excel invoice templates with replacer inside formulas

### DIFF
--- a/src/Invoice/Renderer/AbstractSpreadsheetRenderer.php
+++ b/src/Invoice/Renderer/AbstractSpreadsheetRenderer.php
@@ -68,7 +68,8 @@ abstract class AbstractSpreadsheetRenderer extends AbstractRenderer
             foreach ($row->getCellIterator() as $cell) {
                 $value = $cell->getValue();
                 $replacer = null;
-                if (stripos($value, '${') === false) {
+                $firstReplacerPos = stripos($value, '${');
+                if ($firstReplacerPos === false) {
                     continue;
                 }
 
@@ -86,16 +87,25 @@ abstract class AbstractSpreadsheetRenderer extends AbstractRenderer
                 }
 
                 // we can have mixed cell content, which makes it much more complicated
+                // templates can have a formula, which utilize the timesheet records content like this:
+                // =IF("${entry.category}"="work";"${entry.activity}";"")
+                $contentLooksLikeFormula = false;
                 foreach ($replacer as $key => $content) {
                     $searchKey = '${' . $key . '}';
                     if (stripos($value, $searchKey) === false) {
                         continue;
                     }
+                    if (\is_string($content) && $content[0] === '=') {
+                        $contentLooksLikeFormula = true;
+                    }
                     $value = str_replace($searchKey, $content, $value);
                 }
 
-                if (\is_string($value)) {
+                if ($contentLooksLikeFormula && $firstReplacerPos === 0) {
+                    // see https://github.com/kevinpapst/kimai2/pull/2054
+                    // see https://github.com/kevinpapst/kimai2/issues/2014
                     $cell->setValueExplicit($value, DataType::TYPE_STRING);
+                //$cell->setValue($value);
                 } else {
                     $cell->setValue($value);
                 }

--- a/src/Invoice/Renderer/AbstractSpreadsheetRenderer.php
+++ b/src/Invoice/Renderer/AbstractSpreadsheetRenderer.php
@@ -103,9 +103,7 @@ abstract class AbstractSpreadsheetRenderer extends AbstractRenderer
 
                 if ($contentLooksLikeFormula && $firstReplacerPos === 0) {
                     // see https://github.com/kevinpapst/kimai2/pull/2054
-                    // see https://github.com/kevinpapst/kimai2/issues/2014
                     $cell->setValueExplicit($value, DataType::TYPE_STRING);
-                //$cell->setValue($value);
                 } else {
                     $cell->setValue($value);
                 }


### PR DESCRIPTION
## Description

Bugfix in #2054 was too strict: if an invoice excel template used a formula like `=IF("${entry.category}"="work";"${entry.activity}";"")` it was not executed as formula any longer.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
