### PR TITLE
Show budget and time-budget in listing views

### DIFF
--- a/src/Controller/ActivityController.php
+++ b/src/Controller/ActivityController.php
@@ -92,6 +92,7 @@ final class ActivityController extends AbstractController
             'query' => $query,
             'toolbarForm' => $form->createView(),
             'metaColumns' => $this->findMetaColumns($query),
+            'defaultCurrency' => $this->configuration->getCustomerDefaultCurrency()
         ]);
     }
 

--- a/src/Widget/Type/UserTeamProjects.php
+++ b/src/Widget/Type/UserTeamProjects.php
@@ -62,7 +62,10 @@ class UserTeamProjects extends SimpleWidget implements AuthorizedWidget, UserWid
 
         foreach ($projects as $id => $project) {
             if ($project->getBudget() > 0 || $project->getTimeBudget() > 0) {
-                $stats[] = $this->repository->getProjectStatistics($project);
+                $stats[] = [
+                    'project' => $project,
+                    'stats' => $this->repository->getProjectStatistics($project),
+                ];
             }
         }
 

--- a/templates/activity/index.html.twig
+++ b/templates/activity/index.html.twig
@@ -15,6 +15,8 @@
     }) %}
 {% endfor %}
 {% set columns = columns|merge({
+    'budget': {'class': 'hidden-xs hidden-sm hidden', 'title': 'label.budget'|trans},
+    'timeBudget': {'class': 'hidden-xs hidden-sm hidden', 'title': 'label.timeBudget'|trans},
     'team': {'class': 'text-center w-min', 'orderBy': false},
     'visible': {'class': 'text-center hidden w-min'},
     'actions': {'class': 'actions alwaysVisible'},
@@ -58,6 +60,8 @@
                         {{ tables.datatable_meta_column(entry, field) }}
                     </td>
                 {% endfor %}
+                <td class="{{ tables.data_table_column_class(tableName, columns, 'budget') }}">{{ entry.budget|money((entry.project is null ? defaultCurrency : entry.project.customer.currency)) }}</td>
+                <td class="{{ tables.data_table_column_class(tableName, columns, 'timeBudget') }}">{{ entry.timeBudget|duration }}</td>
                 <td class="{{ tables.data_table_column_class(tableName, columns, 'team') }}">{{ widgets.badge_team_access(entry.teams) }}</td>
                 <td class="{{ tables.data_table_column_class(tableName, columns, 'visible') }}">{{ widgets.label_visible(entry.visible) }}</td>
                 <td class="{{ tables.data_table_column_class(tableName, columns, 'actions') }}">{{ actions.activity(entry, 'index') }}</td>

--- a/templates/customer/index.html.twig
+++ b/templates/customer/index.html.twig
@@ -26,6 +26,8 @@
     }) %}
 {% endfor %}
 {% set columns = columns|merge({
+    'budget': {'class': 'hidden-xs hidden-sm hidden', 'title': 'label.budget'|trans},
+    'timeBudget': {'class': 'hidden-xs hidden-sm hidden', 'title': 'label.timeBudget'|trans},
     'team': {'class': 'text-center w-min', 'orderBy': false},
     'visible': {'class': 'text-center hidden w-min'},
     'actions': {'class': 'actions alwaysVisible'},
@@ -69,6 +71,8 @@
                         {{ tables.datatable_meta_column(entry, field) }}
                     </td>
                 {% endfor %}
+                <td class="{{ tables.data_table_column_class(tableName, columns, 'budget') }}">{{ entry.budget|money(entry.currency) }}</td>
+                <td class="{{ tables.data_table_column_class(tableName, columns, 'timeBudget') }}">{{ entry.timeBudget|duration }}</td>
                 <td class="{{ tables.data_table_column_class(tableName, columns, 'team') }}">{{ widgets.badge_team_access(entry.teams) }}</td>
                 <td class="{{ tables.data_table_column_class(tableName, columns, 'visible') }}">{{ widgets.label_visible(entry.visible) }}</td>
                 <td class="{{ tables.data_table_column_class(tableName, columns, 'actions') }}">{{ actions.customer(entry, 'index') }}</td>

--- a/templates/project/index.html.twig
+++ b/templates/project/index.html.twig
@@ -19,6 +19,8 @@
     }) %}
 {% endfor %}
 {% set columns = columns|merge({
+    'budget': {'class': 'hidden-xs hidden-sm hidden', 'title': 'label.budget'|trans},
+    'timeBudget': {'class': 'hidden-xs hidden-sm hidden', 'title': 'label.timeBudget'|trans},
     'team': {'class': 'text-center w-min', 'orderBy': false},
     'visible': {'class': 'text-center hidden w-min'},
     'actions': {'class': 'actions alwaysVisible'},
@@ -55,6 +57,8 @@
                         {{ tables.datatable_meta_column(entry, field) }}
                     </td>
                 {% endfor %}
+                <td class="{{ tables.data_table_column_class(tableName, columns, 'budget') }}">{{ entry.budget|money(entry.customer.currency) }}</td>
+                <td class="{{ tables.data_table_column_class(tableName, columns, 'timeBudget') }}">{{ entry.timeBudget|duration }}</td>
                 <td class="{{ tables.data_table_column_class(tableName, columns, 'team') }}">{{ widgets.badge_team_access(entry.teams) }}</td>
                 <td class="{{ tables.data_table_column_class(tableName, columns, 'visible') }}">{{ widgets.label_visible(entry.visible) }}</td>
                 <td class="{{ tables.data_table_column_class(tableName, columns, 'actions') }}">{{ actions.project(entry, 'index') }}</td>

--- a/templates/widget/widget-userteamprojects.html.twig
+++ b/templates/widget/widget-userteamprojects.html.twig
@@ -16,13 +16,14 @@
             {% block box_body %}
                 <table class="table table-hover dataTable" role="grid">
                     <tbody>
-                    {% for stats in projectStats|sort((a, b) => a.project.name <=> b.project.name) %}
-                        {% set project = stats.project %}
-                        <tr{% if is_granted('details', stats.project) %} class="alternative-link open-edit" data-href="{{ path('project_details', {'id': stats.project.id}) }}"{% endif %}>
+                    {% for row in projectStats|sort((a, b) => a.project.name <=> b.project.name) %}
+                        {% set stats = row.stats %}
+                        {% set project = row.project %}
+                        <tr{% if is_granted('details', project) %} class="alternative-link open-edit" data-href="{{ path('project_details', {'id': project.id}) }}"{% endif %}>
                             <td>
-                                {{ widgets.label_project(stats.project) }}
+                                {{ widgets.label_project(project) }}
                                 <br>
-                                <small>{{ widgets.label_customer(stats.project.customer) }}</small>
+                                <small>{{ widgets.label_customer(project.customer) }}</small>
                             </td>
                             <td class="hidden-xs hidden-sm hidden-md">
                                 {% for team in project.teams %}

--- a/tests/Controller/TimesheetControllerTest.php
+++ b/tests/Controller/TimesheetControllerTest.php
@@ -455,6 +455,7 @@ class TimesheetControllerTest extends ControllerBaseTest
                     'hourlyRate' => 100,
                     'begin' => '2020-02-18 01:00',
                     'end' => '2020-02-18 02:10',
+                    'duration' => '01:10',
                     'project' => 1,
                     'activity' => $activity->getId(),
                 ]


### PR DESCRIPTION
## Description

Eye icon allows to display time-budget and budget columns for customer/project/activity.

Fixes #2343 

Columns are hidden by default.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
