### PR TITLE
fix api 404 on page parameter

### DIFF
--- a/config/packages/fos_rest.yaml
+++ b/config/packages/fos_rest.yaml
@@ -26,6 +26,7 @@ fos_rest:
             'Symfony\Component\Routing\Exception\ResourceNotFoundException': 404
             'Symfony\Component\HttpKernel\Exception\NotFoundHttpException': 404
             'App\API\NotFoundException': 404
+            'Pagerfanta\Exception\OutOfRangeCurrentPageException': 404
     body_listener:
         enabled: true
         decoders:


### PR DESCRIPTION
## Description

One of the last updates brought in new major versions of API related libraries ... and they changed something critical.
This fixes the error codes and adds tests to make sure it won't break in the future again.

Fixes https://github.com/kevinpapst/kimai2/issues/2466

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
