### PR TITLE
Add list ALLOWED_URL_SCHEMES for Markdown link

### DIFF
--- a/src/Twig/Runtime/MarkdownExtension.php
+++ b/src/Twig/Runtime/MarkdownExtension.php
@@ -126,6 +126,25 @@ final class MarkdownExtension implements RuntimeExtensionInterface
      */
     public function markdownToHtml(string $content): string
     {
+        $ALLOWED_URL_SCHEMES = array("ftp", "ftps", "http", "https", "mailto", "sftp", "ssh", "tel", "telnet", "tftp", "vnc");
+        
+        $pattern = '/([\[\s\S\]]*?)\(([\s\S]*?):([\[\s\S\]]*?)\)/';
+        # regex check
+        preg_match_all($pattern, $content, $matches, PREG_SET_ORDER);
+        if($matches) {
+            foreach ($matches as $match) {
+                // get value of group regex
+                $scheme = $match[2];
+            }
+            // scheme check
+            if(in_array($scheme, $ALLOWED_URL_SCHEMES)) {
+                $replacement = '$1($2:$3)';
+            } else {
+                $replacement = '$1($3)';
+            }
+            
+            $content = preg_replace($pattern, $replacement, $content);
+        }
         return $this->markdown->toHtml($content, false);
     }
 }

--- a/src/Twig/Runtime/MarkdownExtension.php
+++ b/src/Twig/Runtime/MarkdownExtension.php
@@ -128,7 +128,7 @@ final class MarkdownExtension implements RuntimeExtensionInterface
     {
         $ALLOWED_URL_SCHEMES = array("ftp", "ftps", "http", "https", "mailto", "sftp", "ssh", "tel", "telnet", "tftp", "vnc");
         
-        $pattern = '/([\[\s\S\]]*?)\(([\s\S]*?):([\[\s\S\]]*?)\)/';
+        $pattern = '/([\[\s\S\]]*?)\(([\s\S]*?):([\s\S]*?)\)/';
         # regex check
         preg_match_all($pattern, $content, $matches, PREG_SET_ORDER);
         if($matches) {


### PR DESCRIPTION
Fix bug Stored XSS via Markdown at the comment in Project
Disclousre: https://huntr.dev/bounties/89d6c3de-efbd-4354-8cc8-46e999e4c5a4/

## Description
When rendering to Markdown, the application does not filter and check the properties are valid, so when the user enters ``[XSS](javascript:alert(`document.domain`))`` it will render as `<a href="javascript:alert(document.domain)">XSS</a> `.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
