### PR TITLE
improve error handling during invoice generation

### DIFF
--- a/config/packages/kimai.yaml
+++ b/config/packages/kimai.yaml
@@ -91,6 +91,7 @@ kimai:
             CUSTOMERS_TEAMLEAD: ['view_teamlead_customer','budget_teamlead_customer','comments_teamlead_customer','comments_create_teamlead_customer','details_teamlead_customer']
             INVOICE: ['view_invoice','create_invoice']
             INVOICE_ADMIN: ['manage_invoice_template']
+            INVOICE_ALL: ['delete_invoice']
             TIMESHEET: ['view_own_timesheet','start_own_timesheet','stop_own_timesheet','create_own_timesheet','edit_own_timesheet','export_own_timesheet','delete_own_timesheet','weekly_own_timesheet']
             TIMESHEET_OTHER: ['view_other_timesheet','start_other_timesheet','stop_other_timesheet','create_other_timesheet','edit_other_timesheet','export_other_timesheet','delete_other_timesheet']
             PROFILE: ['view_own_profile','edit_own_profile','password_own_profile','preferences_own_profile','api-token_own_profile']
@@ -120,7 +121,7 @@ kimai:
             ROLE_ADMIN: ['ROLE_ADMIN']
             ROLE_SUPER_ADMIN: ['ROLE_SUPER_ADMIN']
             # only here to register the (partially) unused permissions in the UI
-            ROLE_FAKE: ['CUSTOMERS_ALL_TEAMLEAD','CUSTOMERS_ALL_TEAM','PROJECTS_ALL_TEAMLEAD','PROJECTS_ALL_TEAM','ACTIVITIES_ALL_TEAMLEAD','ACTIVITIES_ALL_TEAM']
+            ROLE_FAKE: ['CUSTOMERS_ALL_TEAMLEAD','CUSTOMERS_ALL_TEAM','PROJECTS_ALL_TEAMLEAD','PROJECTS_ALL_TEAM','ACTIVITIES_ALL_TEAMLEAD','ACTIVITIES_ALL_TEAM','INVOICE_ALL']
         # add or remove single permissions
         roles:
             ROLE_USER: []

--- a/src/Command/InvoiceCreateCommand.php
+++ b/src/Command/InvoiceCreateCommand.php
@@ -63,6 +63,7 @@ class InvoiceCreateCommand extends Command
      * @var string|null
      */
     private $previewDirectory;
+    private $previewUniqueFile = false;
 
     public function __construct(
         ServiceInvoice $serviceInvoice,
@@ -104,6 +105,7 @@ class InvoiceCreateCommand extends Command
             ->addOption('search', null, InputOption::VALUE_OPTIONAL, 'Search term to filter invoice entries', null)
             ->addOption('exported', null, InputOption::VALUE_OPTIONAL, 'Exported filter for invoice entries (possible values: exported, all), by default only "not exported" items are fetched', null)
             ->addOption('preview', null, InputOption::VALUE_OPTIONAL, 'Absolute path for a rendered preview of the invoice, which will neither be saved nor the items be marked as exported.', null)
+            ->addOption('preview-unique', null, InputOption::VALUE_NONE, 'Adds a unique part to the filename of the generated invoice preview file, so there is no chance that they get overwritten on same project name.')
         ;
     }
 
@@ -225,6 +227,7 @@ class InvoiceCreateCommand extends Command
 
         $markAsExported = false;
         if ($input->getOption('preview') !== null) {
+            $this->previewUniqueFile = $input->getOption('preview-unique');
             $this->previewDirectory = rtrim($input->getOption('preview'), '/') . '/';
             if (!is_dir($this->previewDirectory) || !is_writable($this->previewDirectory)) {
                 $io->error('Invalid preview directory given');
@@ -350,8 +353,9 @@ class InvoiceCreateCommand extends Command
                     $filename = $filename[1];
                 }
             }
-            // depending on your setup, this might be a good idea
-            // $filename = uniqid() . $filename;
+            if ($this->previewUniqueFile) {
+                $filename = uniqid('invoice_') . $filename;
+            }
         }
 
         if ($response instanceof BinaryFileResponse) {

--- a/src/EventSubscriber/Actions/InvoiceSubscriber.php
+++ b/src/EventSubscriber/Actions/InvoiceSubscriber.php
@@ -36,13 +36,18 @@ class InvoiceSubscriber extends AbstractActionsSubscriber
             $event->addAction('invoice.paid', ['url' => $this->path('admin_invoice_status', ['id' => $invoice->getId(), 'status' => 'paid']), 'class' => 'modal-ajax-form']);
         }
 
+        $allowDelete = $this->isGranted('delete_invoice');
         if (!$invoice->isCanceled()) {
-            $event->addAction('invoice.cancel', ['url' => $this->path('admin_invoice_status', ['id' => $invoice->getId(), 'status' => 'canceled'])]);
+            $id = $allowDelete ? 'invoice.cancel' : 'trash';
+            $event->addAction($id, ['url' => $this->path('admin_invoice_status', ['id' => $invoice->getId(), 'status' => 'canceled']), 'title' => 'invoice.cancel', 'translation_domain' => 'actions']);
         }
 
         $event->addDivider();
 
         $event->addAction('download', ['url' => $this->path('admin_invoice_download', ['id' => $invoice->getId()]), 'target' => '_blank']);
-        $event->addDelete($this->path('admin_invoice_delete', ['id' => $invoice->getId(), 'token' => $payload['token']]), false);
+
+        if ($this->isGranted('delete_invoice')) {
+            $event->addDelete($this->path('admin_invoice_delete', ['id' => $invoice->getId(), 'token' => $payload['token']]), false);
+        }
     }
 }

--- a/src/Invoice/DuplicateInvoiceNumberException.php
+++ b/src/Invoice/DuplicateInvoiceNumberException.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Invoice;
+
+final class DuplicateInvoiceNumberException extends \Exception
+{
+    public function __construct(string $invoiceNumber)
+    {
+        parent::__construct('Invoice number "' . $invoiceNumber . '" already existing');
+    }
+}

--- a/tests/Controller/PermissionControllerTest.php
+++ b/tests/Controller/PermissionControllerTest.php
@@ -35,7 +35,7 @@ class PermissionControllerTest extends ControllerBaseTest
         $client = $this->getClientForAuthenticatedUser(User::ROLE_SUPER_ADMIN);
         $this->assertAccessIsGranted($client, '/admin/permissions');
         $this->assertHasDataTable($client);
-        $this->assertDataTableRowCount($client, 'datatable_user_admin_permissions', 120);
+        $this->assertDataTableRowCount($client, 'datatable_user_admin_permissions', 121);
         $this->assertPageActions($client, [
             //'back' => $this->createUrl('/admin/user/'),
             'create modal-ajax-form' => $this->createUrl('/admin/permissions/roles/create'),


### PR DESCRIPTION
## Description

- prevent that items will be marked as exported if invoice can not be generated 
  - fixes #2917 
- check for existing invoice number to prevent that invalid invoices will be generated
- allow to add unique prefix to preview invoice filename 
  - fixes #1741 
- Try to increase invoice id upon duplicate counter (which can happen if invoices are deleted) up to 99 times
  - fixes #1914
- Deactivate "delete invoice" function
  - can be activated again with new `delete_invoice` permission

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
