### PR TITLE
Add a calendar configuration event

### DIFF
--- a/src/Calendar/CalendarService.php
+++ b/src/Calendar/CalendarService.php
@@ -11,6 +11,7 @@ namespace App\Calendar;
 
 use App\Configuration\SystemConfiguration;
 use App\Entity\User;
+use App\Event\CalendarConfigurationEvent;
 use App\Event\CalendarDragAndDropSourceEvent;
 use App\Event\CalendarGoogleSourceEvent;
 use App\Event\RecentActivityEvent;
@@ -98,5 +99,25 @@ final class CalendarService
         }
 
         return new Google($apiKey, $sources);
+    }
+
+    public function getConfiguration(): array
+    {
+        $config = [
+            'dayLimit' => $this->configuration->getCalendarDayLimit(),
+            'showWeekNumbers' => $this->configuration->isCalendarShowWeekNumbers(),
+            'showWeekends' => $this->configuration->isCalendarShowWeekends(),
+            'businessDays' => $this->configuration->getCalendarBusinessDays(),
+            'businessTimeBegin' => $this->configuration->getCalendarBusinessTimeBegin(),
+            'businessTimeEnd' => $this->configuration->getCalendarBusinessTimeEnd(),
+            'slotDuration' => $this->configuration->getCalendarSlotDuration(),
+            'timeframeBegin' => $this->configuration->getCalendarTimeframeBegin(),
+            'timeframeEnd' => $this->configuration->getCalendarTimeframeEnd(),
+            'dragDropAmount' => $this->configuration->getCalendarDragAndDropMaxEntries(),
+        ];
+        $event = new CalendarConfigurationEvent($config);
+        $this->dispatcher->dispatch($event);
+
+        return $event->getConfiguration();
     }
 }

--- a/src/Controller/CalendarController.php
+++ b/src/Controller/CalendarController.php
@@ -39,18 +39,7 @@ class CalendarController extends AbstractController
         $factory = $this->getDateTimeFactory();
         $defaultStart = $factory->createDateTime($configuration->getTimesheetDefaultBeginTime());
 
-        $config = [
-            'dayLimit' => $configuration->getCalendarDayLimit(),
-            'showWeekNumbers' => $configuration->isCalendarShowWeekNumbers(),
-            'showWeekends' => $configuration->isCalendarShowWeekends(),
-            'businessDays' => $configuration->getCalendarBusinessDays(),
-            'businessTimeBegin' => $configuration->getCalendarBusinessTimeBegin(),
-            'businessTimeEnd' => $configuration->getCalendarBusinessTimeEnd(),
-            'slotDuration' => $configuration->getCalendarSlotDuration(),
-            'timeframeBegin' => $configuration->getCalendarTimeframeBegin(),
-            'timeframeEnd' => $configuration->getCalendarTimeframeEnd(),
-            'dragDropAmount' => $configuration->getCalendarDragAndDropMaxEntries(),
-        ];
+        $config = $this->calendarService->getConfiguration();
 
         $isPunchMode = !$mode->canEditDuration() && !$mode->canEditBegin() && !$mode->canEditEnd();
         $dragAndDrop = [];

--- a/src/Event/CalendarConfigurationEvent.php
+++ b/src/Event/CalendarConfigurationEvent.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Event;
+
+use Symfony\Contracts\EventDispatcher\Event;
+
+class CalendarConfigurationEvent extends Event
+{
+    /**
+     * @var array
+     */
+    private $configuration;
+
+    public function __construct(array $configuration)
+    {
+        $this->configuration = $configuration;
+    }
+
+    public function getConfiguration(): array
+    {
+        return $this->configuration;
+    }
+
+    public function setConfiguration(array $configuration)
+    {
+        $this->configuration = $configuration;
+    }
+}

--- a/src/Event/CalendarConfigurationEvent.php
+++ b/src/Event/CalendarConfigurationEvent.php
@@ -14,7 +14,7 @@ use Symfony\Contracts\EventDispatcher\Event;
 class CalendarConfigurationEvent extends Event
 {
     /**
-     * @var array
+     * @var array<string, string|int|bool|array>
      */
     private $configuration;
 
@@ -30,6 +30,10 @@ class CalendarConfigurationEvent extends Event
 
     public function setConfiguration(array $configuration)
     {
-        $this->configuration = $configuration;
+        foreach ($configuration as $key => $value) {
+            if (array_key_exists($key, $this->configuration)) {
+                $this->configuration[$key] = $value;
+            }
+        }
     }
 }

