### PR TITLE
use token in invoice delete route

### DIFF
--- a/src/Constants.php
+++ b/src/Constants.php
@@ -17,15 +17,15 @@ class Constants
     /**
      * The current release version
      */
-    public const VERSION = '1.15.6';
+    public const VERSION = '1.16.0';
     /**
      * The current release: major * 10000 + minor * 100 + patch
      */
-    public const VERSION_ID = 11506;
+    public const VERSION_ID = 11600;
     /**
      * The current release status, either "stable" or "dev"
      */
-    public const STATUS = 'stable';
+    public const STATUS = 'dev';
     /**
      * The software name
      */

--- a/src/EventSubscriber/Actions/InvoiceSubscriber.php
+++ b/src/EventSubscriber/Actions/InvoiceSubscriber.php
@@ -37,6 +37,6 @@ class InvoiceSubscriber extends AbstractActionsSubscriber
         }
 
         $event->addAction('download', ['url' => $this->path('admin_invoice_download', ['id' => $invoice->getId()]), 'target' => '_blank']);
-        $event->addDelete($this->path('admin_invoice_delete', ['id' => $invoice->getId()]), false);
+        $event->addDelete($this->path('admin_invoice_delete', ['id' => $invoice->getId(), 'token' => $payload['token']]), false);
     }
 }

--- a/templates/invoice/actions.html.twig
+++ b/templates/invoice/actions.html.twig
@@ -6,7 +6,7 @@
 
 {% macro invoice(invoice, view) %}
     {% import "macros/widgets.html.twig" as widgets %}
-    {% set event = actions(app.user, 'invoice', view, {'invoice': invoice}) %}
+    {% set event = actions(app.user, 'invoice', view, {'invoice': invoice, 'token': csrf_token('invoice.delete')}) %}
     {{ widgets.table_actions(event.actions) }}
 {% endmacro %}
 

--- a/tests/Controller/InvoiceControllerTest.php
+++ b/tests/Controller/InvoiceControllerTest.php
@@ -353,7 +353,8 @@ class InvoiceControllerTest extends ControllerBaseTest
         $client->followRedirect();
         $this->assertTrue($client->getResponse()->isSuccessful());
 
-        $this->request($client, '/invoice/delete/' . $id);
+        // this does not delete the invoice, because the token is wrong
+        $this->request($client, '/invoice/delete/' . $id . '/fghfkjhgkjhg');
         $this->assertIsRedirect($client, '/invoice/show');
         $client->followRedirect();
         $this->assertTrue($client->getResponse()->isSuccessful());


### PR DESCRIPTION
## Description

protect invoice delete route with csrf token (possible CSRF attack)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
