### PR TITLE
Improve progressbar values in report

### DIFF
--- a/templates/macros/progressbar.html.twig
+++ b/templates/macros/progressbar.html.twig
@@ -1,3 +1,56 @@
+{% macro progressbar_full(options) %}
+    {% set max = options['max'] ?? 0 %}
+    {% set current = options['current'] ?? 0 %}
+    {% set open = options['open'] ?? null %}
+    {% set reverseColors = options['reverseColors'] ?? false %}
+    {% set formatter = options['format'] ?? null %}
+    {% set currency = options['currency'] ?? null %}
+    {% set percentDecimals = options['decimals'] ?? 0 %}
+    {% if formatter == 'duration' %}
+        {% set currentFormatted = current|duration %}
+        {% set maxFormatted = max|duration %}
+        {% set openFormatted = open is not null ? open|duration : null %}
+    {% elseif formatter == 'money' and currency is not null %}
+        {% set currentFormatted = current|money(currency) %}
+        {% set maxFormatted = max|money(currency) %}
+        {% set openFormatted = open is not null ? open|money(currency) : null %}
+    {% else %}
+        {% set currentFormatted = current %}
+        {% set maxFormatted = max %}
+        {% set openFormatted = open is not null ? open : null %}
+    {% endif %}
+    {% set percentReached = 0 %}
+    {% if max > 0 %}
+        {% set percentReached = (current / (max / 100)) %}
+    {% endif %}
+    {% set width = percentReached|number_format(1, '.', '') %}
+
+    {% if width > 100 %}
+        {% set width = 100 %}
+    {% endif %}
+
+    <div class="progress-group">
+        <div class="progress-title">
+            <span class="progress-text">
+                {{ currentFormatted }}
+            </span>
+            <span class="progress-number">
+                <strong>
+                    {{ maxFormatted }}
+                </strong>
+            </span>
+        </div>
+        <div class="progress">
+            <div class="progress-bar {{ progressbar_color(percentReached, reverseColors) }}" role="progressbar" aria-valuenow="{{ width }}" aria-valuemin="0" aria-valuemax="100" style="width: {{ width }}%"></div>
+        </div>
+        {% if open is not null and open > 0 %}
+            <small>{{ 'stats.percentUsedLeft'|trans({'%percent%': percentReached|number_format(percentDecimals), '%left%': openFormatted}) }}</small>
+        {% else %}
+            <small>{{ 'stats.percentUsed'|trans({'%percent%': percentReached|number_format(percentDecimals)}) }}</small>
+        {% endif %}
+    </div>
+{% endmacro %}
+
 {% macro progressbar(max, current, title, subTitle, reverseColors) %}
     {% set percentReached = 0 %}
     {% if max > 0 %}

--- a/templates/macros/progressbar.html.twig
+++ b/templates/macros/progressbar.html.twig
@@ -5,7 +5,7 @@
     {% set reverseColors = options['reverseColors'] ?? false %}
     {% set formatter = options['format'] ?? null %}
     {% set currency = options['currency'] ?? null %}
-    {% set percentDecimals = options['decimals'] ?? 0 %}
+    {% set percentDecimals = options['decimals'] ?? 1 %}
     {% if formatter == 'duration' %}
         {% set currentFormatted = current|duration %}
         {% set maxFormatted = max|duration %}

--- a/templates/reporting/project_view.html.twig
+++ b/templates/reporting/project_view.html.twig
@@ -75,12 +75,27 @@
                                 <td class="{{ tables.data_table_column_class(tableName, columns, 'durationTotal') }}">{{ entry.durationTotal|duration }}</td>
                                 <td class="{{ tables.data_table_column_class(tableName, columns, 'timeBudget') }}">
                                     {% if project.timeBudget > 0 %}
