### PR TITLE
allow changing calendar entry title

### DIFF
--- a/src/Calendar/CalendarService.php
+++ b/src/Calendar/CalendarService.php
@@ -114,6 +114,7 @@ final class CalendarService
             'timeframeBegin' => $this->configuration->getCalendarTimeframeBegin(),
             'timeframeEnd' => $this->configuration->getCalendarTimeframeEnd(),
             'dragDropAmount' => $this->configuration->getCalendarDragAndDropMaxEntries(),
+            'entryTitlePattern' => $this->configuration->find('calendar.title_pattern'),
         ];
 
         $event = new CalendarConfigurationEvent($config);

--- a/src/Controller/SystemConfigurationController.php
+++ b/src/Controller/SystemConfigurationController.php
@@ -16,6 +16,7 @@ use App\Form\Model\SystemConfiguration as SystemConfigurationModel;
 use App\Form\SystemConfigurationForm;
 use App\Form\Type\ActivityTypePatternType;
 use App\Form\Type\ArrayToCommaStringType;
+use App\Form\Type\CalendarTitlePatternType;
 use App\Form\Type\CustomerTypePatternType;
 use App\Form\Type\DatePickerType;
 use App\Form\Type\DateTimeTextType;
@@ -623,6 +624,10 @@ final class SystemConfigurationController extends AbstractController
                         ->setTranslationDomain('system-configuration')
                         ->setType(IntegerType::class)
                         ->setConstraints([new Range(['min' => 0, 'max' => 20]), new NotNull()]),
+                    (new Configuration())
+                        ->setName('calendar.title_pattern')
+                        ->setTranslationDomain('system-configuration')
+                        ->setType(CalendarTitlePatternType::class),
                 ]),
             (new SystemConfigurationModel('branding'))
                 ->setConfiguration([

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -429,6 +429,10 @@ class Configuration implements ConfigurationInterface
                         ->thenInvalid('The dragdrop_amount must be between 0 and 20')
                     ->end()
                 ->end()
+                ->enumNode('title_pattern')
+                    ->values(['{activity}', '{project}', '{customer}', '{description}'])
+                    ->defaultValue('{activity}')
+                ->end()
             ->end()
         ;
 

--- a/src/Form/Type/CalendarTitlePatternType.php
+++ b/src/Form/Type/CalendarTitlePatternType.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Contracts\Translation\TranslatorInterface;
+
+/**
+ * Select the pattern that will be used for calendar entry titles.
+ */
+class CalendarTitlePatternType extends AbstractType
+{
+    public const PATTERN_CUSTOMER = '{customer}';
+    public const PATTERN_PROJECT = '{project}';
+    public const PATTERN_ACTIVITY = '{activity}';
+    public const PATTERN_DESCRIPTION = '{description}';
+    public const SPACER = ' - ';
+
+    private $translator;
+
+    public function __construct(TranslatorInterface $translator)
+    {
+        $this->translator = $translator;
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $customer = $this->translator->trans('label.customer');
+        $project = $this->translator->trans('label.project');
+        $activity = $this->translator->trans('label.activity');
+        $description = $this->translator->trans('label.description');
+        $spacer = CustomerType::SPACER;
+
+        $resolver->setDefaults([
+            'label' => 'label.choice_pattern',
+            'choices' => [
+                $activity => CalendarTitlePatternType::PATTERN_ACTIVITY,
+                $project => CalendarTitlePatternType::PATTERN_PROJECT,
+                $customer => CalendarTitlePatternType::PATTERN_CUSTOMER,
+                $description => CalendarTitlePatternType::PATTERN_DESCRIPTION,
+            ]
+        ]);
+    }
+
+    public function getParent(): string
+    {
+        return ChoiceType::class;
+    }
+}

--- a/src/Form/Type/CalendarTitlePatternType.php
+++ b/src/Form/Type/CalendarTitlePatternType.php
@@ -23,6 +23,10 @@ class CalendarTitlePatternType extends AbstractType
     public const PATTERN_PROJECT = '{project}';
     public const PATTERN_ACTIVITY = '{activity}';
     public const PATTERN_DESCRIPTION = '{description}';
+    public const SPACER = ' - ';
+    public const PATTERN_ACTIVITY_DESCRIPTION = self::PATTERN_ACTIVITY . self::SPACER . self::PATTERN_DESCRIPTION;
+    public const PATTERN_PROJECT_DESCRIPTION = self::PATTERN_PROJECT . self::SPACER . self::PATTERN_DESCRIPTION;
+    public const PATTERN_CUSTOMER_DESCRIPTION = self::PATTERN_CUSTOMER . self::SPACER . self::PATTERN_DESCRIPTION;
 
     private $translator;
 
@@ -45,6 +49,9 @@ class CalendarTitlePatternType extends AbstractType
                 $project => CalendarTitlePatternType::PATTERN_PROJECT,
                 $customer => CalendarTitlePatternType::PATTERN_CUSTOMER,
                 $description => CalendarTitlePatternType::PATTERN_DESCRIPTION,
+                $activity . self::SPACER . $description => CalendarTitlePatternType::PATTERN_ACTIVITY_DESCRIPTION,
+                $project . self::SPACER . $description => CalendarTitlePatternType::PATTERN_PROJECT_DESCRIPTION,
+                $customer . self::SPACER . $description => CalendarTitlePatternType::PATTERN_CUSTOMER_DESCRIPTION,
             ]
         ]);
     }

