### PR TITLE
support more complex metafield queries

### DIFF
--- a/src/Repository/RepositorySearchTrait.php
+++ b/src/Repository/RepositorySearchTrait.php
@@ -1,0 +1,118 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Repository;
+
+use App\Repository\Query\BaseQuery;
+use Doctrine\ORM\QueryBuilder;
+
+trait RepositorySearchTrait
+{
+    private function getMetaFieldClass(): ?string
+    {
+        return null;
+    }
+
+    private function getMetaFieldName(): ?string
+    {
+        return null;
+    }
+
+    /**
+     * @return array<string>
+     */
+    private function getSearchableFields(): array
+    {
+        return [];
+    }
+
+    private function supportsMetaFields(): bool
+    {
+        /* @phpstan-ignore-next-line  */
+        return $this->getMetaFieldClass() !== null && $this->getMetaFieldName() !== null;
+    }
+
+    private function addSearchTerm(QueryBuilder $qb, BaseQuery $query): void
+    {
+        if (!$query->hasSearchTerm()) {
+            return;
+        }
+
+        $searchTerm = $query->getSearchTerm();
+
+        if (!$this->supportsMetaFields() && !$searchTerm->hasSearchTerm()) {
+            return;
+        }
+
+        $aliases = $qb->getRootAliases();
+        if (!isset($aliases[0])) {
+            throw new RepositoryException('No alias was set before invoking addSearchTerm().');
+        }
+        $rootAlias = $aliases[0];
+
+        $searchAnd = $qb->expr()->andX();
+
+        if ($this->supportsMetaFields()) {
+            foreach ($searchTerm->getSearchFields() as $metaName => $metaValue) {
+                $and = $qb->expr()->andX();
+
+                if ($metaValue === '*') {
+                    $qb->leftJoin($rootAlias . '.meta', 'meta');
+                    $and->add($qb->expr()->eq('meta.name', ':metaName'));
+                    $qb->setParameter('metaName', $metaName);
+                    $and->add($qb->expr()->isNotNull('meta.value'));
+                } elseif ($metaValue === '~') {
+                    $and->add(
+                        sprintf('NOT EXISTS(SELECT metaNotExists FROM %s metaNotExists WHERE metaNotExists.%s = %s.id)', $this->getMetaFieldClass(), $this->getMetaFieldName(), $rootAlias)
+                    );
+                } elseif ($metaValue === '' || $metaValue === null) {
+                    $qb->leftJoin($rootAlias . '.meta', 'meta');
+                    $and->add(
+                        $qb->expr()->orX(
+                            $qb->expr()->andX(
+                                $qb->expr()->eq('meta.name', ':metaName'),
+                                $qb->expr()->isNull('meta.value')
+                            ),
+                            sprintf('NOT EXISTS(SELECT metaNotExists FROM %s metaNotExists WHERE metaNotExists.%s = %s.id)', $this->getMetaFieldClass(), $this->getMetaFieldName(), $rootAlias)
+                        )
+                    );
+                    $qb->setParameter('metaName', $metaName);
+                } else {
+                    $qb->leftJoin($rootAlias . '.meta', 'meta');
+                    $and->add($qb->expr()->eq('meta.name', ':metaName'));
+                    $and->add($qb->expr()->like('meta.value', ':metaValue'));
+                    $qb->setParameter('metaName', $metaName);
+                    $qb->setParameter('metaValue', '%' . $metaValue . '%');
+                }
+
+                $searchAnd->add($and);
+            }
+        }
+
+        $fields = $this->getSearchableFields();
+
+        if ($searchTerm->hasSearchTerm() && \count($fields) > 0) {
+            $or = $qb->expr()->orX();
+            foreach ($fields as $field) {
+                if (stripos($field, '.') === false) {
+                    $field = $rootAlias . '.' . $field;
+                }
+                $or->add(
+                    $qb->expr()->like($field, ':searchTerm'),
+                );
+            }
+            $searchAnd->add($or);
+            $qb->setParameter('searchTerm', '%' . $searchTerm->getSearchTerm() . '%');
+        }
+
+        if ($searchAnd->count() > 0) {
+            $qb->andWhere($searchAnd);
+        }
+    }
+}

--- a/src/Repository/TimesheetRepository.php
+++ b/src/Repository/TimesheetRepository.php
@@ -16,6 +16,7 @@ use App\Entity\ProjectRate;
 use App\Entity\RateInterface;
 use App\Entity\Team;
 use App\Entity\Timesheet;
+use App\Entity\TimesheetMeta;
 use App\Entity\User;
 use App\Model\Statistic\Day;
 use App\Model\Statistic\Month;
@@ -41,6 +42,8 @@ use Pagerfanta\Pagerfanta;
  */
 class TimesheetRepository extends EntityRepository
 {
+    use RepositorySearchTrait;
+
     public const STATS_QUERY_DURATION = 'duration';
     public const STATS_QUERY_RATE = 'rate';
     public const STATS_QUERY_USER = 'users';
@@ -1001,33 +1004,7 @@ class TimesheetRepository extends EntityRepository
 
         $requiresTeams = $this->addPermissionCriteria($qb, $query->getCurrentUser(), $query->getTeams());
 
-        if ($query->hasSearchTerm()) {
-            $searchAnd = $qb->expr()->andX();
-            $searchTerm = $query->getSearchTerm();
-
-            foreach ($searchTerm->getSearchFields() as $metaName => $metaValue) {
-                $qb->leftJoin('t.meta', 'meta');
-                $searchAnd->add(
-                    $qb->expr()->andX(
-                        $qb->expr()->eq('meta.name', ':metaName'),
-                        $qb->expr()->like('meta.value', ':metaValue')
-                    )
-                );
-                $qb->setParameter('metaName', $metaName);
-                $qb->setParameter('metaValue', '%' . $metaValue . '%');
-            }
-
-            if ($searchTerm->hasSearchTerm()) {
-                $searchAnd->add(
-                    $qb->expr()->like('t.description', ':searchTerm')
-                );
-                $qb->setParameter('searchTerm', '%' . $searchTerm->getSearchTerm() . '%');
-            }
-
-            if ($searchAnd->count() > 0) {
-                $qb->andWhere($searchAnd);
-            }
-        }
+        $this->addSearchTerm($qb, $query);
 
         if ($requiresCustomer || $requiresProject || $requiresTeams) {
             $qb->leftJoin('t.project', 'p');
@@ -1046,6 +1023,24 @@ class TimesheetRepository extends EntityRepository
         }
 
         return $qb;
+    }
+
+    private function getMetaFieldClass(): string
+    {
+        return TimesheetMeta::class;
+    }
+
+    private function getMetaFieldName(): string
+    {
+        return 'timesheet';
+    }
+
+    /**
+     * @return array<string>
+     */
+    private function getSearchableFields(): array
+    {
+        return ['t.description'];
     }
 
     /**


### PR DESCRIPTION
## Description

- searchterm `checkbox:`: find results with empty field value or not existing (AKA when term is `empty` or `null`)
- searchterm `~`: find results with not existing metafield (created before metafield was created)
- searchterm `*`: find results with any value (basically the opposite of `~`)
- searchterm `checkbox:1`: find results with exactly given field value

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