-                                                {{ progress.progressbar(project.timeBudget, entry.billableDuration|default(0), entry.billableDuration|duration ~ ' / ' ~ project.timeBudget|duration, '') }}
+                                        {% set timeBudgetLeft = project.timeBudget - entry.billableDuration %}
+                                        {% set options = {
+                                            'max': project.timeBudget|default(0),
+                                            'current': entry.billableDuration|default(0),
+                                            'open': timeBudgetLeft,
+                                            'format': 'duration'
+                                        } %}
+                                        {{ progress.progressbar_full(options) }}
                                     {% endif %}
                                 </td>
                                 <td class="{{ tables.data_table_column_class(tableName, columns, 'budget') }}">
                                     {% if project.budget > 0 %}
-                                                {{ progress.progressbar(project.budget, entry.billableRate|default(0), entry.billableRate|money(currency) ~ ' / ' ~ project.budget|money(currency), '') }}
+                                        {% set budgetLeft = project.budget - entry.billableRate %}
+                                        {% set options = {
+                                            'max': project.budget|default(0),
+                                            'current': entry.billableRate|default(0),
+                                            'open': budgetLeft,
+                                            'format': 'money',
+                                            'currency': currency
+                                        } %}
+                                        {{ progress.progressbar_full(options) }}
                                     {% endif %}
                                 </td>
                                 <td class="{{ tables.data_table_column_class(tableName, columns, 'stateDuration') }}">

--- a/templates/reporting/project_view.html.twig
+++ b/templates/reporting/project_view.html.twig
@@ -14,6 +14,7 @@
     'budget':           {'class': 'hidden-xs', 'title': 'label.budget'|trans},
     'stateDuration':    {'class': 'hidden-sm hidden-xs text-center hw-min', 'title': 'label.not_exported'|trans},
     'stateMoney':       {'class': 'hidden-sm hidden-xs text-center hw-min', 'title': 'label.not_invoiced'|trans},
+    'projectStart':     {'class': 'hidden-md hidden-sm hidden-xs hidden text-center w-min', 'title': 'label.project_start'|trans},
     'projectEnd':       {'class': 'hidden-md hidden-sm hidden-xs hidden text-center w-min', 'title': 'label.project_end'|trans},
     'comment':          {'class': 'hidden-md hidden-sm hidden-xs hidden', 'title': 'label.comment'|trans},
     'actions':          {'class': 'actions alwaysVisible'},
@@ -116,6 +117,7 @@
                                         {{ entry.notBilledRate|money(currency) }}
                                     {% endif %}
                                 </td>
+                                <td class="{{ tables.data_table_column_class(tableName, columns, 'projectStart') }}">{% if project.start is not null %}{{ project.start|date_short }}{% endif %}</td>
                                 <td class="{{ tables.data_table_column_class(tableName, columns, 'projectEnd') }}">{% if project.end is not null %}{{ project.end|date_short }}{% endif %}</td>
                                 <td class="{{ tables.data_table_column_class(tableName, columns, 'comment') }}">{{ project.comment }}</td>
                                 <td class="{{ tables.data_table_column_class(tableName, columns, 'actions') }}">


### PR DESCRIPTION

## Description

Added open duration / money to progressbar

Before:
<img width="454" alt="Bildschirmfoto 2021-05-14 um 01 02 13" src="https://user-images.githubusercontent.com/533162/118197836-06d5f280-b450-11eb-8b9d-b9a2d3b6a28c.png">
<img width="463" alt="Bildschirmfoto 2021-05-14 um 11 40 28" src="https://user-images.githubusercontent.com/533162/118252571-32d19200-b4a9-11eb-9ce5-3a9b2d32754f.png">

After:
<img width="384" alt="Bildschirmfoto 2021-05-14 um 01 02 36" src="https://user-images.githubusercontent.com/533162/118197863-13f2e180-b450-11eb-926b-7b7af29b17b8.png">
<img width="389" alt="Bildschirmfoto 2021-05-14 um 11 40 53" src="https://user-images.githubusercontent.com/533162/118252616-3fee8100-b4a9-11eb-9aff-062f277f30bc.png">

Added project start column (default: hidden) to project report

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