--- a/src/Event/CalendarConfigurationEvent.php
+++ b/src/Event/CalendarConfigurationEvent.php
@@ -31,7 +31,7 @@ class CalendarConfigurationEvent extends Event
     public function setConfiguration(array $configuration)
     {
         foreach ($configuration as $key => $value) {
-            if (array_key_exists($key, $this->configuration)) {
+            if (\array_key_exists($key, $this->configuration)) {
                 $this->configuration[$key] = $value;
             }
         }

--- a/tests/Event/CalendarConfigurationEventTest.php
+++ b/tests/Event/CalendarConfigurationEventTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Tests\Event;
+
+use App\Calendar\GoogleSource;
+use App\Entity\User;
+use App\Event\CalendarGoogleSourceEvent;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \App\Event\CalendarGoogleSourceEvent
+ */
+class CalendarGoogleSourceEventTest extends TestCase
+{
+    public function testGetterAndSetter()
+    {
+        $user = new User();
+        $user->setAlias('foo');
+
+        $sut = new CalendarGoogleSourceEvent($user);
+
+        self::assertSame($user, $sut->getUser());
+        self::assertIsArray($sut->getSources());
+        self::assertEmpty($sut->getSources());
+        self::assertInstanceOf(CalendarGoogleSourceEvent::class, $sut->addSource(new GoogleSource('', '')));
+        self::assertCount(1, $sut->getSources());
+    }
+}

--- a/tests/Event/CalendarConfigurationEventTest.php
+++ b/tests/Event/CalendarConfigurationEventTest.php
@@ -9,27 +9,29 @@
 
 namespace App\Tests\Event;
 
-use App\Calendar\GoogleSource;
-use App\Entity\User;
-use App\Event\CalendarGoogleSourceEvent;
+use App\Event\CalendarConfigurationEvent;
 use PHPUnit\Framework\TestCase;
 
 /**
- * @covers \App\Event\CalendarGoogleSourceEvent
+ * @covers \App\Event\CalendarConfigurationEvent
  */
-class CalendarGoogleSourceEventTest extends TestCase
+class CalendarConfigurationEventTest extends TestCase
 {
     public function testGetterAndSetter()
     {
-        $user = new User();
-        $user->setAlias('foo');
+        $configuration = [
+          'a' => 'b',
+          'c' => 1,
+          'd' => false,
+        ];
+        $sut = new CalendarConfigurationEvent($configuration);
 
-        $sut = new CalendarGoogleSourceEvent($user);
+        self::assertSame($configuration, $sut->getConfiguration());
 
-        self::assertSame($user, $sut->getUser());
-        self::assertIsArray($sut->getSources());
-        self::assertEmpty($sut->getSources());
-        self::assertInstanceOf(CalendarGoogleSourceEvent::class, $sut->addSource(new GoogleSource('', '')));
-        self::assertCount(1, $sut->getSources());
+        $new_configuration = ['a' => 'new_value'] + $configuration + ['e' => 'should_not_be_set'];
+        $sut->setConfiguration($configuration);
+
+        unset($new_configuration['e']);
+        self::assertSame($new_configuration, $sut->getConfiguration());
     }
 }

--- a/tests/Event/CalendarConfigurationEventTest.php
+++ b/tests/Event/CalendarConfigurationEventTest.php
@@ -29,7 +29,7 @@ class CalendarConfigurationEventTest extends TestCase
         self::assertSame($configuration, $sut->getConfiguration());
 
         $new_configuration = ['a' => 'new_value'] + $configuration + ['e' => 'should_not_be_set'];
-        $sut->setConfiguration($configuration);
+        $sut->setConfiguration($new_configuration);
 
         unset($new_configuration['e']);
         self::assertSame($new_configuration, $sut->getConfiguration());


### PR DESCRIPTION
This way plugins can define subscribers in which they can alter the
configuration of the calendar. Coming from
https://github.com/digipolisgent/kimai_plugin_personal-calendar-pref/issues/1

## Description
Adds a calendar configuration event that is dispatched before rendering the calendar.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
