### PR TITLE
improve calendar in duration mode (#968)

### DIFF
--- a/src/Controller/CalendarController.php
+++ b/src/Controller/CalendarController.php
@@ -62,6 +62,7 @@ class CalendarController extends AbstractController
             'can_edit_begin' => $mode->canEditBegin(),
             'can_edit_end' => $mode->canEditBegin(),
             'can_edit_duration' => $mode->canEditDuration(),
+            'is_duration_mode' => $mode->isDurationMode(),
         ]);
     }
 }

--- a/src/Timesheet/TrackingMode/AbstractTrackingMode.php
+++ b/src/Timesheet/TrackingMode/AbstractTrackingMode.php
@@ -34,7 +34,15 @@ abstract class AbstractTrackingMode implements TrackingModeInterface
             return;
         }
 
-        $start = DateTime::createFromFormat('Y-m-d', $start, $this->getTimezone($entry));
+        $startFormat = 'Y-m-d';
+
+        // keep default begin time in duration timetracking modes
+        if ($this->isDurationMode()) {
+            $startFormat .= ' H:i:s';
+            $start .= ' ' . $entry->getBegin()->format('H:i:s');
+        }
+
+        $start = DateTime::createFromFormat($startFormat, $start, $this->getTimezone($entry));
         if (false === $start) {
             return;
         }

--- a/src/Timesheet/TrackingMode/DefaultMode.php
+++ b/src/Timesheet/TrackingMode/DefaultMode.php
@@ -56,6 +56,11 @@ final class DefaultMode extends AbstractTrackingMode
         return true;
     }
 
+    public function isDurationMode(): bool
+    {
+        return false;
+    }
+
     public function create(Timesheet $timesheet, ?Request $request = null): void
     {
         parent::create($timesheet, $request);

--- a/src/Timesheet/TrackingMode/DurationFixedBeginMode.php
+++ b/src/Timesheet/TrackingMode/DurationFixedBeginMode.php
@@ -48,6 +48,11 @@ final class DurationFixedBeginMode implements TrackingModeInterface
         return false;
     }
 
