### PR TITLE
Add option to copy the billable status of the timesheet

### DIFF
--- a/src/API/TimesheetController.php
+++ b/src/API/TimesheetController.php
@@ -590,7 +590,7 @@ class TimesheetController extends BaseApiController
      *      required=true,
      * )
      *
-     * @Rest\RequestParam(name="copy", requirements="all|tags|rates|meta|description", strict=true, nullable=true, description="Whether data should be copied to the new entry. Allowed values: all, tags, rates, description, meta (default: nothing is copied)")
+     * @Rest\RequestParam(name="copy", requirements="all|tags|rates|meta|description|billable", strict=true, nullable=true, description="Whether data should be copied to the new entry. Allowed values: all, tags, rates, description, billable, meta (default: nothing is copied)")
      * @Rest\RequestParam(name="begin", requirements=@Constraints\DateTime(format="Y-m-d\TH:i:s"), strict=true, nullable=true, description="Changes the restart date to the given one (default: now)")
      *
      * @ApiSecurity(name="apiUser")
@@ -640,6 +640,10 @@ class TimesheetController extends BaseApiController
                     $metaNew = clone $metaField;
                     $copyTimesheet->setMetaField($metaNew);
                 }
+            }
+
+            if (\in_array($copy, ['billable', 'all'])) {
+                $copyTimesheet->setBillable($timesheet->isBillable());
             }
         }
 

--- a/src/API/TimesheetController.php
+++ b/src/API/TimesheetController.php
@@ -590,7 +590,7 @@ class TimesheetController extends BaseApiController
      *      required=true,
      * )
      *
-     * @Rest\RequestParam(name="copy", requirements="all|tags|rates|meta|description|billable", strict=true, nullable=true, description="Whether data should be copied to the new entry. Allowed values: all, tags, rates, description, billable, meta (default: nothing is copied)")
+     * @Rest\RequestParam(name="copy", requirements="all|tags|rates|meta|description", strict=true, nullable=true, description="Whether data should be copied to the new entry. Allowed values: all, tags (deprecated), rates (deprecated), description (deprecated), meta (deprecated) (default: nothing is copied)")
      * @Rest\RequestParam(name="begin", requirements=@Constraints\DateTime(format="Y-m-d\TH:i:s"), strict=true, nullable=true, description="Changes the restart date to the given one (default: now)")
      *
      * @ApiSecurity(name="apiUser")
@@ -620,30 +620,24 @@ class TimesheetController extends BaseApiController
         ;
 
         if (null !== ($copy = $paramFetcher->get('copy'))) {
-            if (\in_array($copy, ['rates', 'all'])) {
-                $copyTimesheet->setHourlyRate($timesheet->getHourlyRate());
-                $copyTimesheet->setFixedRate($timesheet->getFixedRate());
+            if ($copy !== 'all') {
+                @trigger_error('Setting the "copy" attribute in "restart timesheet" API to something else then "all" is deprecated', E_USER_DEPRECATED);
             }
 
-            if (\in_array($copy, ['description', 'all'])) {
-                $copyTimesheet->setDescription($timesheet->getDescription());
+            $copyTimesheet
+                ->setHourlyRate($timesheet->getHourlyRate())
+                ->setFixedRate($timesheet->getFixedRate())
+                ->setDescription($timesheet->getDescription())
+                ->setBillable($timesheet->isBillable())
+                ;
+
+            foreach ($timesheet->getTags() as $tag) {
+                $copyTimesheet->addTag($tag);
             }
 
-            if (\in_array($copy, ['tags', 'all'])) {
-                foreach ($timesheet->getTags() as $tag) {
-                    $copyTimesheet->addTag($tag);
-                }
-            }
-
-            if (\in_array($copy, ['meta', 'all'])) {
-                foreach ($timesheet->getMetaFields() as $metaField) {
-                    $metaNew = clone $metaField;
-                    $copyTimesheet->setMetaField($metaNew);
-                }
-            }
-
-            if (\in_array($copy, ['billable', 'all'])) {
-                $copyTimesheet->setBillable($timesheet->isBillable());
+            foreach ($timesheet->getMetaFields() as $metaField) {
+                $metaNew = clone $metaField;
+                $copyTimesheet->setMetaField($metaNew);
             }
         }
 


### PR DESCRIPTION
## Description
I added the possibility to also copy the field "billable" of a timesheet. This fixes #2777.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [X] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
