### PR TITLE
allow switching user displayed in calendar

### DIFF
--- a/src/Controller/TimesheetAbstractController.php
+++ b/src/Controller/TimesheetAbstractController.php
@@ -23,10 +23,9 @@ use App\Form\MultiUpdate\MultiUpdateTableDTO;
 use App\Form\MultiUpdate\TimesheetMultiUpdate;
 use App\Form\MultiUpdate\TimesheetMultiUpdateDTO;
 use App\Form\TimesheetEditForm;
+use App\Form\TimesheetPreCreateForm;
 use App\Form\Toolbar\TimesheetExportToolbarForm;
 use App\Form\Toolbar\TimesheetToolbarForm;
-use App\Repository\ActivityRepository;
-use App\Repository\ProjectRepository;
 use App\Repository\Query\TimesheetQuery;
 use App\Repository\TagRepository;
 use App\Repository\TimesheetRepository;
@@ -147,48 +146,14 @@ abstract class TimesheetAbstractController extends AbstractController
         ]);
     }
 
-    protected function getTags(TagRepository $tagRepository, $tagNames)
-    {
-        $tags = [];
-        if (!\is_array($tagNames)) {
-            $tagNames = explode(',', $tagNames);
-        }
-        foreach ($tagNames as $tagName) {
-            $tag = $tagRepository->findTagByName($tagName);
-            if (!$tag) {
-                $tag = new Tag();
-                $tag->setName($tagName);
-            }
-            $tags[] = $tag;
-        }
-
-        return $tags;
-    }
-
-    protected function create(Request $request, string $renderTemplate, ProjectRepository $projectRepository, ActivityRepository $activityRepository, TagRepository $tagRepository): Response
+    protected function create(Request $request, string $renderTemplate): Response
     {
         $entry = $this->service->createNewTimesheet($this->getUser());
 
-        if ($request->query->get('project')) {
-            $project = $projectRepository->find($request->query->get('project'));
-            $entry->setProject($project);
-        }
-
-        if ($request->query->get('activity')) {
-            $activity = $activityRepository->find($request->query->get('activity'));
-            $entry->setActivity($activity);
-        }
-
-        if ($request->query->get('description')) {
-            $description = $request->query->get('description');
-            $entry->setDescription($description);
-        }
-
-        if ($request->query->get('tags')) {
-            foreach ($this->getTags($tagRepository, $request->query->get('tags')) as $tag) {
-                $entry->addTag($tag);
-            }
-        }
+        $preForm = $this->createFormForGetRequest(TimesheetPreCreateForm::class, $entry, [
+            'include_user' => $this->includeUserInForms('create'),
+        ]);
+        $preForm->submit($request->query->all(), false);
 
         $this->service->prepareNewTimesheet($entry, $request);
         $createForm = $this->getCreateForm($entry);

--- a/src/Controller/TimesheetController.php
+++ b/src/Controller/TimesheetController.php
@@ -13,9 +13,6 @@ use App\Entity\Timesheet;
 use App\Event\TimesheetMetaDisplayEvent;
 use App\Export\ServiceExport;
 use App\Form\TimesheetEditForm;
-use App\Repository\ActivityRepository;
-use App\Repository\ProjectRepository;
-use App\Repository\TagRepository;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -90,9 +87,9 @@ class TimesheetController extends TimesheetAbstractController
      * @Route(path="/create", name="timesheet_create", methods={"GET", "POST"})
      * @Security("is_granted('create_own_timesheet')")
      */
-    public function createAction(Request $request, ProjectRepository $projectRepository, ActivityRepository $activityRepository, TagRepository $tagRepository): Response
+    public function createAction(Request $request): Response
     {
-        return $this->create($request, 'timesheet/edit.html.twig', $projectRepository, $activityRepository, $tagRepository);
+        return $this->create($request, 'timesheet/edit.html.twig');
     }
 
     protected function getCreateForm(Timesheet $entry): FormInterface

--- a/src/Controller/TimesheetTeamController.php
+++ b/src/Controller/TimesheetTeamController.php
@@ -18,10 +18,7 @@ use App\Export\ServiceExport;
 use App\Form\Model\MultiUserTimesheet;
 use App\Form\TimesheetAdminEditForm;
 use App\Form\TimesheetMultiUserEditForm;
-use App\Repository\ActivityRepository;
-use App\Repository\ProjectRepository;
 use App\Repository\Query\TimesheetQuery;
-use App\Repository\TagRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Security;
 use Symfony\Component\Form\FormInterface;
@@ -83,9 +80,9 @@ class TimesheetTeamController extends TimesheetAbstractController
      * @Route(path="/create", name="admin_timesheet_create", methods={"GET", "POST"})
      * @Security("is_granted('create_other_timesheet')")
      */
-    public function createAction(Request $request, ProjectRepository $projectRepository, ActivityRepository $activityRepository, TagRepository $tagRepository): Response
+    public function createAction(Request $request): Response
     {
-        return $this->create($request, 'timesheet-team/edit.html.twig', $projectRepository, $activityRepository, $tagRepository);
+        return $this->create($request, 'timesheet-team/edit.html.twig');
     }
 
     /**

--- a/src/Form/CalendarForm.php
+++ b/src/Form/CalendarForm.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Form;
+
+use App\Form\Type\UserType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class CalendarForm extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder->add('user', UserType::class, [
+            'required' => false,
+            'attr' => ['onchange' => 'this.form.submit()']
+        ]);
+    }
+
+    public function configureOptions(OptionsResolver $resolver): void
+    {
+        $resolver->setDefaults([
+            'csrf_protection' => false,
+            'method' => 'GET',
+        ]);
+    }
+}

--- a/src/Form/TimesheetPreCreateForm.php
+++ b/src/Form/TimesheetPreCreateForm.php
@@ -25,8 +25,8 @@ class TimesheetPreCreateForm extends AbstractType
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $this->addProject($builder, true);
-        $this->addActivity($builder);
+        $this->addProject($builder, true, null, null, ['required' => false]);
+        $this->addActivity($builder, null, null, ['required' => false]);
         $builder->add('description', DescriptionType::class, ['required' => false]);
         $builder->add('tags', TagsInputType::class, ['required' => false]);
         if ($options['include_user']) {
@@ -40,7 +40,7 @@ class TimesheetPreCreateForm extends AbstractType
             'csrf_protection' => false,
             'include_user' => false,
             'method' => 'GET',
-            'allow_extra_fields' => true,
+            'validation_groups' => ['none'] // otherwise the default timesheet validations would trigger
         ]);
     }
 }

--- a/src/Form/TimesheetPreCreateForm.php
+++ b/src/Form/TimesheetPreCreateForm.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Form;
+
+use App\Form\Type\DescriptionType;
+use App\Form\Type\TagsInputType;
+use App\Form\Type\UserType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+/**
+ * Values that are allowed to be pre-set via URL.
+ */
+class TimesheetPreCreateForm extends AbstractType
+{
+    use FormTrait;
+
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $this->addProject($builder, true);
+        $this->addActivity($builder);
+        $builder->add('description', DescriptionType::class, ['required' => false]);
+        $builder->add('tags', TagsInputType::class, ['required' => false]);
+        if ($options['include_user']) {
+            $builder->add('user', UserType::class, ['required' => false]);
+        }
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults([
+            'csrf_protection' => false,
+            'include_user' => false,
+            'method' => 'GET',
+            'allow_extra_fields' => true,
+        ]);
+    }
+}

