### PR TITLE
allow increasing invoice numbers per day

### DIFF
--- a/src/Invoice/Calculator/AbstractSumInvoiceCalculator.php
+++ b/src/Invoice/Calculator/AbstractSumInvoiceCalculator.php
@@ -20,6 +20,17 @@ abstract class AbstractSumInvoiceCalculator extends AbstractMergedCalculator imp
 {
     abstract protected function calculateSumIdentifier(InvoiceItemInterface $invoiceItem): string;
 
+    protected function calculateIdentifier(InvoiceItemInterface $entry): string
+    {
+        $prefix = $this->calculateSumIdentifier($entry);
+
+        if (null !== $entry->getFixedRate()) {
+            return $prefix . '_fixed_' . (string) $entry->getFixedRate();
+        }
+
+        return $prefix . '_hourly_' . (string) $entry->getHourlyRate();
+    }
+
     /**
      * @return InvoiceItem[]
      */
@@ -34,13 +45,7 @@ abstract class AbstractSumInvoiceCalculator extends AbstractMergedCalculator imp
         $invoiceItems = [];
 
         foreach ($entries as $entry) {
-            $id = $this->calculateSumIdentifier($entry);
-
-            if (null !== $entry->getFixedRate()) {
-                $id = $id . '_fixed_' . (string) $entry->getFixedRate();
-            } else {
-                $id = $id . '_hourly_' . (string) $entry->getHourlyRate();
-            }
+            $id = $this->calculateIdentifier($entry);
 
             if (!isset($invoiceItems[$id])) {
                 $invoiceItems[$id] = new InvoiceItem();

--- a/src/Repository/InvoiceRepository.php
+++ b/src/Repository/InvoiceRepository.php
@@ -40,6 +40,20 @@ class InvoiceRepository extends EntityRepository
         $entityManager->flush();
     }
 
+    public function hasInvoice(string $invoiceNumber): bool
+    {
+        $qb = $this->getEntityManager()->createQueryBuilder();
+        $qb->select('count(i.id) as counter')
+            ->from(Invoice::class, 'i')
+            ->andWhere($qb->expr()->eq('i.invoiceNumber', ':number'))
+            ->setParameter('number', $invoiceNumber)
+        ;
+
+        $counter = (int) $qb->getQuery()->getSingleScalarResult();
+
+        return $counter > 0;
+    }
+
     private function getCounterFor(\DateTime $start, \DateTime $end, ?Customer $customer = null): int
     {
         $qb = $this->getEntityManager()->createQueryBuilder();

--- a/tests/Entity/InvoiceTest.php
+++ b/tests/Entity/InvoiceTest.php
@@ -23,6 +23,7 @@ use App\Entity\UserPreference;
 use App\Invoice\Calculator\DefaultCalculator;
 use App\Invoice\InvoiceModel;
 use App\Invoice\NumberGenerator\DateNumberGenerator;
+use App\Repository\InvoiceRepository;
 use App\Repository\Query\InvoiceQuery;
 use App\Tests\Invoice\DebugFormatter;
 use PHPUnit\Framework\TestCase;
@@ -159,11 +160,22 @@ class InvoiceTest extends TestCase
 
         $model->setCalculator($calculator);
 
-        $numberGenerator = new DateNumberGenerator();
+        $numberGenerator = $this->getNumberGeneratorSut();
         $numberGenerator->setModel($model);
 
         $model->setNumberGenerator($numberGenerator);
 
         return $model;
+    }
+
+    private function getNumberGeneratorSut()
+    {
+        $repository = $this->createMock(InvoiceRepository::class);
+        $repository
+            ->expects($this->any())
+            ->method('hasInvoice')
+            ->willReturn(false);
+
+        return new DateNumberGenerator($repository);
     }
 }

--- a/tests/Invoice/InvoiceFilenameTest.php
+++ b/tests/Invoice/InvoiceFilenameTest.php
@@ -15,6 +15,7 @@ use App\Entity\Project;
 use App\Invoice\InvoiceFilename;
 use App\Invoice\InvoiceModel;
 use App\Invoice\NumberGenerator\DateNumberGenerator;
+use App\Repository\InvoiceRepository;
 use App\Repository\Query\InvoiceQuery;
 use PHPUnit\Framework\TestCase;
 
@@ -29,7 +30,7 @@ class InvoiceFilenameTest extends TestCase
         $template = new InvoiceTemplate();
 
         $model = new InvoiceModel(new DebugFormatter());
-        $model->setNumberGenerator(new DateNumberGenerator());
+        $model->setNumberGenerator($this->getNumberGeneratorSut());
         $model->setTemplate($template);
         $model->setCustomer($customer);
 
@@ -70,5 +71,16 @@ class InvoiceFilenameTest extends TestCase
         $customer->setCompany('\"#+ß.!$%&/()=?\\n=/*-+´_<>@' . "\n");
         $sut = new InvoiceFilename($model);
         self::assertEquals($datePrefix . '-ss_n_--Demo_ProjecT1', $sut->getFilename());
+    }
+
+    private function getNumberGeneratorSut()
+    {
+        $repository = $this->createMock(InvoiceRepository::class);
+        $repository
+            ->expects($this->any())
+            ->method('hasInvoice')
+            ->willReturn(false);
+
+        return new DateNumberGenerator($repository);
     }
 }

