### PR TITLE
fix project are not filtered after submit

### DIFF
--- a/src/Form/Toolbar/InvoiceToolbarSimpleForm.php
+++ b/src/Form/Toolbar/InvoiceToolbarSimpleForm.php
@@ -28,7 +28,7 @@ class InvoiceToolbarSimpleForm extends AbstractToolbarForm
         $this->addTemplateChoice($builder);
         $this->addDateRange($builder, ['timezone' => $options['timezone']]);
         $this->addCustomerMultiChoice($builder, ['required' => false, 'start_date_param' => null, 'end_date_param' => null, 'ignore_date' => true, 'placeholder' => ''], true);
-        $this->addProjectMultiChoice($builder, ['ignore_date' => true], false, true);
+        $this->addProjectMultiChoice($builder, ['ignore_date' => true], true, true);
         $builder->add('markAsExported', CheckboxType::class, [
             'label' => 'label.mark_as_exported',
             'required' => false,


### PR DESCRIPTION
## Description

invoice screen search displayed all project for all customers after form submit, even if one or more customers where used to filter the data.  this fixes it and filters the project list for those customers.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