--- a/src/Validator/Constraints/TimesheetZeroDurationValidator.php
+++ b/src/Validator/Constraints/TimesheetZeroDurationValidator.php
@@ -17,9 +17,6 @@ use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 final class TimesheetZeroDurationValidator extends ConstraintValidator
 {
-    /**
-     * @var SystemConfiguration
-     */
     private $configuration;
 
     public function __construct(SystemConfiguration $configuration)
@@ -45,7 +42,16 @@ final class TimesheetZeroDurationValidator extends ConstraintValidator
             return;
         }
 
-        if ($timesheet->getDuration() == 0) {
+        if ($timesheet->isRunning()) {
+            return;
+        }
+
+        $duration = 0;
+        if ($timesheet->getEnd() !== null && $timesheet->getBegin() !== null) {
+            $duration = $timesheet->getEnd()->getTimestamp() - $timesheet->getBegin()->getTimestamp();
+        }
+
+        if ($duration <= 0) {
             $this->context->buildViolation($constraint->message)
                 ->atPath('duration')
                 ->setTranslationDomain('validators')

--- a/templates/calendar/user.html.twig
+++ b/templates/calendar/user.html.twig
@@ -11,8 +11,17 @@
 {% block main %}
     <div class="row">
         {% set hasDragAndDrop = (config.dragDropAmount > 0 and dragAndDrop is not empty and (dragAndDrop|filter(s => s.entries|length > 0)|length > 0)) %}
-        {% if hasDragAndDrop %}
+        {% if hasDragAndDrop or form is not null %}
         <div class="hidden-xs col-sm-5 col-md-4 col-lg-3 no-print">
+            {% if form is not null %}
+                {% embed '@AdminLTE/Widgets/box-widget.html.twig' %}
+                    {% block box_body %}
+                        {{ form_start(form) }}
+                        {{ form_widget(form) }}
+                        {{ form_end(form) }}
+                    {% endblock %}
+                {% endembed %}
+            {% endif %}
             {% for source in dragAndDrop|filter(s => s.entries|length > 0) %}
                 {% embed '@AdminLTE/Widgets/box-widget.html.twig' %}
                     {% block box_title %}{{ source.title|trans }}{% endblock %}
@@ -58,6 +67,19 @@
 
 {% block javascripts %}
     {% set calendarSelector = '#timesheet_calendar' %}
+    {% set createParams = '' %}
+    {% set createRoute = 'timesheet_create' %}
+    {% set canDelete = is_granted('delete_own_timesheet') %}
+    {% set canCreate = is_granted('create_own_timesheet') %}
+    {% set canEdit = is_granted('edit_own_timesheet') %}
+    {% if user != app.user %}
+        {% set createParams = '&user=' ~ user.id %}
+        {% set createRoute = 'admin_timesheet_create' %}
+        {% set canDelete = is_granted('delete_other_timesheet') %}
+        {% set canCreate = is_granted('create_other_timesheet') %}
+        {% set canEdit = is_granted('edit_other_timesheet') %}
+    {% endif %}
+
     {{ parent() }}
     <script>
         activatePopover();
@@ -237,7 +259,7 @@
                 googleCalendarApiKey: '{{ google.apiKey }}',
                 {% endif %}
                 header    : {
-                    left  : 'prev,next today{% if is_granted('delete_own_timesheet') %} deleteButton{% endif %}',
+                    left  : 'prev,next today{% if canDelete %} deleteButton{% endif %}',
                     center: 'title',
                     right : 'month,agendaWeek,agendaDay'
                 },
@@ -347,7 +369,7 @@
                         events: function(start, end, timezone, callback) {
                             let from = moment(start.format()).format(moment.HTML5_FMT.DATETIME_LOCAL_SECONDS);
                             let to = moment(end.format()).format(moment.HTML5_FMT.DATETIME_LOCAL_SECONDS);
-                            API.get('{{ path('get_timesheets') }}?size=1000&full=true&begin='+from+'&end='+to, {}, function(result) {
+                            API.get('{{ path('get_timesheets') }}?user={{ user.id }}&size=1000&full=true&begin='+from+'&end='+to, {}, function(result) {
                                 let apiEvents = [];
                                 for (const record of result) {
                                     apiEvents.push(convertApiTimesheetToCalendar(record));
@@ -436,7 +458,7 @@
                     $element.data('ids', event.id + ' ' + ids);
                     $element.text(DATES.formatSeconds(duration));
                 },
-                {% if not is_punch_mode and is_granted('create_own_timesheet') %}
+                {% if not is_punch_mode and canCreate %}
                     dayClick: function(date, jsEvent, view) {
                         {#
                            Day-clicks are always triggered, unless a selection was created.
@@ -447,7 +469,7 @@
                             return;
                         }
 
-                        let createUrl = '{{ path('timesheet_create') }}?begin=' + date.format();
+                        let createUrl = '{{ path(createRoute) }}?begin=' + date.format() + '{{ createParams|raw }}';
                         kimai.getPlugin('modal').openUrlInModal(createUrl);
                     },
                     selectable: true,
@@ -459,11 +481,11 @@
                             #}
                             return;
                         }
-                        let createUrl = '{{ path('timesheet_create') }}' + '?from=' + start.format() + '&to=' + end.format();
+                        let createUrl = '{{ path(createRoute) }}' + '?from=' + start.format() + '&to=' + end.format() + '{{ createParams|raw }}';
                         kimai.getPlugin('modal').openUrlInModal(createUrl);
                     },
                 {% endif %}
-                {% if is_granted('edit_own_timesheet') %}
+                {% if canEdit %}
                     eventClick: function(eventObj, jsEvent, view) {
                         if (eventObj.source.ajaxSettings !== undefined) {
                             jsEvent.preventDefault();
@@ -479,7 +501,7 @@
                         },
                         eventDragStop: function(event, jsEvent, ui, view) {
                             activatePopover();
-                            {% if is_granted('delete_own_timesheet') %}
+                            {% if canDelete %}
                                 var trash = jQuery('.fc-deleteButton-button');
                                 var offset = trash.offset();
 


### PR DESCRIPTION
## Description

Only activated if user has permission `view_other_timesheet`.
<img width="679" alt="Bildschirmfoto 2022-05-18 um 17 21 04" src="https://user-images.githubusercontent.com/533162/169082666-aa6eb1cf-5bd3-4741-a848-da501fe2c641.png">

Being able to manipulate other users timesheets requires permissions:
- `delete_other_timesheet`
- `create_other_timesheet`
- `edit_other_timesheet `

Fixes #1746
Fixes #1067

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [x] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