--- a/src/Form/Type/CalendarTitlePatternType.php
+++ b/src/Form/Type/CalendarTitlePatternType.php
@@ -23,7 +23,6 @@ class CalendarTitlePatternType extends AbstractType
     public const PATTERN_PROJECT = '{project}';
     public const PATTERN_ACTIVITY = '{activity}';
     public const PATTERN_DESCRIPTION = '{description}';
-    public const SPACER = ' - ';
 
     private $translator;
 
@@ -38,7 +37,6 @@ class CalendarTitlePatternType extends AbstractType
         $project = $this->translator->trans('label.project');
         $activity = $this->translator->trans('label.activity');
         $description = $this->translator->trans('label.description');
-        $spacer = CustomerType::SPACER;
 
         $resolver->setDefaults([
             'label' => 'label.choice_pattern',

--- a/templates/calendar/user.html.twig
+++ b/templates/calendar/user.html.twig
@@ -105,12 +105,23 @@
 
             let title = apiItem.activity.name;
 
+            let description = '';
+            if (apiItem.description !== null && apiItem.description !== '') {
+                description = '{{ constant('\\App\\Form\\Type\\CalendarTitlePatternType::SPACER') }}' + apiItem.description;
+            }
+
             {% if config.entryTitlePattern == constant('\\App\\Form\\Type\\CalendarTitlePatternType::PATTERN_PROJECT') %}
                 title = apiItem.project.name;
             {% elseif config.entryTitlePattern == constant('\\App\\Form\\Type\\CalendarTitlePatternType::PATTERN_CUSTOMER') %}
                 title = apiItem.project.customer.name;
             {% elseif config.entryTitlePattern == constant('\\App\\Form\\Type\\CalendarTitlePatternType::PATTERN_DESCRIPTION') %}
                 title = apiItem.description;
+            {% elseif config.entryTitlePattern == constant('\\App\\Form\\Type\\CalendarTitlePatternType::PATTERN_ACTIVITY_DESCRIPTION') %}
+                title = apiItem.activity.name + description;
+            {% elseif config.entryTitlePattern == constant('\\App\\Form\\Type\\CalendarTitlePatternType::PATTERN_PROJECT_DESCRIPTION') %}
+                title = apiItem.project.name + description;
+            {% elseif config.entryTitlePattern == constant('\\App\\Form\\Type\\CalendarTitlePatternType::PATTERN_CUSTOMER_DESCRIPTION') %}
+                title = apiItem.project.customer.name + description;
             {% endif %}
 
             if (title === '' || title === null) {

--- a/templates/calendar/user.html.twig
+++ b/templates/calendar/user.html.twig
@@ -62,6 +62,10 @@
     <script>
         activatePopover();
 
+        document.addEventListener('kimai.initialized', function() {
+            KimaiReloadPageWidget.create('kimai.systemConfigUpdate', true);
+        });
+
         document.addEventListener('kimai.timesheetUpdate', function() {
             jQuery('{{ calendarSelector }}').fullCalendar('refetchEvents');
         });
@@ -98,9 +102,24 @@
             if (color == null) {
                 color = defaultColor;
             }
+
+            let title = apiItem.activity.name;
+
+            {% if config.entryTitlePattern == constant('\\App\\Form\\Type\\CalendarTitlePatternType::PATTERN_PROJECT') %}
+                title = apiItem.project.name;
+            {% elseif config.entryTitlePattern == constant('\\App\\Form\\Type\\CalendarTitlePatternType::PATTERN_CUSTOMER') %}
+                title = apiItem.project.customer.name;
+            {% elseif config.entryTitlePattern == constant('\\App\\Form\\Type\\CalendarTitlePatternType::PATTERN_DESCRIPTION') %}
+                title = apiItem.description;
+            {% endif %}
+
+            if (title === '' || title === null) {
+                title = apiItem.activity.name;
+            }
+
             return {
                 id: apiItem.id,
-                title: apiItem.activity.name,
+                title: title,
                 description: apiItem.description,
                 start: apiItem.begin,
                 end: apiItem.end,

--- a/tests/DependencyInjection/AppExtensionTest.php
+++ b/tests/DependencyInjection/AppExtensionTest.php
@@ -131,6 +131,7 @@ class AppExtensionTest extends TestCase
                 ],
                 'weekends' => true,
                 'dragdrop_amount' => 10,
+                'title_pattern' => '{activity}',
             ],
             'kimai.dashboard' => [],
             'kimai.widgets' => [],

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -360,6 +360,7 @@ class ConfigurationTest extends TestCase
                 ],
                 'weekends' => true,
                 'dragdrop_amount' => 10,
+                'title_pattern' => '{activity}',
             ],
             'theme' => [
                 'active_warning' => 3,

--- a/translations/system-configuration.de.xlf
+++ b/translations/system-configuration.de.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file source-language="en" target-language="de" datatype="plaintext" original="system-configuration.en.xlf">
     <body>
-      <trans-unit id="ycErWZK" resname="timesheet">
+      <trans-unit id="lt2Y2LO" resname="timesheet">
         <source>Time tracking</source>
         <target state="translated">Zeiterfassung</target>
       </trans-unit>
@@ -297,6 +297,10 @@
       <trans-unit id="ZUTc3eH" resname="label.calendar.dragdrop_amount">
         <source>label.calendar.dragdrop_amount</source>
         <target>Anzahl an Einträgen für Drag&amp;Drop (0 = deaktiviert)</target>
+      </trans-unit>
+      <trans-unit id="MXabpD7" resname="label.calendar.title_pattern">
+        <source>label.calendar.title_pattern</source>
+        <target>Darstellung der Titel von Kalender Einträgen</target>
       </trans-unit>
     </body>
   </file>

--- a/translations/system-configuration.en.xlf
+++ b/translations/system-configuration.en.xlf
@@ -2,7 +2,7 @@
 <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
   <file source-language="en" target-language="en" datatype="plaintext" original="system-configuration.en.xlf">
     <body>
-      <trans-unit id="ycErWZK" resname="timesheet">
+      <trans-unit id="lt2Y2LO" resname="timesheet">
         <source>Time tracking</source>
         <target>Time tracking</target>
       </trans-unit>
@@ -297,6 +297,10 @@
       <trans-unit id="ZUTc3eH" resname="label.calendar.dragdrop_amount">
         <source>label.calendar.dragdrop_amount</source>
         <target>Amount of entries for drag&amp;drop (0 = deactivated)</target>
+      </trans-unit>
+      <trans-unit id="MXabpD7" resname="label.calendar.title_pattern">
+        <source>label.calendar.title_pattern</source>
+        <target>Display of the titles of calendar entries</target>
       </trans-unit>
     </body>
   </file>


### PR DESCRIPTION
## Description

Change the pattern used for rendering the calendar entry title. Possible choices:
- activity name
- project name
- customer name
- timesheet description

<img width="889" alt="Bildschirmfoto 2022-04-25 um 17 31 08" src="https://user-images.githubusercontent.com/533162/165122439-ab11df0e-f5ca-438a-9822-6970c77abb11.png">

Fixes #2740

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
