### PR TITLE
prevent that lock files will be committed in PRs

### DIFF
--- a/.github/workflows/lockfiles.yaml
+++ b/.github/workflows/lockfiles.yaml
@@ -10,8 +10,8 @@ jobs:
         name: Verify lock file integrity
         if: ${{ github.actor != 'kevinpapst' && github.actor != 'dependabot[bot]' }}
         steps:
-            -   name: Clone Kimai
-                uses: actions/checkout@v2
+            - name: Clone Kimai
+              uses: actions/checkout@v2
             - name: Prevent file change
               uses: xalvarez/prevent-file-change-action@v1
               with:

--- a/.github/workflows/lockfiles.yaml
+++ b/.github/workflows/lockfiles.yaml
@@ -8,7 +8,7 @@ jobs:
     lockfiles:
         runs-on: ubuntu-latest
         name: Verify lock file integrity
-        if: ${{ github.actor != 'kevinpapst' }}
+        if: ${{ github.actor != 'kevinpapst' && github.actor != 'dependabot[bot]' }}
         steps:
             -   name: Clone Kimai
                 uses: actions/checkout@v2

--- a/.github/workflows/lockfiles.yaml
+++ b/.github/workflows/lockfiles.yaml
@@ -1,0 +1,19 @@
+name: Check .lock files
+on:
+    pull_request: null
+    push:
+        branches:
+            - master
+jobs:
+    lockfiles:
+        runs-on: ubuntu-latest
+        name: Verify lock file integrity
+        if: ${{ github.actor != 'kevinpapst' }}
+        steps:
+            -   name: Clone Kimai
+                uses: actions/checkout@v2
+            - name: Prevent file change
+              uses: xalvarez/prevent-file-change-action@v1
+              with:
+                  githubToken: ${{ secrets.GITHUB_TOKEN }}
+                  pattern: .*.lock


### PR DESCRIPTION
## Description

A new GitHub action to check which files were changed. If the user opening a PR commits a changed .lock file, the build will fail. The only users allowed to do so are myself and dependabot.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
