### PR TITLE
Release 1.19.6

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -11838,16 +11838,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.6.0",
+            "version": "1.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "b480ba2ae0699a72d43a340c20b9c00ede91ee3e"
+                "reference": "e8852764cf5ec8dcd2a3fa8ea03cbcf523639419"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b480ba2ae0699a72d43a340c20b9c00ede91ee3e",
-                "reference": "b480ba2ae0699a72d43a340c20b9c00ede91ee3e",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/e8852764cf5ec8dcd2a3fa8ea03cbcf523639419",
+                "reference": "e8852764cf5ec8dcd2a3fa8ea03cbcf523639419",
                 "shasum": ""
             },
             "require": {
@@ -11873,7 +11873,7 @@
             "description": "PHPStan - PHP Static Analysis Tool",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/1.6.0"
+                "source": "https://github.com/phpstan/phpstan/tree/1.6.1"
             },
             "funding": [
                 {
@@ -11893,7 +11893,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-04-26T05:43:03+00:00"
+            "time": "2022-04-26T18:09:31+00:00"
         },
         {
             "name": "phpstan/phpstan-doctrine",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,7 +3,7 @@ includes:
     - %rootDir%/../phpstan-symfony/rules.neon
     - %rootDir%/../phpstan-doctrine/extension.neon
     - %rootDir%/../phpstan-doctrine/rules.neon
-#    - %rootDir%/../phpstan/conf/bleedingEdge.neon
+    - %rootDir%/../phpstan/conf/bleedingEdge.neon
 
 parameters:
     tmpDir: %rootDir%/../../../var/cache/phpstan

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -17,11 +17,11 @@ class Constants
     /**
      * The current release version
      */
-    public const VERSION = '1.19.5';
+    public const VERSION = '1.19.6';
     /**
      * The current release: major * 10000 + minor * 100 + patch
      */
-    public const VERSION_ID = 11905;
+    public const VERSION_ID = 11906;
     /**
      * The current release status, either "stable" or "dev"
      */

--- a/src/Form/Type/QuickEntryWeekType.php
+++ b/src/Form/Type/QuickEntryWeekType.php
@@ -111,7 +111,7 @@ class QuickEntryWeekType extends AbstractType
             ],
             'allow_add' => true,
             'constraints' => [
-                new Valid(),
+                // having "new Valid()," here will trigger constraint violations on activity and project for completely empty rows
                 new All(['constraints' => [new QuickEntryTimesheet()]])
             ],
         ]);

--- a/templates/reporting/customer/monthly_projects_data.html.twig
+++ b/templates/reporting/customer/monthly_projects_data.html.twig
@@ -18,7 +18,7 @@
             {% for activity in stats.activities %}
                 <th colspan="3" class="text-center">{{ activity.name }}</th>
             {% endfor %}
-            <th rowspan="2" style="{{ rowspanStyle }}">{{ dataTypeTitle|trans }}</th>
+            <th rowspan="2" style="{{ rowspanStyle }}" class="text-center">{{ dataTypeTitle|trans }}</th>
         </tr>
         <tr>
             {% for activity in stats.activities %}


### PR DESCRIPTION
## Description

- CRITICAL: **fix saving in quick-entry form with empty rows**
- fix `totals` cell alignment in new customer report
- DEV: reactivate phpstan bleeding edge rules after update

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
