### PR TITLE
fix weekly view day format

### DIFF
--- a/src/Controller/QuickEntryController.php
+++ b/src/Controller/QuickEntryController.php
@@ -25,7 +25,7 @@ use Symfony\Component\Routing\Annotation\Route;
  * Controller used to enter times in weekly form.
  *
  * @Route(path="/quick_entry")
- * @Security("is_granted('view_own_timesheet')")
+ * @Security("is_granted('edit_own_timesheet')")
  */
 class QuickEntryController extends AbstractController
 {
@@ -42,7 +42,6 @@ class QuickEntryController extends AbstractController
 
     /**
      * @Route(path="/{begin}", name="quick_entry", methods={"GET", "POST"})
-     * @Security("is_granted('edit_own_timesheet')")
      */
     public function quickEntry(Request $request, ?string $begin = null)
     {

--- a/src/EventSubscriber/Actions/ProjectSubscriber.php
+++ b/src/EventSubscriber/Actions/ProjectSubscriber.php
@@ -68,13 +68,13 @@ class ProjectSubscriber extends AbstractActionsSubscriber
                     'class' => 'modal-ajax-form'
                 ]);
             }
+        }
 
-            if ($this->isGranted('edit', $project)) {
-                $event->addAction(
-                    'copy',
-                    ['url' => $this->path('admin_project_duplicate', ['id' => $project->getId()])]
-                );
-            }
+        if ($this->isGranted('edit', $project) && $this->isGranted('create_project')) {
+            $event->addAction(
+                'copy',
+                ['url' => $this->path('admin_project_duplicate', ['id' => $project->getId()])]
+            );
         }
 
         if (($event->isIndexView() || $event->isView('customer_details')) && $this->isGranted('delete', $project)) {

--- a/src/EventSubscriber/Actions/QuickEntrySubscriber.php
+++ b/src/EventSubscriber/Actions/QuickEntrySubscriber.php
@@ -20,10 +20,6 @@ class QuickEntrySubscriber extends AbstractActionsSubscriber
 
     public function onActions(PageActionsEvent $event): void
     {
-        if ($this->isGranted('view_own_timesheet')) {
-            $event->addBack($this->path('timesheet'));
-        }
-
         $event->addHelp($this->documentationLink('weekly-times.html'));
     }
 }

--- a/src/EventSubscriber/Actions/TimesheetsSubscriber.php
+++ b/src/EventSubscriber/Actions/TimesheetsSubscriber.php
@@ -35,7 +35,6 @@ class TimesheetsSubscriber extends AbstractActionsSubscriber
 
         if ($this->isGranted('create_own_timesheet')) {
             $event->addCreate($this->path('timesheet_create'));
-            $event->addAction('quick_entry', ['url' => $this->path('quick_entry'), 'class' => 'create-ts', 'icon' => 'weekly-times']);
         }
 
         $event->addHelp($this->documentationLink('timesheet.html'));

