### PR TITLE
fix calendar totals for empty weeks

### DIFF
--- a/templates/calendar/user.html.twig
+++ b/templates/calendar/user.html.twig
@@ -390,7 +390,7 @@
                     {# TODO split day entries are calculated only for the begin date #}
                     var $element = jQuery("#dailytotal-" + moment(event.start).format("YYYY-MM-DD"));
                     var ids = $element.data('ids');
-                    if (ids === null) {
+                    if (ids === null || ids === undefined) {
                         ids = '';
                     }
 


### PR DESCRIPTION
## Description

fix calendar totals for empty weeks:

<img width="797" alt="Bildschirmfoto 2021-05-21 um 15 13 18" src="https://user-images.githubusercontent.com/533162/119142686-143e3e80-ba47-11eb-920b-d55164dac12e.png">

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
