### PR TITLE
prevent empty migration warning

### DIFF
--- a/src/Doctrine/AbstractMigration.php
+++ b/src/Doctrine/AbstractMigration.php
@@ -113,4 +113,9 @@ abstract class AbstractMigration extends BaseAbstractMigration
 
         $this->addSql('DROP INDEX ' . $indexName . ' ON ' . $tableName);
     }
+
+    protected function preventEmptyMigrationWarning(): void
+    {
+        $this->addSql('#prevent empty warning - no SQL to execute');
+    }
 }

--- a/src/Migrations/Version20190219200020.php
+++ b/src/Migrations/Version20190219200020.php
@@ -30,5 +30,6 @@ final class Version20190219200020 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
+        $this->preventEmptyMigrationWarning();
     }
 }

--- a/src/Migrations/Version20190706224211.php
+++ b/src/Migrations/Version20190706224211.php
@@ -49,5 +49,6 @@ final class Version20190706224211 extends AbstractMigration
     {
         // the columns above were created incorrect in migration Version20190617100845 for upgraded systems
         // that's why there are no equivalent changes in down()
+        $this->preventEmptyMigrationWarning();
     }
 }

--- a/src/Migrations/Version20190729162655.php
+++ b/src/Migrations/Version20190729162655.php
@@ -40,5 +40,6 @@ final class Version20190729162655 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
+        $this->preventEmptyMigrationWarning();
     }
 }

--- a/src/Migrations/Version20191113132640.php
+++ b/src/Migrations/Version20191113132640.php
@@ -45,5 +45,6 @@ final class Version20191113132640 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
+        $this->preventEmptyMigrationWarning();
     }
 }

--- a/src/Migrations/Version20191113132640.php
+++ b/src/Migrations/Version20191113132640.php
@@ -39,6 +39,8 @@ final class Version20191113132640 extends AbstractMigration
             $timesheetTags->removeForeignKey('FK_732EECA9BAD26311');
         }
         $timesheetTags->addForeignKeyConstraint('kimai2_tags', ['tag_id'], ['id'], ['onDelete' => 'CASCADE'], 'FK_732EECA9BAD26311');
+
+        $this->preventEmptyMigrationWarning();
     }
 
     public function down(Schema $schema): void

--- a/src/Migrations/Version20200323163039.php
+++ b/src/Migrations/Version20200323163039.php
@@ -31,5 +31,6 @@ final class Version20200323163039 extends AbstractMigration
 
     public function down(Schema $schema): void
     {
+        $this->preventEmptyMigrationWarning();
     }
 }

--- a/src/Migrations/Version20210802152814.php
+++ b/src/Migrations/Version20210802152814.php
@@ -43,6 +43,8 @@ final class Version20210802152814 extends AbstractMigration
         }
 
         $fetch->free();
+
+        $this->preventEmptyMigrationWarning();
     }
 
     public function down(Schema $schema): void

--- a/src/Migrations/Version20210802152814.php
+++ b/src/Migrations/Version20210802152814.php
@@ -51,5 +51,7 @@ final class Version20210802152814 extends AbstractMigration
     {
         $timesheet = $schema->getTable('kimai2_timesheet');
         $timesheet->changeColumn('date_tz', ['notnull' => false]);
+
+        $this->preventEmptyMigrationWarning();
     }
 }

--- a/src/Migrations/Version20210802174319.php
+++ b/src/Migrations/Version20210802174319.php
@@ -33,6 +33,8 @@ final class Version20210802174319 extends AbstractMigration
         }
 
         $fetch->free();
+
+        $this->preventEmptyMigrationWarning();
     }
 
     public function down(Schema $schema): void
@@ -48,5 +50,7 @@ final class Version20210802174319 extends AbstractMigration
         $teams = $schema->getTable('kimai2_teams');
         $teams->getColumn('teamlead_id')->setNotnull(true);
         $teams->addForeignKeyConstraint('kimai2_users', ['teamlead_id'], ['id'], ['onDelete' => 'CASCADE'], 'FK_3BEDDC7F8F7DE5D7');
+
+        $this->preventEmptyMigrationWarning();
     }
 }


### PR DESCRIPTION
## Description

Some users are trouble by the doctrine migration warnings like
```
[warning] Migration DoctrineMigrations\Version20191113132640 was executed but did not result in any SQL statements.
[warning] Migration DoctrineMigrations\Version20210802152814 was executed but did not result in any SQL statements.
[warning] Migration DoctrineMigrations\Version20210802174319 was executed but did not result in any SQL statements.
```

This PR adds a helper method to prevent them.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
