### PR TITLE
allow to configure the amount of recent activity rows in an empty week

### DIFF
--- a/src/Configuration/SystemConfiguration.php
+++ b/src/Configuration/SystemConfiguration.php
@@ -352,6 +352,11 @@ class SystemConfiguration implements SystemBundleConfiguration
         return $this->getIncrement('timesheet.time_increment', $this->getTimesheetDefaultRoundingEnd(), 0);
     }
 
+    public function getQuickEntriesRecentAmount(): int
+    {
+        return $this->getIncrement('quick_entry.recent_activities', 5, 0) ?? 5;
+    }
+
     // ========== Company configurations ==========
 
     public function getFinancialYearStart(): ?string

--- a/src/Controller/QuickEntryController.php
+++ b/src/Controller/QuickEntryController.php
@@ -106,7 +106,8 @@ class QuickEntryController extends AbstractController
         ksort($rows);
 
         // attach recent activities
-        $timesheets = $this->repository->getRecentActivities($this->getUser(), null, 5);
+        $amount = $this->configuration->getQuickEntriesRecentAmount();
+        $timesheets = $this->repository->getRecentActivities($this->getUser(), null, $amount);
         foreach ($timesheets as $timesheet) {
             $id = $timesheet->getProject()->getId() . '_' . $timesheet->getActivity()->getId();
             if (\array_key_exists($id, $rows)) {

--- a/src/Controller/SystemConfigurationController.php
+++ b/src/Controller/SystemConfigurationController.php
@@ -266,8 +266,7 @@ final class SystemConfigurationController extends AbstractController
             }
         }
 
-        $authentication = (new SystemConfigurationModel())
-            ->setSection(SystemConfigurationModel::SECTION_AUTHENTICATION)
+        $authentication = (new SystemConfigurationModel('authentication'))
             ->setConfiguration([
                 (new Configuration())
                     ->setName('user.login')
@@ -319,9 +318,8 @@ final class SystemConfigurationController extends AbstractController
             $authentication->getConfigurationByName('user.password_reset_token_ttl')->setEnabled(false);
         }
 
-        $configurationModels = [
-            (new SystemConfigurationModel())
-                ->setSection(SystemConfigurationModel::SECTION_TIMESHEET)
+        return [
+            (new SystemConfigurationModel('timesheet'))
                 ->setConfiguration([
                     (new Configuration())
                         ->setName('timesheet.mode')
@@ -387,8 +385,20 @@ final class SystemConfigurationController extends AbstractController
                         ->setType(YesNoType::class)
                         ->setOptions(['help' => 'default_value_new', 'label' => 'label.billable']),
                 ]),
-            (new SystemConfigurationModel())
-                ->setSection(SystemConfigurationModel::SECTION_LOCKDOWN)
+            (new SystemConfigurationModel('quick_entry'))
+                ->setTranslation('quick_entry.title')
+                ->setTranslationDomain('messages')
+                ->setConfiguration([
+                    (new Configuration())
+                        ->setName('quick_entry.recent_activities')
+                        ->setType(IntegerType::class)
+                        ->setTranslationDomain('system-configuration')
+                        ->setRequired(false)
+                        ->setConstraints([
+                            new Range(['min' => 0, 'max' => 20]),
+                        ]),
+                ]),
+            (new SystemConfigurationModel('lockdown_period'))
                 ->setConfiguration([
                     (new Configuration())
                         ->setName('timesheet.rules.lockdown_period_start')
@@ -417,8 +427,7 @@ final class SystemConfigurationController extends AbstractController
                         ->setConstraints([new DateTimeFormat()])
                         ->setTranslationDomain('system-configuration'),
                 ]),
-            (new SystemConfigurationModel())
-                ->setSection(SystemConfigurationModel::SECTION_ROUNDING)
+            (new SystemConfigurationModel('rounding'))
                 ->setConfiguration([
                     (new Configuration())
                         ->setName('timesheet.rounding.default.mode')
@@ -450,8 +459,9 @@ final class SystemConfigurationController extends AbstractController
                         ->setType(WeekDaysType::class)
                         ->setTranslationDomain('system-configuration'),
                 ]),
-            (new SystemConfigurationModel())
-                ->setSection(SystemConfigurationModel::SECTION_FORM_INVOICE)
+            (new SystemConfigurationModel('invoice'))
+                ->setTranslation('invoices')
+                ->setTranslationDomain('messages')
                 ->setConfiguration([
                     // TODO that should be a custom type with validation
                     (new Configuration())
@@ -468,8 +478,7 @@ final class SystemConfigurationController extends AbstractController
                         ->setTranslationDomain('system-configuration'),
                 ]),
             $authentication,
-            (new SystemConfigurationModel())
-                ->setSection(SystemConfigurationModel::SECTION_FORM_CUSTOMER)
+            (new SystemConfigurationModel('customer'))
                 ->setConfiguration([
                     (new Configuration())
                         ->setName('defaults.customer.timezone')
@@ -488,8 +497,7 @@ final class SystemConfigurationController extends AbstractController
                         ->setType(CurrencyType::class)
                         ->setOptions(['help' => 'default_value_new']),
                 ]),
-            (new SystemConfigurationModel())
-                ->setSection(SystemConfigurationModel::SECTION_FORM_USER)
+            (new SystemConfigurationModel('user'))
                 ->setConfiguration([
                     (new Configuration())
                         ->setName('defaults.user.timezone')
@@ -518,8 +526,7 @@ final class SystemConfigurationController extends AbstractController
                         ->setType(CheckboxType::class)
                         ->setTranslationDomain('system-configuration'),
                 ]),
-            (new SystemConfigurationModel())
-                ->setSection(SystemConfigurationModel::SECTION_THEME)
+            (new SystemConfigurationModel('theme'))
                 ->setConfiguration([
                     (new Configuration())
                         ->setName('theme.autocomplete_chars')
@@ -557,8 +564,9 @@ final class SystemConfigurationController extends AbstractController
                         ->setType(CheckboxType::class)
                         ->setTranslationDomain('system-configuration'),
                 ]),
-            (new SystemConfigurationModel())
-                ->setSection(SystemConfigurationModel::SECTION_CALENDAR)
+            (new SystemConfigurationModel('calendar'))
+                ->setTranslation('calendar')
+                ->setTranslationDomain('messages')
                 ->setConfiguration([
                     (new Configuration())
                         ->setName('calendar.week_numbers')
@@ -599,8 +607,7 @@ final class SystemConfigurationController extends AbstractController
                         ->setType(IntegerType::class)
                         ->setConstraints([new Range(['min' => 0, 'max' => 20]), new NotNull()]),
                 ]),
-            (new SystemConfigurationModel())
-                ->setSection(SystemConfigurationModel::SECTION_BRANDING)
+            (new SystemConfigurationModel('branding'))
                 ->setConfiguration([
                     (new Configuration())
                         ->setName('theme.branding.logo')
@@ -632,7 +639,5 @@ final class SystemConfigurationController extends AbstractController
                     ->setOptions(['input' => 'string']),
                 ]),
         ];
-
-        return $configurationModels;
     }
 }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -30,7 +30,7 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritdoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('kimai');
         /** @var ArrayNodeDefinition $node */
@@ -69,13 +69,32 @@ class Configuration implements ConfigurationInterface
                 ->append($this->getPermissionsNode())
                 ->append($this->getLdapNode())
                 ->append($this->getSamlNode())
+                ->append($this->getQuickEntryNode())
             ->end()
         ->end();
 
         return $treeBuilder;
     }
 
-    protected function getTimesheetNode()
+    private function getQuickEntryNode()
+    {
+        $builder = new TreeBuilder('quick_entry');
+        /** @var ArrayNodeDefinition $node */
+        $node = $builder->getRootNode();
+
+        $node
+            ->addDefaultsIfNotSet()
+            ->children()
+                ->integerNode('recent_activities')
+                    ->defaultValue(5)
+                ->end()
+            ->end()
+        ;
+
+        return $node;
+    }
+
+    private function getTimesheetNode(): ArrayNodeDefinition
     {
         $builder = new TreeBuilder('timesheet');
         /** @var ArrayNodeDefinition $node */
@@ -259,7 +278,7 @@ class Configuration implements ConfigurationInterface
         return $node;
     }
 
-    protected function getInvoiceNode()
+    private function getInvoiceNode(): ArrayNodeDefinition
     {
         $builder = new TreeBuilder('invoice');
         /** @var ArrayNodeDefinition $node */
@@ -292,7 +311,7 @@ class Configuration implements ConfigurationInterface
         return $node;
     }
 
-    protected function getExportNode()
+    private function getExportNode()
     {
         $builder = new TreeBuilder('export');
         /** @var ArrayNodeDefinition $node */
@@ -319,7 +338,7 @@ class Configuration implements ConfigurationInterface
         return $node;
     }
 
-    protected function getLanguagesNode()
+    private function getLanguagesNode(): ArrayNodeDefinition
     {
         $builder = new TreeBuilder('languages');
         /** @var ArrayNodeDefinition $node */
@@ -349,7 +368,7 @@ class Configuration implements ConfigurationInterface
         return $node;
     }
 
-    protected function getCalendarNode()
+    private function getCalendarNode(): ArrayNodeDefinition
     {
         $builder = new TreeBuilder('calendar');
         /** @var ArrayNodeDefinition $node */
@@ -416,7 +435,7 @@ class Configuration implements ConfigurationInterface
         return $node;
     }
 
-    protected function getThemeNode()
+    private function getThemeNode(): ArrayNodeDefinition
     {
         $builder = new TreeBuilder('theme');
         /** @var ArrayNodeDefinition $node */
@@ -506,7 +525,7 @@ class Configuration implements ConfigurationInterface
         return $node;
     }
 
-    protected function getIndustryNode()
+    private function getIndustryNode(): ArrayNodeDefinition
     {
         $builder = new TreeBuilder('industry');
         /** @var ArrayNodeDefinition $node */
@@ -522,7 +541,7 @@ class Configuration implements ConfigurationInterface
         return $node;
     }
 
-    protected function getCompanyNode()
+    private function getCompanyNode(): ArrayNodeDefinition
     {
         $builder = new TreeBuilder('company');
         /** @var ArrayNodeDefinition $node */
@@ -538,7 +557,7 @@ class Configuration implements ConfigurationInterface
         return $node;
     }
 
-    protected function getUserNode()
+    private function getUserNode(): ArrayNodeDefinition
     {
         $builder = new TreeBuilder('user');
         /** @var ArrayNodeDefinition $node */
@@ -568,7 +587,7 @@ class Configuration implements ConfigurationInterface
         return $node;
     }
 
-    protected function getWidgetsNode()
+    private function getWidgetsNode(): ArrayNodeDefinition
     {
         $builder = new TreeBuilder('widgets');
         /** @var ArrayNodeDefinition $node */
@@ -595,7 +614,7 @@ class Configuration implements ConfigurationInterface
         return $node;
     }
 
-    protected function getDashboardNode()
+    private function getDashboardNode(): ArrayNodeDefinition
     {
         $builder = new TreeBuilder('dashboard');
         /** @var ArrayNodeDefinition $node */
@@ -624,7 +643,7 @@ class Configuration implements ConfigurationInterface
         return $node;
     }
 
-    protected function getDefaultsNode()
+    private function getDefaultsNode(): ArrayNodeDefinition
     {
         $builder = new TreeBuilder('defaults');
         /** @var ArrayNodeDefinition $node */
@@ -662,7 +681,7 @@ class Configuration implements ConfigurationInterface
         return $node;
     }
 
-    protected function getPermissionsNode()
+    private function getPermissionsNode(): ArrayNodeDefinition
     {
         $builder = new TreeBuilder('permissions');
         /** @var ArrayNodeDefinition $node */
@@ -712,7 +731,7 @@ class Configuration implements ConfigurationInterface
         return $node;
     }
 
-    protected function getLdapNode()
+    private function getLdapNode(): ArrayNodeDefinition
     {
         $treeBuilder = new TreeBuilder('ldap');
         $node = $treeBuilder->getRootNode();
@@ -835,7 +854,7 @@ class Configuration implements ConfigurationInterface
         return $node;
     }
 
-    protected function getSamlNode()
+    private function getSamlNode(): ArrayNodeDefinition
     {
         $builder = new TreeBuilder('saml');
         /** @var ArrayNodeDefinition $node */

--- a/src/EventSubscriber/MenuSubscriber.php
+++ b/src/EventSubscriber/MenuSubscriber.php
@@ -65,12 +65,12 @@ final class MenuSubscriber implements EventSubscriberInterface
             }
 
             $menu->addItem(
-                new MenuItemModel('calendar', 'calendar.title', 'calendar', [], $icons->icon('calendar'))
+                new MenuItemModel('calendar', 'calendar', 'calendar', [], $icons->icon('calendar'))
             );
         }
 
         if ($auth->isGranted('view_invoice')) {
-            $invoice = new MenuItemModel('invoice', 'menu.invoice', 'invoice', [], $icons->icon('invoice'));
+            $invoice = new MenuItemModel('invoice', 'invoices', 'invoice', [], $icons->icon('invoice'));
             $invoice->setChildRoutes(['admin_invoice_template', 'admin_invoice_template_edit', 'admin_invoice_template_create', 'admin_invoice_template_copy', 'admin_invoice_list', 'admin_invoice_document_upload']);
             $menu->addItem($invoice);
         }