+    public function isDurationMode(): bool
+    {
+        return true;
+    }
+
     public function create(Timesheet $timesheet, ?Request $request = null): void
     {
         if (null === $timesheet->getBegin()) {

--- a/src/Timesheet/TrackingMode/DurationOnlyMode.php
+++ b/src/Timesheet/TrackingMode/DurationOnlyMode.php
@@ -56,6 +56,11 @@ final class DurationOnlyMode extends AbstractTrackingMode
         return false;
     }
 
+    public function isDurationMode(): bool
+    {
+        return true;
+    }
+
     public function create(Timesheet $timesheet, ?Request $request = null): void
     {
         if (null === $timesheet->getBegin()) {

--- a/src/Timesheet/TrackingMode/PunchInOutMode.php
+++ b/src/Timesheet/TrackingMode/PunchInOutMode.php
@@ -37,6 +37,11 @@ final class PunchInOutMode implements TrackingModeInterface
         return false;
     }
 
+    public function isDurationMode(): bool
+    {
+        return false;
+    }
+
     public function create(Timesheet $timesheet, ?Request $request = null): void
     {
         if (null === $timesheet->getBegin()) {

--- a/src/Timesheet/TrackingMode/TrackingModeInterface.php
+++ b/src/Timesheet/TrackingMode/TrackingModeInterface.php
@@ -66,6 +66,13 @@ interface TrackingModeInterface
     public function canSeeBeginAndEndTimes(): bool;
 
     /**
+     * Whether the timetracking mode is duration based.
+     *
+     * @return bool
+     */
+    public function isDurationMode(): bool;
+
+    /**
      * Returns a unique identifier for this tracking mode.
      *
      * @return string

--- a/templates/calendar/user.html.twig
+++ b/templates/calendar/user.html.twig
@@ -104,6 +104,7 @@
                 description: apiItem.description,
                 start: apiItem.begin,
                 end: apiItem.end,
+                duration: apiItem.duration,
                 activity: apiItem.activity.name,
                 project: apiItem.project.name,
                 customer: apiItem.project.customer.name,
@@ -353,6 +354,12 @@
                     if (view.name !== 'month' ) {
                         jQuery(".fc-dailytotal").text(DATES.formatSeconds(0)).data('seconds', 0).data('ids', '');
                     }
+
+                    {% if is_duration_mode %}
+                    if (view.name === 'month') {
+                        $el.find(".fc-time").replaceWith('<span class="fc-time fc-duration">' + DATES.formatSeconds(eventObj.duration) + '</span>');
+                    }
+                    {% endif %}
 
                     hidePopover();
                     $el.popover({

--- a/tests/Timesheet/TrackingMode/AbstractTrackingModeTest.php
+++ b/tests/Timesheet/TrackingMode/AbstractTrackingModeTest.php
@@ -161,7 +161,7 @@ abstract class AbstractTrackingModeTest extends TestCase
         self::assertEquals(12196, $timesheet->getDuration());
     }
 
-    public function testCreateUseFromToDatetimeOverwritesBeginEndTatesFromRequest()
+    public function testCreateUseFromToDatetimeOverwritesBeginEndDatesFromRequest()
     {
         $sut = $this->createSut();
 
@@ -213,6 +213,22 @@ abstract class AbstractTrackingModeTest extends TestCase
         $sut->create($timesheet, $request);
 
         self::assertEquals('2018-05-23 21:47:55', $timesheet->getBegin()->format('Y-m-d H:i:s'));
+        self::assertNull($timesheet->getEnd());
+        self::assertEquals(0, $timesheet->getDuration());
+    }
+
+    public function testCreateUsesDefaultStartTimeOnBeginFromRequest()
+    {
+        $sut = $this->createSut();
+
+        $timesheet = $this->createTimesheet();
+        $request = new Request([
+            'begin' => '2017-07-23',
+        ]);
+
+        $sut->create($timesheet, $request);
+
+        $this->assertDefaultBegin($timesheet);
         self::assertNull($timesheet->getEnd());
         self::assertEquals(0, $timesheet->getDuration());
     }

--- a/tests/Timesheet/TrackingMode/DefaultModeTest.php
+++ b/tests/Timesheet/TrackingMode/DefaultModeTest.php
@@ -41,6 +41,7 @@ class DefaultModeTest extends AbstractTrackingModeTest
         self::assertTrue($sut->canEditDuration());
         self::assertTrue($sut->canUpdateTimesWithAPI());
         self::assertTrue($sut->canSeeBeginAndEndTimes());
+        self::assertFalse($sut->isDurationMode());
         self::assertEquals('default', $sut->getId());
     }
 }

--- a/tests/Timesheet/TrackingMode/DurationFixedBeginModeTest.php
+++ b/tests/Timesheet/TrackingMode/DurationFixedBeginModeTest.php
@@ -39,6 +39,7 @@ class DurationFixedBeginModeTest extends TestCase
         self::assertTrue($sut->canEditDuration());
         self::assertFalse($sut->canUpdateTimesWithAPI());
         self::assertFalse($sut->canSeeBeginAndEndTimes());
+        self::assertTrue($sut->isDurationMode());
         self::assertEquals('duration_fixed_begin', $sut->getId());
     }
 

--- a/tests/Timesheet/TrackingMode/DurationOnlyModeTest.php
+++ b/tests/Timesheet/TrackingMode/DurationOnlyModeTest.php
@@ -42,6 +42,7 @@ class DurationOnlyModeTest extends AbstractTrackingModeTest
         self::assertTrue($sut->canEditDuration());
         self::assertTrue($sut->canUpdateTimesWithAPI());
         self::assertFalse($sut->canSeeBeginAndEndTimes());
+        self::assertTrue($sut->isDurationMode());
         self::assertEquals('duration_only', $sut->getId());
     }
 }

--- a/tests/Timesheet/TrackingMode/PunchInOutModeTest.php
+++ b/tests/Timesheet/TrackingMode/PunchInOutModeTest.php
@@ -29,6 +29,7 @@ class PunchInOutModeTest extends TestCase
         self::assertFalse($sut->canEditDuration());
         self::assertFalse($sut->canUpdateTimesWithAPI());
         self::assertTrue($sut->canSeeBeginAndEndTimes());
+        self::assertFalse($sut->isDurationMode());
         self::assertEquals('punch', $sut->getId());
     }
 


### PR DESCRIPTION
## Description

Fix #968

Upon creating a timesheet from the calendar monthly view, set the timesheet time to 'default_begin' instead of current time in both duration timetracking modes.

In the user calendar view, replace the event start time by the duration in the event title.



## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [X] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [X] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
