### PR TITLE
add setAvatarBase64

### DIFF
--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -268,7 +268,7 @@ class User extends BaseUser implements UserInterface
     public function setAvatarBase64(?string $avatar): User
     {
         $prefix = 'data:image/jpeg,base64,';
-        $this->avatar = $prefix.$avatar;
+        $this->avatar = $prefix . $avatar;
 
         return $this;
     }

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -267,7 +267,8 @@ class User extends BaseUser implements UserInterface
 
     public function setAvatarBase64(?string $avatar): User
     {
-        $this->avatar = "data:image/jpeg,base64,".$avatar;
+        $prefix = 'data:image/jpeg,base64,'
+        $this->avatar = $prefix.$avatar;
 
         return $this;
     }

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -267,7 +267,7 @@ class User extends BaseUser implements UserInterface
 
     public function setAvatarBase64(?string $avatar): User
     {
-        $prefix = 'data:image/jpeg,base64,'
+        $prefix = 'data:image/jpeg,base64,';
         $this->avatar = $prefix.$avatar;
 
         return $this;

--- a/src/Entity/User.php
+++ b/src/Entity/User.php
@@ -265,6 +265,13 @@ class User extends BaseUser implements UserInterface
         return $this;
     }
 
+    public function setAvatarBase64(?string $avatar): User
+    {
+        $this->avatar = "data:image/jpeg,base64,".$avatar;
+
+        return $this;
+    }
+
     public function getApiToken(): ?string
     {
         return $this->apiToken;


### PR DESCRIPTION
Fix for #2323  and #1405 

Added 
   ` public function setAvatarBase64(?string $avatar)`
that should sync base64 jpegPhoto from ldap indo kimai

## Description
A clear and concise description of what this pull request adds or changes.

## Types of changes
- [ x] New feature (non-breaking change which adds functionality)


## Checklist
- [ x ] I verified that my code applies to the guidelines (`composer code-check`)
I DID NOT update the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [ x ] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