--- a/src/Form/Model/SystemConfiguration.php
+++ b/src/Form/Model/SystemConfiguration.php
@@ -9,17 +9,27 @@
 
 namespace App\Form\Model;
 
-class SystemConfiguration
+final class SystemConfiguration
 {
+    /** @deprecated since 1.16.10 */
     public const SECTION_ROUNDING = 'rounding';
+    /** @deprecated since 1.16.10 */
     public const SECTION_LOCKDOWN = 'lockdown_period';
+    /** @deprecated since 1.16.10 */
     public const SECTION_TIMESHEET = 'timesheet';
+    /** @deprecated since 1.16.10 */
     public const SECTION_FORM_INVOICE = 'invoice';
+    /** @deprecated since 1.16.10 */
     public const SECTION_FORM_CUSTOMER = 'customer';
+    /** @deprecated since 1.16.10 */
     public const SECTION_FORM_USER = 'user';
+    /** @deprecated since 1.16.10 */
     public const SECTION_THEME = 'theme';
+    /** @deprecated since 1.16.10 */
     public const SECTION_AUTHENTICATION = 'authentication';
+    /** @deprecated since 1.16.10 */
     public const SECTION_CALENDAR = 'calendar';
+    /** @deprecated since 1.16.10 */
     public const SECTION_BRANDING = 'branding';
 
     /**
@@ -27,20 +37,62 @@ class SystemConfiguration
      */
     private $section;
     /**
+     * @var string|null
+     */
+    private $translation;
+    /**
+     * @var string|null
+     */
+    private $translationDomain = 'system-configuration';
+    /**
      * @var Configuration[]
      */
     private $configuration = [];
+
+    public function __construct(?string $section = null)
+    {
+        $this->section = $section;
+    }
 
     public function getSection(): ?string
     {
         return $this->section;
     }
 
+    /**
+     * @deprecated since 1.16.10
+     * @param string|null $section
+     * @return $this
+     */
     public function setSection(?string $section): SystemConfiguration
     {
         $this->section = $section;
 
         return $this;
+    }
+
+    public function setTranslation(string $translation): SystemConfiguration
+    {
+        $this->translation = $translation;
+
+        return $this;
+    }
+
+    public function getTranslation(): string
+    {
+        return $this->translation ?? $this->section;
+    }
+
+    public function setTranslationDomain(string $domain): SystemConfiguration
+    {
+        $this->translationDomain = $domain;
+
+        return $this;
+    }
+
+    public function getTranslationDomain(): string
+    {
+        return $this->translationDomain;
     }
 
     /**

--- a/src/Form/Type/InitialViewType.php
+++ b/src/Form/Type/InitialViewType.php
@@ -28,11 +28,11 @@ class InitialViewType extends AbstractType
     private const ALLOWED_VIEWS = [
         'dashboard' => 'menu.homepage',
         'timesheet' => 'menu.timesheet',
-        'calendar' => 'calendar.title',
+        'calendar' => 'calendar',
         'quick_entry' => 'quick_entry.title',
         'my_profile' => 'profile.title',
         'admin_timesheet' => 'menu.admin_timesheet',
-        'invoice' => 'menu.invoice',
+        'invoice' => 'invoices',
         'admin_user' => 'users',
         'admin_customer' => 'customers',
         'admin_project' => 'projects',

--- a/templates/calendar/user.html.twig
+++ b/templates/calendar/user.html.twig
@@ -2,7 +2,7 @@
 {% import "macros/widgets.html.twig" as widgets %}
 {% import "macros/widgets.html.twig" as widgets %}
 
-{% block page_title %}{{ 'calendar.title'|trans }}{% endblock %}
+{% block page_title %}{{ 'calendar'|trans }}{% endblock %}
 {% block page_actions %}
     {% set event = actions(app.user, 'calendar', 'index') %}
     {{ widgets.page_actions(event.actions) }}

--- a/templates/invoice/index.html.twig
+++ b/templates/invoice/index.html.twig
@@ -17,7 +17,7 @@
 
 {% set tableName = 'invoice' %}
 
-{% block page_title %}{{ 'invoice.title'|trans }}{% endblock %}
+{% block page_title %}{{ 'invoices'|trans }}{% endblock %}
 {% block page_actions %}{{ actions.invoices('index') }}{% endblock %}
 
 {% block main_before %}
@@ -81,7 +81,7 @@
             {% import "macros/widgets.html.twig" as widgets %}
             {% import '@AdminLTE/Macros/buttons.html.twig' as button %}
             {% block box_title %}
-                {{ 'button.preview'|trans }}: {{ 'invoice.title'|trans }}
+                {{ 'button.preview'|trans }}: {{ 'invoices'|trans }}
             {% endblock %}
             {% block box_body_class %}no-padding{% endblock %}
             {% block box_footer %}

--- a/templates/invoice/listing.html.twig
+++ b/templates/invoice/listing.html.twig
@@ -21,7 +21,7 @@
 
 {% set tableName = 'invoices' %}
 
-{% block page_title %}{{ 'invoice.title'|trans }}{% endblock %}
+{% block page_title %}{{ 'invoices'|trans }}{% endblock %}
 {% block page_actions %}{{ actions.invoice_listing('index', query) }}{% endblock %}
 {% block page_search %}{{ search.searchModal(toolbarForm) }}{% endblock %}
 

--- a/templates/invoice/payment_date_edit.html.twig
+++ b/templates/invoice/payment_date_edit.html.twig
@@ -1,6 +1,6 @@
 {% extends app.request.xmlHttpRequest ? 'form.html.twig' : 'base.html.twig' %}
 
-{% block page_title %}{{ 'invoice.title'|trans }}{% endblock %}
+{% block page_title %}{{ 'invoices'|trans }}{% endblock %}
 
 {% block main %}
     {% set formEditTemplate = app.request.xmlHttpRequest ? 'default/_form_modal.html.twig' : 'default/_form.html.twig' %}

--- a/templates/system-configuration/index.html.twig
+++ b/templates/system-configuration/index.html.twig
@@ -1,7 +1,7 @@
 {% extends app.request.xmlHttpRequest ? 'form.html.twig' : 'base.html.twig' %}
 {% import "system-configuration/actions.html.twig" as actions %}
 
-{% block page_title %}{{ 'title'|trans({}, 'system-configuration') }}{% endblock %}
+{% block page_title %}{{ 'menu.system_configuration'|trans }}{% endblock %}
 {% block page_actions %}{{ actions.system_configuration('index') }}{% endblock %}
 
 {% block main %}
@@ -9,8 +9,8 @@
     {% set formEditTemplate = app.request.xmlHttpRequest ? 'default/_form_modal.html.twig' : 'default/_form.html.twig' %}
 
     {% for section in sections %}
-        {% set title = section.model.section|trans({}, 'system-configuration') %}
-        {% if title == section.model.section %}
+        {% set title = section.model.translation|trans({}, section.model.translationDomain) %}
+        {% if title == section.model.translation %}
             {% set title = ('label.' ~ section.model.section)|trans %}
         {% endif %}
         {{ include(formEditTemplate, {

--- a/tests/Controller/SystemConfigurationControllerTest.php
+++ b/tests/Controller/SystemConfigurationControllerTest.php
@@ -70,6 +70,7 @@ class SystemConfigurationControllerTest extends ControllerBaseTest
     {
         return [
             ['form[name=system_configuration_form_timesheet]', $this->createUrl('/admin/system-config/update/timesheet')],
+            ['form[name=system_configuration_form_quick_entry]', $this->createUrl('/admin/system-config/update/quick_entry')],
             ['form[name=system_configuration_form_lockdown_period]', $this->createUrl('/admin/system-config/update/lockdown_period')],
             ['form[name=system_configuration_form_invoice]', $this->createUrl('/admin/system-config/update/invoice')],
             ['form[name=system_configuration_form_authentication]', $this->createUrl('/admin/system-config/update/authentication')],

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -459,7 +459,10 @@ class ConfigurationTest extends TestCase
             ],
             'company' => [
                 'financial_year' => null,
-            ]
+            ],
+            'quick_entry' => [
+                'recent_activities' => 5
+            ],
         ];
 
         $this->assertConfig($this->getMinConfig(), $fullDefaultConfig);

--- a/translations/messages.ar.xlf
+++ b/translations/messages.ar.xlf
@@ -79,10 +79,6 @@
         <source>menu.timesheet</source>
         <target>أوقاتي</target>
       </trans-unit>
-      <trans-unit id="Ci9W8.K" resname="menu.invoice">
-        <source>menu.invoice</source>
-        <target>الفواتير</target>
-      </trans-unit>
       <trans-unit id="WGIhZv1" resname="menu.admin_timesheet">
         <source>menu.admin_timesheet</source>
         <target>الجداول الزمنية</target>
@@ -514,8 +510,8 @@
         <source>admin_invoice_template.title</source>
         <target>قالب الفاتورة</target>
       </trans-unit>
-      <trans-unit id="iERywrp" resname="invoice.title">
-        <source>invoice.title</source>
+      <trans-unit id="SR2r1Cs" resname="invoices">
+        <source>invoices</source>
         <target>الفواتير</target>
       </trans-unit>
       <trans-unit id="X70dwP8" resname="button.print">

--- a/translations/messages.cs.xlf
+++ b/translations/messages.cs.xlf
@@ -102,10 +102,6 @@
         <source>menu.timesheet</source>
         <target>Moje časy</target>
       </trans-unit>
-      <trans-unit id="Ci9W8.K" resname="menu.invoice">
-        <source>menu.invoice</source>
-        <target>Faktury</target>
-      </trans-unit>
       <trans-unit id="I.eil4u" resname="menu.export">
         <source>menu.export</source>
         <target>Export</target>
@@ -435,8 +431,8 @@
       <!--
               User timesheet calendar
             -->
-      <trans-unit id="HWiuMV6" resname="calendar.title">
-        <source>calendar.title</source>
+      <trans-unit id="UVJ5Die" resname="calendar">
+        <source>calendar</source>
         <target>Kalendář</target>
       </trans-unit>
       <!--
@@ -640,8 +636,8 @@
         <source>admin_invoice_template.title</source>
         <target>Šablona faktury</target>
       </trans-unit>
-      <trans-unit id="iERywrp" resname="invoice.title">
-        <source>invoice.title</source>
+      <trans-unit id="SR2r1Cs" resname="invoices">
+        <source>invoices</source>
         <target>Faktura</target>
       </trans-unit>
       <trans-unit id="X70dwP8" resname="button.print">

--- a/translations/messages.da.xlf
+++ b/translations/messages.da.xlf
@@ -118,10 +118,6 @@
         <source>menu.timesheet</source>
         <target>Min timeseddel</target>
       </trans-unit>
-      <trans-unit id="Ci9W8.K" resname="menu.invoice">
-        <source>menu.invoice</source>
-        <target>Fakturaer</target>
-      </trans-unit>
       <trans-unit id="I.eil4u" resname="menu.export">
         <source>menu.export</source>
         <target>Eksporter</target>
@@ -479,8 +475,8 @@
       <!--
               User timesheet calendar
             -->
-      <trans-unit id="HWiuMV6" resname="calendar.title">
-        <source>calendar.title</source>
+      <trans-unit id="UVJ5Die" resname="calendar">
+        <source>calendar</source>
         <target>Kalender</target>
       </trans-unit>
       <!--
@@ -708,8 +704,8 @@
         <source>admin_invoice_template.title</source>
         <target>Faturaskabelon</target>
       </trans-unit>
-      <trans-unit id="iERywrp" resname="invoice.title">
-        <source>invoice.title</source>
+      <trans-unit id="SR2r1Cs" resname="invoices">
+        <source>invoices</source>
         <target>Fakturaer</target>
       </trans-unit>
       <trans-unit id="ov4OQOh" resname="invoice.filter">

--- a/translations/messages.de.xlf
+++ b/translations/messages.de.xlf
@@ -183,10 +183,6 @@
         <source>menu.timesheet</source>
         <target>Meine Zeiten</target>
       </trans-unit>
-      <trans-unit id="Ci9W8.K" resname="menu.invoice">
-        <source>menu.invoice</source>
-        <target>Rechnungen</target>
-      </trans-unit>
       <trans-unit id="I.eil4u" resname="menu.export">
         <source>menu.export</source>
         <target>Export</target>
@@ -620,8 +616,8 @@
       <!--
         User timesheet calendar
       -->
-      <trans-unit id="HWiuMV6" resname="calendar.title">
-        <source>calendar.title</source>
+      <trans-unit id="UVJ5Die" resname="calendar">
+        <source>calendar</source>
         <target>Kalender</target>
       </trans-unit>
       <trans-unit id="75kjTF9" resname="calendar.drag_and_drop.delete">
@@ -920,8 +916,8 @@
         <source>admin_invoice_template.title</source>
         <target>Rechnungsvorlagen</target>
       </trans-unit>
-      <trans-unit id="iERywrp" resname="invoice.title">
-        <source>invoice.title</source>
+      <trans-unit id="SR2r1Cs" resname="invoices">
+        <source>invoices</source>
         <target>Rechnungen</target>
       </trans-unit>
       <trans-unit id="ov4OQOh" resname="invoice.filter">

--- a/translations/messages.de_CH.xlf
+++ b/translations/messages.de_CH.xlf
@@ -285,8 +285,8 @@
         <source>invoice.filter</source>
         <target>Rechnungsdaten filtern</target>
       </trans-unit>
-      <trans-unit id="iERywrp" resname="invoice.title">
-        <source>invoice.title</source>
+      <trans-unit id="SR2r1Cs" resname="invoices">
+        <source>invoices</source>
         <target>Rechnungen</target>
       </trans-unit>
       <trans-unit id="Oq.KtC6" resname="admin_invoice_template.title">
@@ -517,8 +517,8 @@
         <source>label.project_start</source>
         <target>Projekt Start</target>
       </trans-unit>
-      <trans-unit id="HWiuMV6" resname="calendar.title">
-        <source>calendar.title</source>
+      <trans-unit id="UVJ5Die" resname="calendar">
+        <source>calendar</source>
         <target>Kalender</target>
       </trans-unit>
       <trans-unit id="5R.QsZ3" resname="theme.update_browser_title">
@@ -904,10 +904,6 @@
       <trans-unit id="I.eil4u" resname="menu.export">
         <source>menu.export</source>
         <target>Export</target>
-      </trans-unit>
-      <trans-unit id="Ci9W8.K" resname="menu.invoice">
-        <source>menu.invoice</source>
-        <target>Rechnungen</target>
       </trans-unit>
       <trans-unit id="C0W7_BT" resname="menu.timesheet">
         <source>menu.timesheet</source>

--- a/translations/messages.el.xlf
+++ b/translations/messages.el.xlf
@@ -167,10 +167,6 @@
         <source>menu.timesheet</source>
         <target>Οι ώρες μου</target>
       </trans-unit>
-      <trans-unit id="Ci9W8.K" resname="menu.invoice">
-        <source>menu.invoice</source>
-        <target>Τιμολόγια</target>
-      </trans-unit>
       <trans-unit id="I.eil4u" resname="menu.export">
         <source>menu.export</source>
         <target>Εξαγωγή</target>
@@ -588,8 +584,8 @@
       <!--
               User timesheet calendar
             -->
-      <trans-unit id="HWiuMV6" resname="calendar.title">
-        <source>calendar.title</source>
+      <trans-unit id="UVJ5Die" resname="calendar">
+        <source>calendar</source>
         <target>Ημερολόγιο</target>
       </trans-unit>
       <trans-unit id="75kjTF9" resname="calendar.drag_and_drop.delete">
@@ -852,8 +848,8 @@
         <source>admin_invoice_template.title</source>
         <target>Πρότυπο τιμολογίου</target>
       </trans-unit>
-      <trans-unit id="iERywrp" resname="invoice.title">
-        <source>invoice.title</source>
+      <trans-unit id="SR2r1Cs" resname="invoices">
+        <source>invoices</source>
         <target>Τιμολόγια</target>
       </trans-unit>
       <trans-unit id="ov4OQOh" resname="invoice.filter">

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -183,10 +183,6 @@
         <source>menu.timesheet</source>
         <target>My times</target>
       </trans-unit>
-      <trans-unit id="Ci9W8.K" resname="menu.invoice">
-        <source>menu.invoice</source>
-        <target>Invoices</target>
-      </trans-unit>
       <trans-unit id="I.eil4u" resname="menu.export">
         <source>menu.export</source>
         <target>Export</target>
@@ -620,8 +616,8 @@
       <!--
               User timesheet calendar
             -->
-      <trans-unit id="HWiuMV6" resname="calendar.title">
-        <source>calendar.title</source>
+      <trans-unit id="UVJ5Die" resname="calendar">
+        <source>calendar</source>
         <target>Calendar</target>
       </trans-unit>
       <trans-unit id="75kjTF9" resname="calendar.drag_and_drop.delete">
@@ -920,8 +916,8 @@
         <source>admin_invoice_template.title</source>
         <target>Invoice template</target>
       </trans-unit>
-      <trans-unit id="iERywrp" resname="invoice.title">
-        <source>invoice.title</source>
+      <trans-unit id="SR2r1Cs" resname="invoices">
+        <source>invoices</source>
         <target>Invoices</target>
       </trans-unit>
       <trans-unit id="ov4OQOh" resname="invoice.filter">

--- a/translations/messages.eo.xlf
+++ b/translations/messages.eo.xlf
@@ -134,10 +134,6 @@
         <source>menu.timesheet</source>
         <target>Miaj tempoj</target>
       </trans-unit>
-      <trans-unit id="Ci9W8.K" resname="menu.invoice">
-        <source>menu.invoice</source>
-        <target>Fakturoj</target>
-      </trans-unit>
       <trans-unit id="I.eil4u" resname="menu.export">
         <source>menu.export</source>
         <target>Eksporto</target>
@@ -511,8 +507,8 @@
       <!--
               User timesheet calendar
             -->
-      <trans-unit id="HWiuMV6" resname="calendar.title">
-        <source>calendar.title</source>
+      <trans-unit id="UVJ5Die" resname="calendar">
+        <source>calendar</source>
         <target>Kalendaro</target>
       </trans-unit>
       <!--
@@ -751,8 +747,8 @@
         <source>admin_invoice_template.title</source>
         <target>Fakturŝablono</target>
       </trans-unit>
-      <trans-unit id="iERywrp" resname="invoice.title">
-        <source>invoice.title</source>
+      <trans-unit id="SR2r1Cs" resname="invoices">
+        <source>invoices</source>
         <target>Fakturoj</target>
       </trans-unit>
       <trans-unit id="ov4OQOh" resname="invoice.filter">

--- a/translations/messages.es.xlf
+++ b/translations/messages.es.xlf
@@ -111,10 +111,6 @@
         <source>menu.timesheet</source>
         <target>Mis horas</target>
       </trans-unit>
-      <trans-unit id="Ci9W8.K" resname="menu.invoice">
-        <source>menu.invoice</source>
-        <target>Facturas</target>
-      </trans-unit>
       <trans-unit id="I.eil4u" resname="menu.export">
         <source>menu.export</source>
         <target>Exportar</target>
@@ -464,8 +460,8 @@
       <!--
               User timesheet calendar
             -->
-      <trans-unit id="HWiuMV6" resname="calendar.title">
-        <source>calendar.title</source>
+      <trans-unit id="UVJ5Die" resname="calendar">
+        <source>calendar</source>
         <target>Calendario</target>
       </trans-unit>
       <!--
@@ -677,8 +673,8 @@
         <source>admin_invoice_template.title</source>
         <target>Plantilla de factura</target>
       </trans-unit>
-      <trans-unit id="iERywrp" resname="invoice.title">
-        <source>invoice.title</source>
+      <trans-unit id="SR2r1Cs" resname="invoices">
+        <source>invoices</source>
         <target>Facturas</target>
       </trans-unit>
       <trans-unit id="ov4OQOh" resname="invoice.filter">

--- a/translations/messages.eu.xlf
+++ b/translations/messages.eu.xlf
@@ -119,10 +119,6 @@
         <source>menu.timesheet</source>
         <target>Nire orduak</target>
       </trans-unit>
-      <trans-unit id="Ci9W8.K" resname="menu.invoice">
-        <source>menu.invoice</source>
-        <target>Fakturak</target>
-      </trans-unit>
       <trans-unit id="I.eil4u" resname="menu.export">
         <source>menu.export</source>
         <target>Exportatu</target>
@@ -476,8 +472,8 @@
       <!--
               User timesheet calendar
             -->
-      <trans-unit id="HWiuMV6" resname="calendar.title">
-        <source>calendar.title</source>
+      <trans-unit id="UVJ5Die" resname="calendar">
+        <source>calendar</source>
         <target>Egutegia</target>
       </trans-unit>
       <!--
@@ -716,8 +712,8 @@
         <source>admin_invoice_template.title</source>
         <target>Faktura eredua</target>
       </trans-unit>
-      <trans-unit id="iERywrp" resname="invoice.title">
-        <source>invoice.title</source>
+      <trans-unit id="SR2r1Cs" resname="invoices">
+        <source>invoices</source>
         <target>Fakturak</target>
       </trans-unit>
       <trans-unit id="ov4OQOh" resname="invoice.filter">

--- a/translations/messages.fa.xlf
+++ b/translations/messages.fa.xlf
@@ -399,10 +399,6 @@
         <source>menu.export</source>
         <target>خروجی گرفتن</target>
       </trans-unit>
-      <trans-unit id="Ci9W8.K" resname="menu.invoice">
-        <source>menu.invoice</source>
-        <target>فاکتورها</target>
-      </trans-unit>
       <trans-unit id="C0W7_BT" resname="menu.timesheet">
         <source>menu.timesheet</source>
         <target>زمان من</target>

--- a/translations/messages.fi.xlf
+++ b/translations/messages.fi.xlf
@@ -134,10 +134,6 @@
         <source>menu.timesheet</source>
         <target state="translated">Omat työajat</target>
       </trans-unit>
-      <trans-unit id="Ci9W8.K" resname="menu.invoice">
-        <source>menu.invoice</source>
-        <target state="translated">Laskut</target>
-      </trans-unit>
       <trans-unit id="I.eil4u" resname="menu.export">
         <source>menu.export</source>
         <target state="translated">Vie</target>
@@ -547,8 +543,8 @@
       <!--
               User timesheet calendar
             -->
-      <trans-unit id="HWiuMV6" resname="calendar.title">
-        <source>calendar.title</source>
+      <trans-unit id="UVJ5Die" resname="calendar">
+        <source>calendar</source>
         <target state="translated">Kalenteri</target>
       </trans-unit>
       <!--
@@ -803,8 +799,8 @@
         <source>admin_invoice_template.title</source>
         <target state="translated">Lasku malli</target>
       </trans-unit>
-      <trans-unit id="iERywrp" resname="invoice.title">
-        <source>invoice.title</source>
+      <trans-unit id="SR2r1Cs" resname="invoices">
+        <source>invoices</source>
         <target state="translated">Laskut</target>
       </trans-unit>
       <trans-unit id="ov4OQOh" resname="invoice.filter">

--- a/translations/messages.fo.xlf
+++ b/translations/messages.fo.xlf
@@ -53,10 +53,6 @@
         <source>menu.timesheet</source>
         <target>Mínar tíðir</target>
       </trans-unit>
-      <trans-unit id="Ci9W8.K" resname="menu.invoice">
-        <source>menu.invoice</source>
-        <target>Fakturar</target>
-      </trans-unit>
       <trans-unit id="I.eil4u" resname="menu.export">
         <source>menu.export</source>
         <target>Útflyt</target>
@@ -199,8 +195,8 @@
         <source>label.avatar</source>
         <target>Vanga mynd</target>
       </trans-unit>
-      <trans-unit id="HWiuMV6" resname="calendar.title">
-        <source>calendar.title</source>
+      <trans-unit id="UVJ5Die" resname="calendar">
+        <source>calendar</source>
         <target>Kalendari</target>
       </trans-unit>
       <trans-unit id="xEYQXPy" resname="profile.settings">
@@ -467,8 +463,8 @@
         <source>admin_invoice_template.title</source>
         <target>Vørurokningar skapilón</target>
       </trans-unit>
-      <trans-unit id="iERywrp" resname="invoice.title">
-        <source>invoice.title</source>
+      <trans-unit id="SR2r1Cs" resname="invoices">
+        <source>invoices</source>
         <target>Vørurokningar</target>
       </trans-unit>
       <trans-unit id="7H7P1mE" resname="button.preview">

--- a/translations/messages.fr.xlf
+++ b/translations/messages.fr.xlf
@@ -99,10 +99,6 @@
         <source>menu.timesheet</source>
         <target>Mes fiches de temps</target>
       </trans-unit>
-      <trans-unit id="Ci9W8.K" resname="menu.invoice">
-        <source>menu.invoice</source>
-        <target>Factures</target>
-      </trans-unit>
       <trans-unit id="I.eil4u" resname="menu.export">
         <source>menu.export</source>
         <target>Export</target>
@@ -412,8 +408,8 @@
       <!--
               User timesheet calendar
             -->
-      <trans-unit id="HWiuMV6" resname="calendar.title">
-        <source>calendar.title</source>
+      <trans-unit id="UVJ5Die" resname="calendar">
+        <source>calendar</source>
         <target>Calendrier</target>
       </trans-unit>
       <!--
@@ -617,8 +613,8 @@
         <source>admin_invoice_template.title</source>
         <target>Modèle de facture</target>
       </trans-unit>
-      <trans-unit id="iERywrp" resname="invoice.title">
-        <source>invoice.title</source>
+      <trans-unit id="SR2r1Cs" resname="invoices">
+        <source>invoices</source>
         <target>Factures</target>
       </trans-unit>
       <trans-unit id="X70dwP8" resname="button.print">

--- a/translations/messages.he.xlf
+++ b/translations/messages.he.xlf
@@ -125,10 +125,6 @@
         <source>menu.timesheet</source>
         <target>השעות שלי</target>
       </trans-unit>
-      <trans-unit id="Ci9W8.K" resname="menu.invoice">
-        <source>menu.invoice</source>
-        <target>חשבוניות</target>
-      </trans-unit>
       <trans-unit id="I.eil4u" resname="menu.export">
         <source>menu.export</source>
         <target>ייצוא נתונים</target>
@@ -497,8 +493,8 @@
         <source>label.timesheet.export_decimal</source>
         <target>ייצוא משך זמן עם נקודה עשרונית</target>
       </trans-unit>
-      <trans-unit id="HWiuMV6" resname="calendar.title">
-        <source>calendar.title</source>
+      <trans-unit id="UVJ5Die" resname="calendar">
+        <source>calendar</source>
         <target>לוח שנה</target>
       </trans-unit>
       <trans-unit id="yLOqEX_" resname="label.project_start">
@@ -713,8 +709,8 @@
         <source>admin_invoice_template.title</source>
         <target>תבנית חשבונית</target>
       </trans-unit>
-      <trans-unit id="iERywrp" resname="invoice.title">
-        <source>invoice.title</source>
+      <trans-unit id="SR2r1Cs" resname="invoices">
+        <source>invoices</source>
         <target>חשבוניות</target>
       </trans-unit>
       <trans-unit id="ov4OQOh" resname="invoice.filter">

--- a/translations/messages.hr.xlf
+++ b/translations/messages.hr.xlf
@@ -175,10 +175,6 @@
         <source>menu.timesheet</source>
         <target>Moja vremena</target>
       </trans-unit>
-      <trans-unit id="Ci9W8.K" resname="menu.invoice">
-        <source>menu.invoice</source>
-        <target>Računi</target>
-      </trans-unit>
       <trans-unit id="I.eil4u" resname="menu.export">
         <source>menu.export</source>
         <target>Izvoz</target>
@@ -600,8 +596,8 @@
       <!--
               User timesheet calendar
             -->
-      <trans-unit id="HWiuMV6" resname="calendar.title">
-        <source>calendar.title</source>
+      <trans-unit id="UVJ5Die" resname="calendar">
+        <source>calendar</source>
         <target>Kalendar</target>
       </trans-unit>
       <trans-unit id="75kjTF9" resname="calendar.drag_and_drop.delete">
@@ -893,8 +889,8 @@
         <source>admin_invoice_template.title</source>
         <target>Predložak računa</target>
       </trans-unit>
-      <trans-unit id="iERywrp" resname="invoice.title">
-        <source>invoice.title</source>
+      <trans-unit id="SR2r1Cs" resname="invoices">
+        <source>invoices</source>
         <target>Računi</target>
       </trans-unit>
       <trans-unit id="ov4OQOh" resname="invoice.filter">

--- a/translations/messages.hu.xlf
+++ b/translations/messages.hu.xlf
@@ -102,10 +102,6 @@
         <source>menu.timesheet</source>
         <target>Rögzített órák</target>
       </trans-unit>
-      <trans-unit id="Ci9W8.K" resname="menu.invoice">
-        <source>menu.invoice</source>
-        <target>Számlák</target>
-      </trans-unit>
       <trans-unit id="I.eil4u" resname="menu.export">
         <source>menu.export</source>
         <target>Exportálás</target>
@@ -415,8 +411,8 @@
       <!--
               User timesheet calendar
             -->
-      <trans-unit id="HWiuMV6" resname="calendar.title">
-        <source>calendar.title</source>
+      <trans-unit id="UVJ5Die" resname="calendar">
+        <source>calendar</source>
         <target>Naptár</target>
       </trans-unit>
       <!--
@@ -620,8 +616,8 @@
         <source>admin_invoice_template.title</source>
         <target>Számla sablon</target>
       </trans-unit>
-      <trans-unit id="iERywrp" resname="invoice.title">
-        <source>invoice.title</source>
+      <trans-unit id="SR2r1Cs" resname="invoices">
+        <source>invoices</source>
         <target>Számlák</target>
       </trans-unit>
       <trans-unit id="X70dwP8" resname="button.print">

--- a/translations/messages.it.xlf
+++ b/translations/messages.it.xlf
@@ -134,10 +134,6 @@
         <source>menu.timesheet</source>
         <target>Registrazioni</target>
       </trans-unit>
-      <trans-unit id="Ci9W8.K" resname="menu.invoice">
-        <source>menu.invoice</source>
-        <target>Fatture</target>
-      </trans-unit>
       <trans-unit id="I.eil4u" resname="menu.export">
         <source>menu.export</source>
         <target>Esporta</target>
@@ -547,16 +543,10 @@
       <!--
               User timesheet calendar
             -->
-      <trans-unit id="HWiuMV6" resname="calendar.title">
-        <source>calendar.title</source>
+      <trans-unit id="UVJ5Die" resname="calendar">
+        <source>calendar</source>
         <target>Calendario</target>
       </trans-unit>
-      <!--
-              Admin: Timesheet
-            -->
-      <!--
-              Admin: Projects
-            -->
       <trans-unit id="yLOqEX_" resname="label.project_start">
         <source>label.project_start</source>
         <target>Inizio progetto</target>
@@ -565,9 +555,6 @@
         <source>label.project_end</source>
         <target>Fine progetto</target>
       </trans-unit>
-      <!--
-              Admin: Customer
-            -->
       <trans-unit id="39AtPxQ" resname="label.number">
         <source>label.number</source>
         <target>Account</target>
@@ -620,9 +607,6 @@
         <source>label.currency</source>
         <target>Valuta</target>
       </trans-unit>
-      <!--
-              Admin: User
-            -->
       <trans-unit id="TRDzmCV" resname="label.alias">
         <source>label.alias</source>
         <target>Nome</target>
@@ -655,9 +639,6 @@
         <source>Allowed character: A-Z and _</source>
         <target>Caratteri permessi: A-Z and _</target>
       </trans-unit>
-      <!--
-              Admin: Plugins
-            -->
       <trans-unit id="d75KAlJ" resname="label.version">
         <source>label.version</source>
         <target>Versione</target>
@@ -666,9 +647,6 @@
         <source>label.required_version</source>
         <target>Compatibile con</target>
       </trans-unit>
-      <!--
-              ROLES
-            -->
       <trans-unit id="WRuKTcz" resname="ROLE_SUPER_ADMIN">
         <source>ROLE_SUPER_ADMIN</source>
         <target>Amministratore di sistema</target>
@@ -685,9 +663,6 @@
         <source>ROLE_USER</source>
         <target>Utente</target>
       </trans-unit>
-      <!--
-              Statistics data for Dashboard & Users profile
-            -->
       <trans-unit id="lfSTZGe" resname="stats.workingTimeToday">
         <source>stats.workingTimeToday</source>
         <target>Oggi, %day%</target>
@@ -796,15 +771,12 @@
         <source>stats.percentUsedLeft</source>
         <target>%percent%% utilizzata (%left% ancora disponibili)</target>
       </trans-unit>
-      <!--
-              Invoice
-            -->
       <trans-unit id="Oq.KtC6" resname="admin_invoice_template.title">
         <source>admin_invoice_template.title</source>
         <target>Template Fatture</target>
       </trans-unit>
-      <trans-unit id="iERywrp" resname="invoice.title">
-        <source>invoice.title</source>
+      <trans-unit id="SR2r1Cs" resname="invoices">
+        <source>invoices</source>
         <target>Fatture</target>
       </trans-unit>
       <trans-unit id="ov4OQOh" resname="invoice.filter">

--- a/translations/messages.ja.xlf
+++ b/translations/messages.ja.xlf
@@ -102,10 +102,6 @@
         <source>menu.timesheet</source>
         <target>タイムシート</target>
       </trans-unit>
-      <trans-unit id="Ci9W8.K" resname="menu.invoice">
-        <source>menu.invoice</source>
-        <target>請求書</target>
-      </trans-unit>
       <trans-unit id="I.eil4u" resname="menu.export">
         <source>menu.export</source>
         <target>エクスポート</target>
@@ -415,8 +411,8 @@
       <!--
               User timesheet calendar
             -->
-      <trans-unit id="HWiuMV6" resname="calendar.title">
-        <source>calendar.title</source>
+      <trans-unit id="UVJ5Die" resname="calendar">
+        <source>calendar</source>
         <target>カレンダー</target>
       </trans-unit>
       <!--
@@ -620,8 +616,8 @@
         <source>admin_invoice_template.title</source>
         <target>請求書のテンプレート</target>
       </trans-unit>
-      <trans-unit id="iERywrp" resname="invoice.title">
-        <source>invoice.title</source>
+      <trans-unit id="SR2r1Cs" resname="invoices">
+        <source>invoices</source>
         <target>請求書</target>
       </trans-unit>
       <trans-unit id="X70dwP8" resname="button.print">

--- a/translations/messages.ko.xlf
+++ b/translations/messages.ko.xlf
@@ -102,10 +102,6 @@
         <source>menu.timesheet</source>
         <target state="translated">나의 근무시간</target>
       </trans-unit>
-      <trans-unit id="Ci9W8.K" resname="menu.invoice">
-        <source>menu.invoice</source>
-        <target state="translated">청구서</target>
-      </trans-unit>
       <trans-unit id="I.eil4u" resname="menu.export">
         <source>menu.export</source>
         <target state="translated">내보내기</target>
@@ -431,8 +427,8 @@
       <!--
               User timesheet calendar
             -->
-      <trans-unit id="HWiuMV6" resname="calendar.title">
-        <source>calendar.title</source>
+      <trans-unit id="UVJ5Die" resname="calendar">
+        <source>calendar</source>
         <target state="translated">달력</target>
       </trans-unit>
       <!--
@@ -636,8 +632,8 @@
         <source>admin_invoice_template.title</source>
         <target state="translated">청구서 템플릿</target>
       </trans-unit>
-      <trans-unit id="iERywrp" resname="invoice.title">
-        <source>invoice.title</source>
+      <trans-unit id="SR2r1Cs" resname="invoices">
+        <source>invoices</source>
         <target state="translated">인보이스</target>
       </trans-unit>
       <trans-unit id="X70dwP8" resname="button.print">

--- a/translations/messages.nb-NO.xlf
+++ b/translations/messages.nb-NO.xlf
@@ -313,8 +313,8 @@
       <!--
               User timesheet calendar
             -->
-      <trans-unit id="HWiuMV6" resname="calendar.title">
-        <source>calendar.title</source>
+      <trans-unit id="UVJ5Die" resname="calendar">
+        <source>calendar</source>
         <target>Kalender</target>
       </trans-unit>
       <trans-unit id="yLOqEX_" resname="label.project_start">
@@ -531,10 +531,6 @@
       <trans-unit id=".ndupSK" resname="registration.check_email">
         <source>registration.check_email</source>
         <target>En e-post har blitt sendt til %email%. Den inneholder en invitasjonslenke du må klikke for å aktivere kontoen din.</target>
-      </trans-unit>
-      <trans-unit id="Ci9W8.K" resname="menu.invoice">
-        <source>menu.invoice</source>
-        <target>Fakturaer</target>
       </trans-unit>
       <trans-unit id="I.eil4u" resname="menu.export">
         <source>menu.export</source>
@@ -1116,8 +1112,8 @@
         <source>error.too_many_entries</source>
         <target state="needs-translation">Forespørselen kunne ikke behandles. For mange resultater.</target>
       </trans-unit>
-      <trans-unit id="iERywrp" resname="invoice.title">
-        <source>invoice.title</source>
+      <trans-unit id="SR2r1Cs" resname="invoices">
+        <source>invoices</source>
         <target>Fakturaer</target>
       </trans-unit>
       <trans-unit id="zPcx3O_" resname="invoice_print">

--- a/translations/messages.nl.xlf
+++ b/translations/messages.nl.xlf
@@ -111,10 +111,6 @@
         <source>menu.timesheet</source>
         <target>Mijn tijden</target>
       </trans-unit>
-      <trans-unit id="Ci9W8.K" resname="menu.invoice">
-        <source>menu.invoice</source>
-        <target>Facturen</target>
-      </trans-unit>
       <trans-unit id="I.eil4u" resname="menu.export">
         <source>menu.export</source>
         <target>Exporteren</target>
@@ -464,8 +460,8 @@
       <!--
               User timesheet calendar
             -->
-      <trans-unit id="HWiuMV6" resname="calendar.title">
-        <source>calendar.title</source>
+      <trans-unit id="UVJ5Die" resname="calendar">
+        <source>calendar</source>
         <target>Agenda</target>
       </trans-unit>
       <!--
@@ -681,8 +677,8 @@
         <source>admin_invoice_template.title</source>
         <target>Factuursjabloon</target>
       </trans-unit>
-      <trans-unit id="iERywrp" resname="invoice.title">
-        <source>invoice.title</source>
+      <trans-unit id="SR2r1Cs" resname="invoices">
+        <source>invoices</source>
         <target>Facturen maken</target>
       </trans-unit>
       <trans-unit id="ov4OQOh" resname="invoice.filter">

--- a/translations/messages.pl.xlf
+++ b/translations/messages.pl.xlf
@@ -122,10 +122,6 @@
         <source>menu.timesheet</source>
         <target>Moje czasy</target>
       </trans-unit>
-      <trans-unit id="Ci9W8.K" resname="menu.invoice">
-        <source>menu.invoice</source>
-        <target>Faktury</target>
-      </trans-unit>
       <trans-unit id="I.eil4u" resname="menu.export">
         <source>menu.export</source>
         <target>Export</target>
@@ -491,8 +487,8 @@
       <!--
               User timesheet calendar
             -->
-      <trans-unit id="HWiuMV6" resname="calendar.title">
-        <source>calendar.title</source>
+      <trans-unit id="UVJ5Die" resname="calendar">
+        <source>calendar</source>
         <target>Kalendarz</target>
       </trans-unit>
       <!--
@@ -724,8 +720,8 @@
         <source>admin_invoice_template.title</source>
         <target>Wzorzec faktury</target>
       </trans-unit>
-      <trans-unit id="iERywrp" resname="invoice.title">
-        <source>invoice.title</source>
+      <trans-unit id="SR2r1Cs" resname="invoices">
+        <source>invoices</source>
         <target>Faktury</target>
       </trans-unit>
       <trans-unit id="ov4OQOh" resname="invoice.filter">

--- a/translations/messages.pt.xlf
+++ b/translations/messages.pt.xlf
@@ -99,10 +99,6 @@
         <source>menu.timesheet</source>
         <target>Meus tempos</target>
       </trans-unit>
-      <trans-unit id="Ci9W8.K" resname="menu.invoice">
-        <source>menu.invoice</source>
-        <target>Faturas</target>
-      </trans-unit>
       <trans-unit id="I.eil4u" resname="menu.export">
         <source>menu.export</source>
         <target>Exportar</target>
@@ -412,8 +408,8 @@
       <!--
               User timesheet calendar
             -->
-      <trans-unit id="HWiuMV6" resname="calendar.title">
-        <source>calendar.title</source>
+      <trans-unit id="UVJ5Die" resname="calendar">
+        <source>calendar</source>
         <target>Calendário</target>
       </trans-unit>
       <!--
@@ -617,8 +613,8 @@
         <source>admin_invoice_template.title</source>
         <target>Modelo de fatura</target>
       </trans-unit>
-      <trans-unit id="iERywrp" resname="invoice.title">
-        <source>invoice.title</source>
+      <trans-unit id="SR2r1Cs" resname="invoices">
+        <source>invoices</source>
         <target>Faturas</target>
       </trans-unit>
       <trans-unit id="X70dwP8" resname="button.print">

--- a/translations/messages.pt_BR.xlf
+++ b/translations/messages.pt_BR.xlf
@@ -102,10 +102,6 @@
         <source>menu.timesheet</source>
         <target>Meus tempos</target>
       </trans-unit>
-      <trans-unit id="Ci9W8.K" resname="menu.invoice">
-        <source>menu.invoice</source>
-        <target>Faturas</target>
-      </trans-unit>
       <trans-unit id="I.eil4u" resname="menu.export">
         <source>menu.export</source>
         <target>Exportar</target>
@@ -415,8 +411,8 @@
       <!--
               User timesheet calendar
             -->
-      <trans-unit id="HWiuMV6" resname="calendar.title">
-        <source>calendar.title</source>
+      <trans-unit id="UVJ5Die" resname="calendar">
+        <source>calendar</source>
         <target>Calendário</target>
       </trans-unit>
       <!--
@@ -620,8 +616,8 @@
         <source>admin_invoice_template.title</source>
         <target>Modelo de fatura</target>
       </trans-unit>
-      <trans-unit id="iERywrp" resname="invoice.title">
-        <source>invoice.title</source>
+      <trans-unit id="SR2r1Cs" resname="invoices">
+        <source>invoices</source>
         <target>Faturas</target>
       </trans-unit>
       <trans-unit id="X70dwP8" resname="button.print">

--- a/translations/messages.ro.xlf
+++ b/translations/messages.ro.xlf
@@ -125,10 +125,6 @@
         <source>menu.timesheet</source>
         <target>Pontajul meu</target>
       </trans-unit>
-      <trans-unit id="Ci9W8.K" resname="menu.invoice">
-        <source>menu.invoice</source>
-        <target>Facturi</target>
-      </trans-unit>
       <trans-unit id="I.eil4u" resname="menu.export">
         <source>menu.export</source>
         <target>Export</target>
@@ -473,8 +469,8 @@
         <source>label.timesheet.export_decimal</source>
         <target>Utilizați durata zecimală la export</target>
       </trans-unit>
-      <trans-unit id="HWiuMV6" resname="calendar.title">
-        <source>calendar.title</source>
+      <trans-unit id="UVJ5Die" resname="calendar">
+        <source>calendar</source>
         <target>Calendarul</target>
       </trans-unit>
       <trans-unit id="yLOqEX_" resname="label.project_start">
@@ -689,8 +685,8 @@
         <source>admin_invoice_template.title</source>
         <target>Macheta factură</target>
       </trans-unit>
-      <trans-unit id="iERywrp" resname="invoice.title">
-        <source>invoice.title</source>
+      <trans-unit id="SR2r1Cs" resname="invoices">
+        <source>invoices</source>
         <target>Facturi</target>
       </trans-unit>
       <trans-unit id="ZWbHl1I" resname="invoice.subtitle">

--- a/translations/messages.ru.xlf
+++ b/translations/messages.ru.xlf
@@ -79,10 +79,6 @@
         <source>menu.timesheet</source>
         <target>Учет времени</target>
       </trans-unit>
-      <trans-unit id="Ci9W8.K" resname="menu.invoice">
-        <source>menu.invoice</source>
-        <target>Счета</target>
-      </trans-unit>
       <trans-unit id="WGIhZv1" resname="menu.admin_timesheet">
         <source>menu.admin_timesheet</source>
         <target>Время работы сотрудников</target>
@@ -510,8 +506,8 @@
         <source>admin_invoice_template.title</source>
         <target>Шаблоны счетов</target>
       </trans-unit>
-      <trans-unit id="iERywrp" resname="invoice.title">
-        <source>invoice.title</source>
+      <trans-unit id="SR2r1Cs" resname="invoices">
+        <source>invoices</source>
         <target>Счета</target>
       </trans-unit>
       <trans-unit id="X70dwP8" resname="button.print">
@@ -744,8 +740,8 @@
         <source>label.project_start</source>
         <target>Проект начат</target>
       </trans-unit>
-      <trans-unit id="HWiuMV6" resname="calendar.title">
-        <source>calendar.title</source>
+      <trans-unit id="UVJ5Die" resname="calendar">
+        <source>calendar</source>
         <target>Календарь</target>
       </trans-unit>
       <trans-unit id="Q0Zip02" resname="agendaDay">

--- a/translations/messages.sk.xlf
+++ b/translations/messages.sk.xlf
@@ -127,10 +127,6 @@
         <source>menu.timesheet</source>
         <target>Moje časy</target>
       </trans-unit>
-      <trans-unit id="Ci9W8.K" resname="menu.invoice">
-        <source>menu.invoice</source>
-        <target>Faktúry</target>
-      </trans-unit>
       <trans-unit id="I.eil4u" resname="menu.export">
         <source>menu.export</source>
         <target>Export</target>
@@ -496,8 +492,8 @@
       <!--
               User timesheet calendar
             -->
-      <trans-unit id="HWiuMV6" resname="calendar.title">
-        <source>calendar.title</source>
+      <trans-unit id="UVJ5Die" resname="calendar">
+        <source>calendar</source>
         <target>Kalendár</target>
       </trans-unit>
       <!--
@@ -757,8 +753,8 @@
         <source>admin_invoice_template.title</source>
         <target>Šablóna faktúry</target>
       </trans-unit>
-      <trans-unit id="iERywrp" resname="invoice.title">
-        <source>invoice.title</source>
+      <trans-unit id="SR2r1Cs" resname="invoices">
+        <source>invoices</source>
         <target>Faktúry</target>
       </trans-unit>
       <trans-unit id="ov4OQOh" resname="invoice.filter">

--- a/translations/messages.sv.xlf
+++ b/translations/messages.sv.xlf
@@ -102,10 +102,6 @@
         <source>menu.timesheet</source>
         <target state="translated">Min tidsredovisning</target>
       </trans-unit>
-      <trans-unit id="Ci9W8.K" resname="menu.invoice">
-        <source>menu.invoice</source>
-        <target state="translated">Fakturor</target>
-      </trans-unit>
       <trans-unit id="I.eil4u" resname="menu.export">
         <source>menu.export</source>
         <target state="translated">Exportera</target>
@@ -415,8 +411,8 @@
       <!--
               User timesheet calendar
             -->
-      <trans-unit id="HWiuMV6" resname="calendar.title">
-        <source>calendar.title</source>
+      <trans-unit id="UVJ5Die" resname="calendar">
+        <source>calendar</source>
         <target state="translated">Kalender</target>
       </trans-unit>
       <!--
@@ -616,8 +612,8 @@
         <source>admin_invoice_template.title</source>
         <target state="translated">Fakturamall</target>
       </trans-unit>
-      <trans-unit id="iERywrp" resname="invoice.title">
-        <source>invoice.title</source>
+      <trans-unit id="SR2r1Cs" resname="invoices">
+        <source>invoices</source>
         <target state="translated">Fakturor</target>
       </trans-unit>
       <trans-unit id="X70dwP8" resname="button.print">

--- a/translations/messages.tr.xlf
+++ b/translations/messages.tr.xlf
@@ -114,10 +114,6 @@
         <source>menu.timesheet</source>
         <target state="translated">Çizelgem</target>
       </trans-unit>
-      <trans-unit id="Ci9W8.K" resname="menu.invoice">
-        <source>menu.invoice</source>
-        <target state="translated">Faturalar</target>
-      </trans-unit>
       <trans-unit id="I.eil4u" resname="menu.export">
         <source>menu.export</source>
         <target state="translated">Dışarı aktar</target>
@@ -467,8 +463,8 @@
       <!--
               User timesheet calendar
             -->
-      <trans-unit id="HWiuMV6" resname="calendar.title">
-        <source>calendar.title</source>
+      <trans-unit id="UVJ5Die" resname="calendar">
+        <source>calendar</source>
         <target state="translated">Takvim</target>
       </trans-unit>
       <!--
@@ -680,8 +676,8 @@
         <source>admin_invoice_template.title</source>
         <target state="translated">Fatura şablonu</target>
       </trans-unit>
-      <trans-unit id="iERywrp" resname="invoice.title">
-        <source>invoice.title</source>
+      <trans-unit id="SR2r1Cs" resname="invoices">
+        <source>invoices</source>
         <target state="translated">Faturalar</target>
       </trans-unit>
       <trans-unit id="ov4OQOh" resname="invoice.filter">

--- a/translations/messages.vi.xlf
+++ b/translations/messages.vi.xlf
@@ -134,10 +134,6 @@
         <source>menu.timesheet</source>
         <target>Bảng chấm công</target>
       </trans-unit>
-      <trans-unit id="Ci9W8.K" resname="menu.invoice">
-        <source>menu.invoice</source>
-        <target>Hóa đơn</target>
-      </trans-unit>
       <trans-unit id="I.eil4u" resname="menu.export">
         <source>menu.export</source>
         <target>Xuất</target>
@@ -527,8 +523,8 @@
       <!--
               User timesheet calendar
             -->
-      <trans-unit id="HWiuMV6" resname="calendar.title">
-        <source>calendar.title</source>
+      <trans-unit id="UVJ5Die" resname="calendar">
+        <source>calendar</source>
         <target>Lịch</target>
       </trans-unit>
       <!--
@@ -764,8 +760,8 @@
         <source>admin_invoice_template.title</source>
         <target>Mẫu hóa đơn</target>
       </trans-unit>
-      <trans-unit id="iERywrp" resname="invoice.title">
-        <source>invoice.title</source>
+      <trans-unit id="SR2r1Cs" resname="invoices">
+        <source>invoices</source>
         <target>Hóa đơn</target>
       </trans-unit>
       <trans-unit id="ov4OQOh" resname="invoice.filter">

--- a/translations/messages.zh_CN.xlf
+++ b/translations/messages.zh_CN.xlf
@@ -118,10 +118,6 @@
         <source>menu.timesheet</source>
         <target>我的时间</target>
       </trans-unit>
-      <trans-unit id="Ci9W8.K" resname="menu.invoice">
-        <source>menu.invoice</source>
-        <target>发票</target>
-      </trans-unit>
       <trans-unit id="I.eil4u" resname="menu.export">
         <source>menu.export</source>
         <target>输出</target>
@@ -479,8 +475,8 @@
       <!--
               User timesheet calendar
             -->
-      <trans-unit id="HWiuMV6" resname="calendar.title">
-        <source>calendar.title</source>
+      <trans-unit id="UVJ5Die" resname="calendar">
+        <source>calendar</source>
         <target>日历</target>
       </trans-unit>
       <!--
@@ -708,8 +704,8 @@
         <source>admin_invoice_template.title</source>
         <target>发票模板</target>
       </trans-unit>
-      <trans-unit id="iERywrp" resname="invoice.title">
-        <source>invoice.title</source>
+      <trans-unit id="SR2r1Cs" resname="invoices">
+        <source>invoices</source>
         <target>发票</target>
       </trans-unit>
       <trans-unit id="ov4OQOh" resname="invoice.filter">

--- a/translations/system-configuration.ar.xlf
+++ b/translations/system-configuration.ar.xlf
@@ -2,25 +2,13 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file source-language="en" target-language="ar" datatype="plaintext" original="system-configuration.en.xlf">
     <body>
-      <trans-unit id="qvIyBkY" resname="title">
-        <source>title</source>
-        <target>إعدادات</target>
-      </trans-unit>
       <trans-unit id="ycErWZK" resname="timesheet">
         <source>Time tracking</source>
         <target>الجداول الزمنية</target>
       </trans-unit>
-      <trans-unit id="Utbj3k_" resname="invoice">
-        <source>invoice</source>
-        <target>الفواتير</target>
-      </trans-unit>
       <trans-unit id="PLggHn." resname="theme">
         <source>theme</source>
         <target>موضوع</target>
-      </trans-unit>
-      <trans-unit id="UVJ5Die" resname="calendar">
-        <source>calendar</source>
-        <target>تقويم</target>
       </trans-unit>
       <trans-unit id="EPBzIy7" resname="label.theme.markdown_content">
         <source>label.theme.markdown_content</source>

--- a/translations/system-configuration.cs.xlf
+++ b/translations/system-configuration.cs.xlf
@@ -2,10 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file source-language="en" target-language="cs" datatype="plaintext" original="system-configuration.en.xlf">
     <body>
-      <trans-unit id="qvIyBkY" resname="title">
-        <source>title</source>
-        <target>Nastavení</target>
-      </trans-unit>
       <trans-unit id="ycErWZK" resname="timesheet">
         <source>Time tracking</source>
         <target>Sledování času</target>
@@ -13,10 +9,6 @@
       <trans-unit id="PLggHn." resname="theme">
         <source>theme</source>
         <target>Vzhled</target>
-      </trans-unit>
-      <trans-unit id="UVJ5Die" resname="calendar">
-        <source>calendar</source>
-        <target>Kalendář</target>
       </trans-unit>
       <trans-unit id="EPBzIy7" resname="label.theme.markdown_content">
         <source>label.theme.markdown_content</source>
@@ -77,10 +69,6 @@
       <trans-unit id="nDS7Pav" resname="label.theme.branding.company">
         <source>label.theme.branding.company</source>
         <target>Firma</target>
-      </trans-unit>
-      <trans-unit id="Utbj3k_" resname="invoice">
-        <source>invoice</source>
-        <target>Faktury</target>
       </trans-unit>
       <trans-unit id="tNxm3eg" resname="off">
         <source>off</source>

--- a/translations/system-configuration.da.xlf
+++ b/translations/system-configuration.da.xlf
@@ -2,10 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file source-language="en" target-language="da" datatype="plaintext" original="system-configuration.en.xlf">
     <body>
-      <trans-unit id="qvIyBkY" resname="title">
-        <source>title</source>
-        <target>Indstillinger</target>
-      </trans-unit>
       <trans-unit id="ycErWZK" resname="timesheet">
         <source>Time tracking</source>
         <target>Timeseddel</target>
@@ -13,10 +9,6 @@
       <trans-unit id="PLggHn." resname="theme">
         <source>theme</source>
         <target>Tema</target>
-      </trans-unit>
-      <trans-unit id="UVJ5Die" resname="calendar">
-        <source>calendar</source>
-        <target>Kalender</target>
       </trans-unit>
       <trans-unit id="EPBzIy7" resname="label.theme.markdown_content">
         <source>label.theme.markdown_content</source>

--- a/translations/system-configuration.de.xlf
+++ b/translations/system-configuration.de.xlf
@@ -2,25 +2,13 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file source-language="en" target-language="de" datatype="plaintext" original="system-configuration.en.xlf">
     <body>
-      <trans-unit id="qvIyBkY" resname="title">
-        <source>title</source>
-        <target>Einstellungen</target>
-      </trans-unit>
       <trans-unit id="ycErWZK" resname="timesheet">
         <source>Time tracking</source>
         <target state="translated">Zeiterfassung</target>
       </trans-unit>
-      <trans-unit id="Utbj3k_" resname="invoice">
-        <source>invoice</source>
-        <target>Rechnungen</target>
-      </trans-unit>
       <trans-unit id="PLggHn." resname="theme">
         <source>theme</source>
         <target>Darstellung</target>
-      </trans-unit>
-      <trans-unit id="UVJ5Die" resname="calendar">
-        <source>calendar</source>
-        <target>Kalender</target>
       </trans-unit>
       <trans-unit id="EPBzIy7" resname="label.theme.markdown_content">
         <source>label.theme.markdown_content</source>
@@ -93,6 +81,10 @@
       <trans-unit id="oIueXaX" resname="label.timesheet.active_entries.hard_limit">
         <source>label.timesheet.active_entries.hard_limit</source>
         <target>Erlaubte Anzahl an gleichzeitig laufenden Zeiteinträgen</target>
+      </trans-unit>
+      <trans-unit id="zeOPuh6" resname="label.quick_entry.recent_activities">
+        <source>label.quick_entry.recent_activities</source>
+        <target>Anzahl übernommener Einträge aus Vorwochen</target>
       </trans-unit>
       <trans-unit id="iZLna_g" resname="label.theme.autocomplete_chars">
         <source>label.theme.autocomplete_chars</source>

--- a/translations/system-configuration.el.xlf
+++ b/translations/system-configuration.el.xlf
@@ -2,25 +2,13 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file source-language="en" target-language="el" datatype="plaintext" original="system-configuration.en.xlf">
     <body>
-      <trans-unit id="qvIyBkY" resname="title">
-        <source>title</source>
-        <target>Ρυθμίσεις</target>
-      </trans-unit>
       <trans-unit id="ycErWZK" resname="timesheet">
         <source>Time tracking</source>
         <target state="translated">Παρακολούθηση Χρόνου</target>
       </trans-unit>
-      <trans-unit id="Utbj3k_" resname="invoice">
-        <source>invoice</source>
-        <target>Τιμολόγια</target>
-      </trans-unit>
       <trans-unit id="PLggHn." resname="theme">
         <source>theme</source>
         <target>Θέμα</target>
-      </trans-unit>
-      <trans-unit id="UVJ5Die" resname="calendar">
-        <source>calendar</source>
-        <target>Ημερολόγιο</target>
       </trans-unit>
       <trans-unit id="EPBzIy7" resname="label.theme.markdown_content">
         <source>label.theme.markdown_content</source>

--- a/translations/system-configuration.en.xlf
+++ b/translations/system-configuration.en.xlf
@@ -2,25 +2,13 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file source-language="en" target-language="en" datatype="plaintext" original="system-configuration.en.xlf">
     <body>
-      <trans-unit id="qvIyBkY" resname="title">
-        <source>title</source>
-        <target>Settings</target>
-      </trans-unit>
       <trans-unit id="ycErWZK" resname="timesheet">
         <source>Time tracking</source>
         <target>Time tracking</target>
       </trans-unit>
-      <trans-unit id="Utbj3k_" resname="invoice">
-        <source>invoice</source>
-        <target>Invoices</target>
-      </trans-unit>
       <trans-unit id="PLggHn." resname="theme">
         <source>theme</source>
         <target>Theme</target>
-      </trans-unit>
-      <trans-unit id="UVJ5Die" resname="calendar">
-        <source>calendar</source>
-        <target>Calendar</target>
       </trans-unit>
       <trans-unit id="EPBzIy7" resname="label.theme.markdown_content">
         <source>label.theme.markdown_content</source>
@@ -93,6 +81,10 @@
       <trans-unit id="oIueXaX" resname="label.timesheet.active_entries.hard_limit">
         <source>label.timesheet.active_entries.hard_limit</source>
         <target>Permitted number of simultaneously running time entries</target>
+      </trans-unit>
+      <trans-unit id="zeOPuh6" resname="label.quick_entry.recent_activities">
+        <source>label.quick_entry.recent_activities</source>
+        <target>Number of entries taken over from previous weeks</target>
       </trans-unit>
       <trans-unit id="iZLna_g" resname="label.theme.autocomplete_chars">
         <source>label.theme.autocomplete_chars</source>

--- a/translations/system-configuration.eo.xlf
+++ b/translations/system-configuration.eo.xlf
@@ -2,25 +2,13 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file source-language="en" target-language="eo" datatype="plaintext" original="system-configuration.en.xlf">
     <body>
-      <trans-unit id="qvIyBkY" resname="title">
-        <source>title</source>
-        <target>Agordoj</target>
-      </trans-unit>
       <trans-unit id="ycErWZK" resname="timesheet">
         <source>Time tracking</source>
         <target>Tempo-registrado</target>
       </trans-unit>
-      <trans-unit id="Utbj3k_" resname="invoice">
-        <source>invoice</source>
-        <target>Fakturoj</target>
-      </trans-unit>
       <trans-unit id="PLggHn." resname="theme">
         <source>theme</source>
         <target>Etoso</target>
-      </trans-unit>
-      <trans-unit id="UVJ5Die" resname="calendar">
-        <source>calendar</source>
-        <target>Kalendaro</target>
       </trans-unit>
       <trans-unit id="EPBzIy7" resname="label.theme.markdown_content">
         <source>label.theme.markdown_content</source>

--- a/translations/system-configuration.es.xlf
+++ b/translations/system-configuration.es.xlf
@@ -2,10 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file source-language="en" target-language="es" datatype="plaintext" original="system-configuration.en.xlf">
     <body>
-      <trans-unit id="qvIyBkY" resname="title">
-        <source>title</source>
-        <target>Configuración</target>
-      </trans-unit>
       <trans-unit id="ycErWZK" resname="timesheet">
         <source>Time tracking</source>
         <target>Parte de horas</target>
@@ -13,10 +9,6 @@
       <trans-unit id="PLggHn." resname="theme">
         <source>theme</source>
         <target>Tema</target>
-      </trans-unit>
-      <trans-unit id="UVJ5Die" resname="calendar">
-        <source>calendar</source>
-        <target>Calendario</target>
       </trans-unit>
       <trans-unit id="EPBzIy7" resname="label.theme.markdown_content">
         <source>label.theme.markdown_content</source>
@@ -133,10 +125,6 @@
       <trans-unit id="NA.6x_i" resname="label.theme.tags_create">
         <source>label.theme.tags_create</source>
         <target>Etiquetas: utilizar búsqueda de compleción automática y permitir crear etiquetas</target>
-      </trans-unit>
-      <trans-unit id="Utbj3k_" resname="invoice">
-        <source>invoice</source>
-        <target>Facturas</target>
       </trans-unit>
       <trans-unit id="Hnl7Jxt" resname="label.timesheet.rounding.default.duration">
         <source>label.timesheet.rounding.default.duration</source>

--- a/translations/system-configuration.eu.xlf
+++ b/translations/system-configuration.eu.xlf
@@ -2,10 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file source-language="en" target-language="eu" datatype="plaintext" original="system-configuration.en.xlf">
     <body>
-      <trans-unit id="qvIyBkY" resname="title">
-        <source>title</source>
-        <target>Aukerak</target>
-      </trans-unit>
       <trans-unit id="ycErWZK" resname="timesheet">
         <source>Time tracking</source>
         <target>Ordu taula</target>
@@ -13,10 +9,6 @@
       <trans-unit id="PLggHn." resname="theme">
         <source>theme</source>
         <target>Itxura</target>
-      </trans-unit>
-      <trans-unit id="UVJ5Die" resname="calendar">
-        <source>calendar</source>
-        <target>Egutegia</target>
       </trans-unit>
       <trans-unit id="EPBzIy7" resname="label.theme.markdown_content">
         <source>label.theme.markdown_content</source>
@@ -225,10 +217,6 @@
       <trans-unit id="NA.6x_i" resname="label.theme.tags_create">
         <source>label.theme.tags_create</source>
         <target>Etiketak: erabili automatikoki osatutako bilaketa eta baimendu etiketak sortzea</target>
-      </trans-unit>
-      <trans-unit id="Utbj3k_" resname="invoice">
-        <source>invoice</source>
-        <target>Fakturak</target>
       </trans-unit>
     </body>
   </file>

--- a/translations/system-configuration.fi.xlf
+++ b/translations/system-configuration.fi.xlf
@@ -2,25 +2,13 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file source-language="en" target-language="fi" datatype="plaintext" original="system-configuration.en.xlf">
     <body>
-      <trans-unit id="qvIyBkY" resname="title">
-        <source>title</source>
-        <target state="translated">Asetukset</target>
-      </trans-unit>
       <trans-unit id="ycErWZK" resname="timesheet">
         <source>Time tracking</source>
         <target state="translated">Työajanseuranta</target>
       </trans-unit>
-      <trans-unit id="Utbj3k_" resname="invoice">
-        <source>invoice</source>
-        <target state="translated">Laskut</target>
-      </trans-unit>
       <trans-unit id="PLggHn." resname="theme">
         <source>theme</source>
         <target state="translated">Teema</target>
-      </trans-unit>
-      <trans-unit id="UVJ5Die" resname="calendar">
-        <source>calendar</source>
-        <target state="translated">Kalenteri</target>
       </trans-unit>
       <trans-unit id="EPBzIy7" resname="label.theme.markdown_content">
         <source>label.theme.markdown_content</source>

--- a/translations/system-configuration.fr.xlf
+++ b/translations/system-configuration.fr.xlf
@@ -2,10 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file source-language="en" target-language="fr" datatype="plaintext" original="system-configuration.en.xlf">
     <body>
-      <trans-unit id="qvIyBkY" resname="title">
-        <source>title</source>
-        <target>Paramètres</target>
-      </trans-unit>
       <trans-unit id="ycErWZK" resname="timesheet">
         <source>Time tracking</source>
         <target>Feuille d'heures</target>
@@ -13,10 +9,6 @@
       <trans-unit id="PLggHn." resname="theme">
         <source>theme</source>
         <target>Thème</target>
-      </trans-unit>
-      <trans-unit id="UVJ5Die" resname="calendar">
-        <source>calendar</source>
-        <target>Calendrier</target>
       </trans-unit>
       <trans-unit id="EPBzIy7" resname="label.theme.markdown_content">
         <source>label.theme.markdown_content</source>
@@ -205,10 +197,6 @@
       <trans-unit id="NA.6x_i" resname="label.theme.tags_create">
         <source>label.theme.tags_create</source>
         <target>Mots-clés : Utiliser la recherche avec auto-complétion et autoriser la création de mots-clés</target>
-      </trans-unit>
-      <trans-unit id="Utbj3k_" resname="invoice">
-        <source>invoice</source>
-        <target>Factures</target>
       </trans-unit>
       <trans-unit id="tNxm3eg" resname="off">
         <source>off</source>

--- a/translations/system-configuration.he.xlf
+++ b/translations/system-configuration.he.xlf
@@ -2,25 +2,13 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file source-language="en" target-language="he" datatype="plaintext" original="system-configuration.en.xlf">
     <body>
-      <trans-unit id="qvIyBkY" resname="title">
-        <source>title</source>
-        <target>הגדרות</target>
-      </trans-unit>
       <trans-unit id="ycErWZK" resname="timesheet">
         <source>Time tracking</source>
         <target>מעקב אחר שעות</target>
       </trans-unit>
-      <trans-unit id="Utbj3k_" resname="invoice">
-        <source>invoice</source>
-        <target>חשבוניות</target>
-      </trans-unit>
       <trans-unit id="PLggHn." resname="theme">
         <source>theme</source>
         <target>ערכת עיצוב</target>
-      </trans-unit>
-      <trans-unit id="UVJ5Die" resname="calendar">
-        <source>calendar</source>
-        <target>לוח שנה</target>
       </trans-unit>
       <trans-unit id="EPBzIy7" resname="label.theme.markdown_content">
         <source>label.theme.markdown_content</source>

--- a/translations/system-configuration.hr.xlf
+++ b/translations/system-configuration.hr.xlf
@@ -2,25 +2,13 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file source-language="en" target-language="hr" datatype="plaintext" original="system-configuration.en.xlf">
     <body>
-      <trans-unit id="qvIyBkY" resname="title">
-        <source>title</source>
-        <target>Postavke</target>
-      </trans-unit>
       <trans-unit id="ycErWZK" resname="timesheet">
         <source>Time tracking</source>
         <target>Praćenje vremena</target>
       </trans-unit>
-      <trans-unit id="Utbj3k_" resname="invoice">
-        <source>invoice</source>
-        <target>Računi</target>
-      </trans-unit>
       <trans-unit id="PLggHn." resname="theme">
         <source>theme</source>
         <target>Tema</target>
-      </trans-unit>
-      <trans-unit id="UVJ5Die" resname="calendar">
-        <source>calendar</source>
-        <target>Kalendar</target>
       </trans-unit>
       <trans-unit id="EPBzIy7" resname="label.theme.markdown_content">
         <source>label.theme.markdown_content</source>

--- a/translations/system-configuration.hu.xlf
+++ b/translations/system-configuration.hu.xlf
@@ -2,10 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file source-language="en" target-language="hu" datatype="plaintext" original="system-configuration.en.xlf">
     <body>
-      <trans-unit id="qvIyBkY" resname="title">
-        <source>title</source>
-        <target>Rendszer beállítások</target>
-      </trans-unit>
       <trans-unit id="ycErWZK" resname="timesheet">
         <source>Time tracking</source>
         <target>Rögzített órák</target>
@@ -21,10 +17,6 @@
       <trans-unit id="oIueXaX" resname="label.timesheet.active_entries.hard_limit">
         <source>label.timesheet.active_entries.hard_limit</source>
         <target>Egyszerre futtatható rögzítések száma</target>
-      </trans-unit>
-      <trans-unit id="Utbj3k_" resname="invoice">
-        <source>invoice</source>
-        <target>Számlák</target>
       </trans-unit>
       <trans-unit id="NULxaYp" resname="label.calendar.weekends">
         <source>label.calendar.weekends</source>
@@ -77,10 +69,6 @@
       <trans-unit id="EPBzIy7" resname="label.theme.markdown_content">
         <source>label.theme.markdown_content</source>
         <target>Engedélyezz markdown-formázást leírásokban és hozzászólásokban</target>
-      </trans-unit>
-      <trans-unit id="UVJ5Die" resname="calendar">
-        <source>calendar</source>
-        <target>Naptár</target>
       </trans-unit>
       <trans-unit id="PLggHn." resname="theme">
         <source>theme</source>

--- a/translations/system-configuration.it.xlf
+++ b/translations/system-configuration.it.xlf
@@ -2,10 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file source-language="en" target-language="it" datatype="plaintext" original="system-configuration.en.xlf">
     <body>
-      <trans-unit id="qvIyBkY" resname="title">
-        <source>title</source>
-        <target>Impostazioni</target>
-      </trans-unit>
       <trans-unit id="ycErWZK" resname="timesheet">
         <source>Time tracking</source>
         <target>Rilevamento del tempo</target>
@@ -13,10 +9,6 @@
       <trans-unit id="PLggHn." resname="theme">
         <source>theme</source>
         <target>Tema</target>
-      </trans-unit>
-      <trans-unit id="UVJ5Die" resname="calendar">
-        <source>calendar</source>
-        <target>Calendario</target>
       </trans-unit>
       <trans-unit id="EPBzIy7" resname="label.theme.markdown_content">
         <source>label.theme.markdown_content</source>
@@ -177,10 +169,6 @@
       <trans-unit id="NA.6x_i" resname="label.theme.tags_create">
         <source>label.theme.tags_create</source>
         <target>Etichette: utilizza la ricerca di completamento automatico e consenti la creazione di etichette</target>
-      </trans-unit>
-      <trans-unit id="Utbj3k_" resname="invoice">
-        <source>invoice</source>
-        <target>Fatture</target>
       </trans-unit>
       <trans-unit id="A3HPT4p" resname="label.saml_activate">
         <source>label.saml_activate</source>

--- a/translations/system-configuration.ja.xlf
+++ b/translations/system-configuration.ja.xlf
@@ -2,10 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file source-language="en" target-language="ja" datatype="plaintext" original="system-configuration.en.xlf">
     <body>
-      <trans-unit id="qvIyBkY" resname="title">
-        <source>title</source>
-        <target>設定</target>
-      </trans-unit>
       <trans-unit id="ycErWZK" resname="timesheet">
         <source>Time tracking</source>
         <target>タイムシート</target>
@@ -13,10 +9,6 @@
       <trans-unit id="PLggHn." resname="theme">
         <source>theme</source>
         <target>テーマ</target>
-      </trans-unit>
-      <trans-unit id="UVJ5Die" resname="calendar">
-        <source>calendar</source>
-        <target>カレンダー</target>
       </trans-unit>
       <trans-unit id="EPBzIy7" resname="label.theme.markdown_content">
         <source>label.theme.markdown_content</source>

--- a/translations/system-configuration.ko.xlf
+++ b/translations/system-configuration.ko.xlf
@@ -2,10 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file source-language="en" target-language="ko" datatype="plaintext" original="system-configuration.en.xlf">
     <body>
-      <trans-unit id="qvIyBkY" resname="title">
-        <source>title</source>
-        <target state="translated">설정 </target>
-      </trans-unit>
       <trans-unit id="ycErWZK" resname="timesheet">
         <source>Time tracking</source>
         <target state="translated">타임시트</target>
@@ -13,10 +9,6 @@
       <trans-unit id="PLggHn." resname="theme">
         <source>theme</source>
         <target state="translated">테마</target>
-      </trans-unit>
-      <trans-unit id="UVJ5Die" resname="calendar">
-        <source>calendar</source>
-        <target state="translated">캘린더</target>
       </trans-unit>
       <trans-unit id="EPBzIy7" resname="label.theme.markdown_content">
         <source>label.theme.markdown_content</source>
@@ -205,10 +197,6 @@
       <trans-unit id="NA.6x_i" resname="label.theme.tags_create">
         <source>label.theme.tags_create</source>
         <target>태그: 자동 완성 검색 사용 및 태그 생성 허용</target>
-      </trans-unit>
-      <trans-unit id="Utbj3k_" resname="invoice">
-        <source>invoice</source>
-        <target>인보이스</target>
       </trans-unit>
     </body>
   </file>

--- a/translations/system-configuration.nl.xlf
+++ b/translations/system-configuration.nl.xlf
@@ -2,25 +2,13 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file source-language="en" target-language="nl" datatype="plaintext" original="system-configuration.en.xlf">
     <body>
-      <trans-unit id="qvIyBkY" resname="title">
-        <source>title</source>
-        <target>Instellingen</target>
-      </trans-unit>
       <trans-unit id="ycErWZK" resname="timesheet">
         <source>Time tracking</source>
         <target>Tijdregistratie</target>
       </trans-unit>
-      <trans-unit id="Utbj3k_" resname="invoice">
-        <source>invoice</source>
-        <target>Facturen</target>
-      </trans-unit>
       <trans-unit id="PLggHn." resname="theme">
         <source>theme</source>
         <target>Thema</target>
-      </trans-unit>
-      <trans-unit id="UVJ5Die" resname="calendar">
-        <source>calendar</source>
-        <target>Kalender</target>
       </trans-unit>
       <trans-unit id="EPBzIy7" resname="label.theme.markdown_content">
         <source>label.theme.markdown_content</source>

--- a/translations/system-configuration.pl.xlf
+++ b/translations/system-configuration.pl.xlf
@@ -2,10 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file source-language="en" target-language="pl" datatype="plaintext" original="system-configuration.en.xlf">
     <body>
-      <trans-unit id="qvIyBkY" resname="title">
-        <source>title</source>
-        <target>Ustawienia</target>
-      </trans-unit>
       <trans-unit id="ycErWZK" resname="timesheet">
         <source>Time tracking</source>
         <target>Ewidencje</target>
@@ -13,10 +9,6 @@
       <trans-unit id="PLggHn." resname="theme">
         <source>theme</source>
         <target>Kompozycja</target>
-      </trans-unit>
-      <trans-unit id="UVJ5Die" resname="calendar">
-        <source>calendar</source>
-        <target>Kalendarz</target>
       </trans-unit>
       <trans-unit id="EPBzIy7" resname="label.theme.markdown_content">
         <source>label.theme.markdown_content</source>
@@ -169,10 +161,6 @@
       <trans-unit id="0mjJxEk" resname="Floor">
         <source>Floor</source>
         <target>W dół: poczatek , koniec i długośc będą zaokraglane w dół</target>
-      </trans-unit>
-      <trans-unit id="Utbj3k_" resname="invoice">
-        <source>invoice</source>
-        <target>Faktury</target>
       </trans-unit>
       <trans-unit id="6CSB6iM" resname="first_weekday">
         <source>first_weekday</source>

--- a/translations/system-configuration.pt.xlf
+++ b/translations/system-configuration.pt.xlf
@@ -2,10 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file source-language="en" target-language="pt" datatype="plaintext" original="system-configuration.en.xlf">
     <body>
-      <trans-unit id="qvIyBkY" resname="title">
-        <source>title</source>
-        <target>Configurações</target>
-      </trans-unit>
       <trans-unit id="ycErWZK" resname="timesheet">
         <source>Time tracking</source>
         <target>Rastreamento de tempo</target>
@@ -13,10 +9,6 @@
       <trans-unit id="PLggHn." resname="theme">
         <source>theme</source>
         <target>Tema</target>
-      </trans-unit>
-      <trans-unit id="UVJ5Die" resname="calendar">
-        <source>calendar</source>
-        <target>Calendário</target>
       </trans-unit>
       <trans-unit id="EPBzIy7" resname="label.theme.markdown_content">
         <source>label.theme.markdown_content</source>
@@ -205,10 +197,6 @@
       <trans-unit id="NA.6x_i" resname="label.theme.tags_create">
         <source>label.theme.tags_create</source>
         <target>Etiquetas: usar pesquisa com preenchimento automático e permitir a criação de etiquetas</target>
-      </trans-unit>
-      <trans-unit id="Utbj3k_" resname="invoice">
-        <source>invoice</source>
-        <target>Faturas</target>
       </trans-unit>
       <trans-unit id="ZUTc3eH" resname="label.calendar.dragdrop_amount">
         <source>label.calendar.dragdrop_amount</source>

--- a/translations/system-configuration.pt_BR.xlf
+++ b/translations/system-configuration.pt_BR.xlf
@@ -2,10 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file source-language="en" target-language="pt-BR" datatype="plaintext" original="system-configuration.en.xlf">
     <body>
-      <trans-unit id="qvIyBkY" resname="title">
-        <source>title</source>
-        <target>Configurações</target>
-      </trans-unit>
       <trans-unit id="ycErWZK" resname="timesheet">
         <source>Time tracking</source>
         <target>Rastreamento de tempo</target>
@@ -13,10 +9,6 @@
       <trans-unit id="PLggHn." resname="theme">
         <source>theme</source>
         <target>Tema</target>
-      </trans-unit>
-      <trans-unit id="UVJ5Die" resname="calendar">
-        <source>calendar</source>
-        <target>Calendário</target>
       </trans-unit>
       <trans-unit id="EPBzIy7" resname="label.theme.markdown_content">
         <source>label.theme.markdown_content</source>
@@ -205,10 +197,6 @@
       <trans-unit id="NA.6x_i" resname="label.theme.tags_create">
         <source>label.theme.tags_create</source>
         <target>Tags: use pesquisa completa automática e permita a criação de tags</target>
-      </trans-unit>
-      <trans-unit id="Utbj3k_" resname="invoice">
-        <source>invoice</source>
-        <target>Faturas</target>
       </trans-unit>
       <trans-unit id="aUc3uU1" resname="help.theme.color_choices">
         <source>help.theme.color_choices</source>

--- a/translations/system-configuration.ro.xlf
+++ b/translations/system-configuration.ro.xlf
@@ -2,10 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file source-language="en" target-language="ro" datatype="plaintext" original="system-configuration.en.xlf">
     <body>
-      <trans-unit id="qvIyBkY" resname="title">
-        <source>title</source>
-        <target>Setari</target>
-      </trans-unit>
       <trans-unit id="ycErWZK" resname="timesheet">
         <source>Time tracking</source>
         <target>Monitorizarea timpului</target>
@@ -13,10 +9,6 @@
       <trans-unit id="PLggHn." resname="theme">
         <source>theme</source>
         <target>Tema</target>
-      </trans-unit>
-      <trans-unit id="UVJ5Die" resname="calendar">
-        <source>calendar</source>
-        <target>Calendarul</target>
       </trans-unit>
       <trans-unit id="EPBzIy7" resname="label.theme.markdown_content">
         <source>label.theme.markdown_content</source>
@@ -205,10 +197,6 @@
       <trans-unit id=".NE5mGi" resname="label.timesheet.rules.allow_overlapping_records">
         <source>label.timesheet.rules.allow_overlapping_records</source>
         <target>Permite suprapunerea intrărilor de timp</target>
-      </trans-unit>
-      <trans-unit id="Utbj3k_" resname="invoice">
-        <source>invoice</source>
-        <target>Facturi</target>
       </trans-unit>
       <trans-unit id="ZUTc3eH" resname="label.calendar.dragdrop_amount">
         <source>label.calendar.dragdrop_amount</source>

--- a/translations/system-configuration.ru.xlf
+++ b/translations/system-configuration.ru.xlf
@@ -2,25 +2,13 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file source-language="en" target-language="ru" datatype="plaintext" original="system-configuration.en.xlf">
     <body>
-      <trans-unit id="qvIyBkY" resname="title">
-        <source>title</source>
-        <target>Настройки</target>
-      </trans-unit>
       <trans-unit id="ycErWZK" resname="timesheet">
         <source>Time tracking</source>
         <target>Учет времени</target>
       </trans-unit>
-      <trans-unit id="Utbj3k_" resname="invoice">
-        <source>invoice</source>
-        <target>Счета</target>
-      </trans-unit>
       <trans-unit id="PLggHn." resname="theme">
         <source>theme</source>
         <target>Тема</target>
-      </trans-unit>
-      <trans-unit id="UVJ5Die" resname="calendar">
-        <source>calendar</source>
-        <target>Календарь</target>
       </trans-unit>
       <trans-unit id="EPBzIy7" resname="label.theme.markdown_content">
         <source>label.theme.markdown_content</source>

--- a/translations/system-configuration.sk.xlf
+++ b/translations/system-configuration.sk.xlf
@@ -2,10 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file source-language="en" target-language="sk" datatype="plaintext" original="system-configuration.en.xlf">
     <body>
-      <trans-unit id="qvIyBkY" resname="title">
-        <source>title</source>
-        <target>Nastavenia</target>
-      </trans-unit>
       <trans-unit id="ycErWZK" resname="timesheet">
         <source>Time tracking</source>
         <target>Pracovný výkaz</target>
@@ -178,17 +174,9 @@
         <source>label.theme.markdown_content</source>
         <target>Povoliť formátovanie poznámok v popiskoch a komentároch</target>
       </trans-unit>
-      <trans-unit id="UVJ5Die" resname="calendar">
-        <source>calendar</source>
-        <target>Kalendár</target>
-      </trans-unit>
       <trans-unit id="PLggHn." resname="theme">
         <source>theme</source>
         <target>Vzhľad</target>
-      </trans-unit>
-      <trans-unit id="Utbj3k_" resname="invoice">
-        <source>invoice</source>
-        <target>Faktúry</target>
       </trans-unit>
       <trans-unit id="0mjJxEk" resname="Floor">
         <source>Floor</source>

--- a/translations/system-configuration.sv.xlf
+++ b/translations/system-configuration.sv.xlf
@@ -2,10 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file source-language="en" target-language="sv" datatype="plaintext" original="system-configuration.en.xlf">
     <body>
-      <trans-unit id="qvIyBkY" resname="title">
-        <source>title</source>
-        <target state="translated">Inställningar</target>
-      </trans-unit>
       <trans-unit id="ycErWZK" resname="timesheet">
         <source>Time tracking</source>
         <target state="translated">Tidsuppföljning</target>
@@ -13,10 +9,6 @@
       <trans-unit id="PLggHn." resname="theme">
         <source>theme</source>
         <target state="translated">Tema</target>
-      </trans-unit>
-      <trans-unit id="UVJ5Die" resname="calendar">
-        <source>calendar</source>
-        <target state="translated">Kalender</target>
       </trans-unit>
       <trans-unit id="EPBzIy7" resname="label.theme.markdown_content">
         <source>label.theme.markdown_content</source>
@@ -253,10 +245,6 @@
       <trans-unit id="NA.6x_i" resname="label.theme.tags_create">
         <source>label.theme.tags_create</source>
         <target>Taggar: använd automatisk komplettering vid sökning och tillåt skapande av taggar</target>
-      </trans-unit>
-      <trans-unit id="Utbj3k_" resname="invoice">
-        <source>invoice</source>
-        <target>Fakturor</target>
       </trans-unit>
       <trans-unit id="ZUTc3eH" resname="label.calendar.dragdrop_amount">
         <source>label.calendar.dragdrop_amount</source>

--- a/translations/system-configuration.tr.xlf
+++ b/translations/system-configuration.tr.xlf
@@ -2,10 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file source-language="en" target-language="tr" datatype="plaintext" original="system-configuration.en.xlf">
     <body>
-      <trans-unit id="qvIyBkY" resname="title">
-        <source>title</source>
-        <target state="translated">Ayarlar</target>
-      </trans-unit>
       <trans-unit id="ycErWZK" resname="timesheet">
         <source>Time tracking</source>
         <target state="translated">Zaman izleme</target>
@@ -13,10 +9,6 @@
       <trans-unit id="PLggHn." resname="theme">
         <source>theme</source>
         <target state="translated">Tema</target>
-      </trans-unit>
-      <trans-unit id="UVJ5Die" resname="calendar">
-        <source>calendar</source>
-        <target state="translated">Takvim</target>
       </trans-unit>
       <trans-unit id="EPBzIy7" resname="label.theme.markdown_content">
         <source>label.theme.markdown_content</source>
@@ -205,10 +197,6 @@
       <trans-unit id="NA.6x_i" resname="label.theme.tags_create">
         <source>label.theme.tags_create</source>
         <target>Etiketler: aramada otomatik tamamlama kullan ve etiket oluşturmaya izin ver</target>
-      </trans-unit>
-      <trans-unit id="Utbj3k_" resname="invoice">
-        <source>invoice</source>
-        <target>Faturalar</target>
       </trans-unit>
       <trans-unit id="tNxm3eg" resname="off">
         <source>off</source>

--- a/translations/system-configuration.vi.xlf
+++ b/translations/system-configuration.vi.xlf
@@ -2,25 +2,13 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file source-language="en" target-language="vi" datatype="plaintext" original="system-configuration.en.xlf">
     <body>
-      <trans-unit id="qvIyBkY" resname="title">
-        <source>title</source>
-        <target>Cài đặt</target>
-      </trans-unit>
       <trans-unit id="ycErWZK" resname="timesheet">
         <source>Time tracking</source>
         <target>Bảng chấm công</target>
       </trans-unit>
-      <trans-unit id="Utbj3k_" resname="invoice">
-        <source>invoice</source>
-        <target>Hóa đơn</target>
-      </trans-unit>
       <trans-unit id="PLggHn." resname="theme">
         <source>theme</source>
         <target>Chủ đề</target>
-      </trans-unit>
-      <trans-unit id="UVJ5Die" resname="calendar">
-        <source>calendar</source>
-        <target>Lịch</target>
       </trans-unit>
       <trans-unit id="EPBzIy7" resname="label.theme.markdown_content">
         <source>label.theme.markdown_content</source>

--- a/translations/system-configuration.zh_CN.xlf
+++ b/translations/system-configuration.zh_CN.xlf
@@ -2,10 +2,6 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file source-language="en" target-language="zh-CN" datatype="plaintext" original="system-configuration.en.xlf">
     <body>
-      <trans-unit id="qvIyBkY" resname="title">
-        <source>title</source>
-        <target>设置</target>
-      </trans-unit>
       <trans-unit id="ycErWZK" resname="timesheet">
         <source>Time tracking</source>
         <target>时间表</target>
@@ -13,10 +9,6 @@
       <trans-unit id="PLggHn." resname="theme">
         <source>theme</source>
         <target>主题</target>
-      </trans-unit>
-      <trans-unit id="UVJ5Die" resname="calendar">
-        <source>calendar</source>
-        <target>日历</target>
       </trans-unit>
       <trans-unit id="EPBzIy7" resname="label.theme.markdown_content">
         <source>label.theme.markdown_content</source>
@@ -265,10 +257,6 @@
       <trans-unit id="NA.6x_i" resname="label.theme.tags_create">
         <source>label.theme.tags_create</source>
         <target>标签:使用自动完成搜索并允许创建标签</target>
-      </trans-unit>
-      <trans-unit id="Utbj3k_" resname="invoice">
-        <source>invoice</source>
-        <target>发票</target>
       </trans-unit>
     </body>
   </file>


### PR DESCRIPTION
## Description

New system configuration: 
<img width="411" alt="Bildschirmfoto 2021-12-16 um 15 37 49" src="https://user-images.githubusercontent.com/533162/146391835-c27b8588-4af6-422d-949c-e4b3ed9064c7.png">

Also some translation key cleanups.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [x] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
