### PR TITLE
customer-name as part of the invoice number

### DIFF
--- a/src/Invoice/NumberGenerator/ConfigurableNumberGenerator.php
+++ b/src/Invoice/NumberGenerator/ConfigurableNumberGenerator.php
@@ -183,6 +183,14 @@ final class ConfigurableNumberGenerator implements NumberGeneratorInterface
                 $partialResult = $this->repository->getCounterForDay($invoiceDate) + $increaseBy;
                 break;
 
+            case 'cname':
+                $partialResult = $this->model->getCustomer()->getName();
+                break;
+
+            case 'cnumber':
+                $partialResult = $this->model->getCustomer()->getNumber();
+                break;
+
             default:
                 $partialResult = $originalFormat;
         }

--- a/tests/Invoice/NumberGenerator/ConfigurableNumberGeneratorTest.php
+++ b/tests/Invoice/NumberGenerator/ConfigurableNumberGeneratorTest.php
@@ -72,6 +72,8 @@ class ConfigurableNumberGeneratorTest extends TestCase
             ['{ccy}', '2', $invoiceDate],
             ['{ccm}', '2', $invoiceDate],
             ['{ccd}', '2', $invoiceDate],
+            ['{cname}', 'Acme company', $invoiceDate],
+            ['{cnumber}', '0815', $invoiceDate],
             // number formatting (not testing the lower case versions, as the tests might break depending on the date)
             ['{date,10}', '0000' . $invoiceDate->format('ymd'), $invoiceDate],
             ['{Y,6}', '00' . $invoiceDate->format('Y'), $invoiceDate],
@@ -131,10 +133,14 @@ class ConfigurableNumberGeneratorTest extends TestCase
      */
     public function testGetInvoiceNumber(string $format, string $expectedInvoiceNumber, \DateTime $invoiceDate, int $counter = 1)
     {
+        $customer = new Customer();
+        $customer->setName('Acme company');
+        $customer->setNumber('0815');
+
         $sut = $this->getSut($format, $counter);
         $model = new InvoiceModel(new DebugFormatter());
         $model->setInvoiceDate($invoiceDate);
-        $model->setCustomer(new Customer());
+        $model->setCustomer($customer);
         $sut->setModel($model);
 
         $this->assertEquals($expectedInvoiceNumber, $sut->getInvoiceNumber());


### PR DESCRIPTION
## Description

allow to use customer-name and customer-number as part of the invoice number

See https://github.com/kevinpapst/kimai2/discussions/2636

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [x] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