--- a/tests/Invoice/Renderer/RendererTestTrait.php
+++ b/tests/Invoice/Renderer/RendererTestTrait.php
@@ -28,6 +28,7 @@ use App\Invoice\InvoiceFormatter;
 use App\Invoice\InvoiceModel;
 use App\Invoice\NumberGenerator\DateNumberGenerator;
 use App\Invoice\Renderer\AbstractRenderer;
+use App\Repository\InvoiceRepository;
 use App\Repository\Query\InvoiceQuery;
 
 trait RendererTestTrait
@@ -228,12 +229,23 @@ trait RendererTestTrait
 
         $model->setCalculator($calculator);
 
-        $numberGenerator = new DateNumberGenerator();
+        $numberGenerator = $this->getNumberGeneratorSut();
         $numberGenerator->setModel($model);
 
         $model->setNumberGenerator($numberGenerator);
 
         return $model;
+    }
+
+    private function getNumberGeneratorSut()
+    {
+        $repository = $this->createMock(InvoiceRepository::class);
+        $repository
+            ->expects($this->any())
+            ->method('hasInvoice')
+            ->willReturn(false);
+
+        return new DateNumberGenerator($repository);
     }
 
     protected function getInvoiceModelOneEntry(): InvoiceModel
@@ -301,7 +313,7 @@ trait RendererTestTrait
 
         $model->setCalculator($calculator);
 
-        $numberGenerator = new DateNumberGenerator();
+        $numberGenerator = $this->getNumberGeneratorSut();
         $numberGenerator->setModel($model);
 
         $model->setNumberGenerator($numberGenerator);

--- a/tests/Invoice/ServiceInvoiceTest.php
+++ b/tests/Invoice/ServiceInvoiceTest.php
@@ -92,7 +92,7 @@ class ServiceInvoiceTest extends TestCase
         $sut = $this->getSut([]);
 
         $sut->addCalculator(new DefaultCalculator());
-        $sut->addNumberGenerator(new DateNumberGenerator());
+        $sut->addNumberGenerator($this->getNumberGeneratorSut());
         $sut->addRenderer(
             new TwigRenderer(
                 $this->getMockBuilder(Environment::class)->disableOriginalConstructor()->getMock()
@@ -132,7 +132,7 @@ class ServiceInvoiceTest extends TestCase
 
         $sut = $this->getSut([]);
         $sut->addCalculator(new DefaultCalculator());
-        $sut->addNumberGenerator(new DateNumberGenerator());
+        $sut->addNumberGenerator($this->getNumberGeneratorSut());
 
         $model = $sut->createModel($query);
 
@@ -152,10 +152,21 @@ class ServiceInvoiceTest extends TestCase
 
         $sut = $this->getSut([]);
         $sut->addCalculator(new DefaultCalculator());
-        $sut->addNumberGenerator(new DateNumberGenerator());
+        $sut->addNumberGenerator($this->getNumberGeneratorSut());
 
         $model = $sut->createModel($query);
 
         self::assertEquals('de', $model->getTemplate()->getLanguage());
+    }
+
+    private function getNumberGeneratorSut()
+    {
+        $repository = $this->createMock(InvoiceRepository::class);
+        $repository
+            ->expects($this->any())
+            ->method('hasInvoice')
+            ->willReturn(false);
+
+        return new DateNumberGenerator($repository);
     }
 }


### PR DESCRIPTION
## Description

See #1914 

only for deprecated DateNumberGenerator (before Kimai 1.9)

will append a suffix to the invoice number `-01`, `-02` ... up until `-99` (more than 99 invoices per day will fail)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