--- a/src/EventSubscriber/MenuSubscriber.php
+++ b/src/EventSubscriber/MenuSubscriber.php
@@ -49,8 +49,12 @@ final class MenuSubscriber implements EventSubscriberInterface
 
         if ($auth->isGranted('view_own_timesheet')) {
             $timesheets = new MenuItemModel('timesheet', 'menu.timesheet', 'timesheet', [], $icons->icon('timesheet'));
-            $timesheets->setChildRoutes(['timesheet_export', 'timesheet_edit', 'timesheet_create', 'timesheet_multi_update', 'quick_entry']);
+            $timesheets->setChildRoutes(['timesheet_export', 'timesheet_edit', 'timesheet_create', 'timesheet_multi_update']);
             $menu->addItem($timesheets);
+
+            $menu->addItem(
+                new MenuItemModel('quick_entry', 'quick_entry.title', 'quick_entry', [], $icons->icon('weekly-times'))
+            );
 
             $menu->addItem(
                 new MenuItemModel('calendar', 'calendar.title', 'calendar', [], $icons->icon('calendar'))

--- a/src/EventSubscriber/MenuSubscriber.php
+++ b/src/EventSubscriber/MenuSubscriber.php
@@ -10,6 +10,7 @@
 namespace App\EventSubscriber;
 
 use App\Event\ConfigureMainMenuEvent;
+use App\Timesheet\TrackingModeService;
 use App\Twig\IconExtension;
 use App\Utils\MenuItemModel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -21,10 +22,12 @@ use Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface;
 final class MenuSubscriber implements EventSubscriberInterface
 {
     private $security;
+    private $trackingModeService;
 
-    public function __construct(AuthorizationCheckerInterface $security)
+    public function __construct(AuthorizationCheckerInterface $security, TrackingModeService $trackingModeService)
     {
         $this->security = $security;
+        $this->trackingModeService = $trackingModeService;
     }
 
     public static function getSubscribedEvents(): array
@@ -52,9 +55,14 @@ final class MenuSubscriber implements EventSubscriberInterface
             $timesheets->setChildRoutes(['timesheet_export', 'timesheet_edit', 'timesheet_create', 'timesheet_multi_update']);
             $menu->addItem($timesheets);
 
-            $menu->addItem(
-                new MenuItemModel('quick_entry', 'quick_entry.title', 'quick_entry', [], $icons->icon('weekly-times'))
-            );
+            if ($auth->isGranted('edit_own_timesheet')) {
+                $mode = $this->trackingModeService->getActiveMode();
+                if ($mode->canEditDuration() || $mode->canEditEnd()) {
+                    $menu->addItem(
+                        new MenuItemModel('quick_entry', 'quick_entry.title', 'quick_entry', [], $icons->icon('weekly-times'))
+                    );
+                }
+            }
 
             $menu->addItem(
                 new MenuItemModel('calendar', 'calendar.title', 'calendar', [], $icons->icon('calendar'))

--- a/src/Twig/LocaleFormatExtensions.php
+++ b/src/Twig/LocaleFormatExtensions.php
@@ -56,6 +56,7 @@ final class LocaleFormatExtensions extends AbstractExtension
             new TwigFilter('date_time', [$this, 'dateTime']),
             new TwigFilter('date_full', [$this, 'dateTimeFull']),
             new TwigFilter('date_format', [$this, 'dateFormat']),
+            new TwigFilter('date_weekday', [$this, 'dateWeekday']),
             new TwigFilter('time', [$this, 'time']),
             new TwigFilter('hour24', [$this, 'hour24']),
             new TwigFilter('duration', [$this, 'duration']),
@@ -186,6 +187,11 @@ final class LocaleFormatExtensions extends AbstractExtension
     public function dateFormat($date, string $format)
     {
         return $this->getFormatter()->dateFormat($date, $format);
+    }
+
+    public function dateWeekday(DateTime $date): string
+    {
+        return $this->dayName($date, true) . ', ' . $this->getFormatter()->dateFormat($date, 'd');
     }
 
     /**

--- a/templates/form/kimai-theme.html.twig
+++ b/templates/form/kimai-theme.html.twig
@@ -156,7 +156,13 @@
             <i class="{{ 'left'|icon }}"></i>
         </a>
         <a class="btn btn-default" href="#" onclick="return false;">
-            <span id="{{ form.vars.id }}_week_number">{{ 'stats.workingTimeWeek'|trans({'%week%': week|date_format('W')}) }}</span>
+            <span id="{{ form.vars.id }}_week_number" data-toggle="tooltip" data-placement="top" title="{{ 'stats.workingTimeWeek'|trans({'%week%': week|date_format('W')}) }}">
+                {{ week|month_name(true) }}
+                {% if week|date_format('m') != nextWeek|date_format('m') %}
+                    &ndash;
+                    {{ nextWeek|month_name(true) }}
+                {% endif %}
+            </span>
         </a>
         <a class="btn btn-default btn-right" href="#" onclick="jQuery('#{{ form.vars.id }}').val('{{ nextWeek|report_date }}').change()" data-toggle="tooltip" data-placement="top" title="{{ 'stats.workingTimeWeek'|trans({'%week%': nextWeek|date_format('W')}) }}">
             <i class="{{ 'right'|icon }}"></i>

--- a/templates/quick-entry/index.html.twig
+++ b/templates/quick-entry/index.html.twig
@@ -29,8 +29,7 @@
                         <th>{{ 'label.activity'|trans }}</th>
                         {% for id, week in days %}
                         <th class="text-center{% if week.day is weekend %} weekend{% endif %}{% if week.day is today %} today{% endif %}">
-                            {{ week.day|day_name(true) }}<br>
-                            {{ week.day|format_date('short') }}
+                            {{ week.day|date_weekday }}
                         </th>
                         {% endfor %}
                         <th class="summary">{{ 'label.duration'|trans }}</th>

--- a/templates/reporting/report_by_user.html.twig
+++ b/templates/reporting/report_by_user.html.twig
@@ -31,8 +31,7 @@
                         <th>&nbsp;</th>
                         {% for day in days.dateTimes %}
                             <th class="text-center text-nowrap{% if day is weekend %} weekend{% endif %}{% if day is today %} today{% endif %}">
-                                {{ day|day_name(true) }}<br>
-                                {{ day|format_date('short') }}
+                                {{ day|date_weekday }}
                             </th>
                             {% set columns = columns + 1 %}
                             {% set totals = totals|merge({(day|report_date): 0}) %}

--- a/templates/reporting/report_user_list.html.twig
+++ b/templates/reporting/report_user_list.html.twig
@@ -29,8 +29,7 @@
                             <th>&nbsp;</th>
                             {% for day in stats.0.getDateTimes() %}
                                 <th class="text-center text-nowrap{% if day is weekend %} weekend{% endif %}{% if day is today %} today{% endif %}">
-                                    {{ day|day_name(true) }}<br>
-                                    {{ day|format_date('short') }}
+                                    {{ day|date_weekday }}
                                 </th>
                                 {% set totals = totals|merge({(day|report_date): 0}) %}
                             {% endfor %}

--- a/tests/Controller/QuickEntryControllerTest.php
+++ b/tests/Controller/QuickEntryControllerTest.php
@@ -52,7 +52,6 @@ class QuickEntryControllerTest extends ControllerBaseTest
         self::assertCount(10, $columns);
 
         $this->assertPageActions($client, [
-            'back' => $this->createUrl('/timesheet/'),
             'help' => 'https://www.kimai.org/documentation/weekly-times.html'
         ]);
     }
@@ -95,7 +94,6 @@ class QuickEntryControllerTest extends ControllerBaseTest
         self::assertCount(10, $columns);
 
         $this->assertPageActions($client, [
-            'back' => $this->createUrl('/timesheet/'),
             'help' => 'https://www.kimai.org/documentation/weekly-times.html'
         ]);
     }

--- a/tests/Controller/TimesheetControllerTest.php
+++ b/tests/Controller/TimesheetControllerTest.php
@@ -44,7 +44,6 @@ class TimesheetControllerTest extends ControllerBaseTest
             'visibility' => '#',
             'download toolbar-action modal-ajax-form' => $this->createUrl('/timesheet/export/'),
             'create modal-ajax-form' => $this->createUrl('/timesheet/create'),
-            'quick_entry create-ts' => $this->createUrl('/quick_entry'),
             'help' => 'https://www.kimai.org/documentation/timesheet.html'
         ]);
     }

--- a/tests/Twig/LocaleFormatExtensionsTest.php
+++ b/tests/Twig/LocaleFormatExtensionsTest.php
@@ -52,7 +52,7 @@ class LocaleFormatExtensionsTest extends TestCase
     public function testGetFilters()
     {
         $filters = [
-            'month_name', 'day_name', 'date_short', 'date_time', 'date_full', 'date_format', 'time', 'hour24',
+            'month_name', 'day_name', 'date_short', 'date_time', 'date_full', 'date_format', 'date_weekday', 'time', 'hour24',
             'duration', 'chart_duration', 'duration_decimal', 'money', 'currency', 'country', 'language', 'amount'
         ];
         $i = 0;

--- a/translations/messages.de.xlf
+++ b/translations/messages.de.xlf
@@ -1265,7 +1265,7 @@
       -->
       <trans-unit id="quick_entry.title">
         <source>quick_entry.title</source>
-        <target>Wöchentliche Arbeitsstunden</target>
+        <target>Wochen-Arbeitsstunden</target>
       </trans-unit>
     </body>
   </file>


### PR DESCRIPTION
## Description

- The date format in table header of weekly views (quick entry and 2 reports) had a weird format (at least wrong for most english speaking users)
- Links to the quick-entry form was moved to the main menu
- Duplicate project action is back available at the detail page level

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
