### PR TITLE
Added version ID for simpler comparison

### DIFF
--- a/src/API/Model/Version.php
+++ b/src/API/Model/Version.php
@@ -34,7 +34,7 @@ class Version
      *
      * Follows the same logic as PHP_VERSION_ID, see https://www.php.net/manual/de/function.phpversion.php
      *
-     * @var string
+     * @var int
      *
      * @Serializer\Expose()
      * @Serializer\Groups({"Default"})

--- a/src/API/Model/Version.php
+++ b/src/API/Model/Version.php
@@ -30,6 +30,16 @@ class Version
      */
     protected $version = Constants::VERSION;
     /**
+     * Kimai Version, as integer eg. "19"
+     *
+     * @var string
+     *
+     * @Serializer\Expose()
+     * @Serializer\Groups({"Default"})
+     * @Serializer\Type(name="integer")
+     */
+    protected $versionId = Constants::VERSION_ID;
+    /**
      * Candidate: either "prod" or "dev"
      *
      * @var string

--- a/src/API/Model/Version.php
+++ b/src/API/Model/Version.php
@@ -20,7 +20,7 @@ use JMS\Serializer\Annotation as Serializer;
 class Version
 {
     /**
-     * Kimai Version, eg. "1.9"
+     * Kimai Version, eg. "1.14"
      *
      * @var string
      *
@@ -30,7 +30,9 @@ class Version
      */
     protected $version = Constants::VERSION;
     /**
-     * Kimai Version, as integer eg. "19"
+     * Kimai Version as integer, eg. 11400
+     *
+     * Follows the same logic as PHP_VERSION_ID, see https://www.php.net/manual/de/function.phpversion.php
      *
      * @var string
      *

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -17,11 +17,15 @@ class Constants
     /**
      * The current release version
      */
-    public const VERSION = '1.13';
+    public const VERSION = '1.14';
+    /**
+     * The current release: major * 10000 + minor * 100 + patch
+     */
+    public const VERSION_ID = 11400;
     /**
      * The current release status, either "stable" or "dev"
      */
-    public const STATUS = 'stable';
+    public const STATUS = 'dev';
     /**
      * The software name
      */

--- a/tests/API/StatusControllerTest.php
+++ b/tests/API/StatusControllerTest.php
@@ -46,12 +46,14 @@ class StatusControllerTest extends APIControllerBaseTest
         $this->assertIsArray($result);
 
         $this->assertArrayHasKey('version', $result);
+        $this->assertArrayHasKey('versionId', $result);
         $this->assertArrayHasKey('candidate', $result);
         $this->assertArrayHasKey('semver', $result);
         $this->assertArrayHasKey('name', $result);
         $this->assertArrayHasKey('copyright', $result);
 
         $this->assertSame(Constants::VERSION, $result['version']);
+        $this->assertSame(Constants::VERSION_ID, $result['versionId']);
         $this->assertEquals(Constants::STATUS, $result['candidate']);
         $this->assertEquals(Constants::VERSION . '-' . Constants::STATUS, $result['semver']);
         $this->assertEquals(Constants::NAME, $result['name']);

--- a/tests/ConstantsTest.php
+++ b/tests/ConstantsTest.php
@@ -21,11 +21,11 @@ class ConstantsTest extends TestCase
     {
         $version = Constants::VERSION;
         $versionParts = explode('.', $version);
+        $major = (int) $versionParts[0];
+        $minor = (int) $versionParts[1];
+        $patch = isset($versionParts[2]) ? (int) $versionParts[2] : 0;
 
-        $expectedId = $versionParts[0] * 10000 + $versionParts[1] * 100;
-        if (isset($versionParts[2])) {
-            $expectedId += (int) $versionParts[2];
-        }
+        $expectedId = $major * 10000 + $minor * 100 + $patch;
 
         self::assertEquals('1.14', Constants::VERSION, 'Invalid release number');
         self::assertEquals('dev', Constants::STATUS, 'Invalid status');

--- a/tests/ConstantsTest.php
+++ b/tests/ConstantsTest.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests;
+
+use App\Constants;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \App\Constants
+ */
+class ConstantsTest extends TestCase
+{
+    public function testBuild()
+    {
+        $version = Constants::VERSION;
+        $versionParts = explode('.', $version);
+
+        $expectedId = $versionParts[0] * 10000 + $versionParts[1] * 100;
+        if (isset($versionParts[2])) {
+            $expectedId += (int) $versionParts[2];
+        }
+
+        self::assertEquals('1.14', Constants::VERSION, 'Invalid release number');
+        self::assertEquals('dev', Constants::STATUS, 'Invalid status');
+        self::assertEquals($expectedId, Constants::VERSION_ID, 'Invalid version ID');
+    }
+}


### PR DESCRIPTION
## Description

Can be used in plugins to check for core version, eg .
```php
if (Constants::VERSION_ID >= 11400) {
...
}
```

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
