### PR TITLE
Add css class for custom fields plugin item in timesheet list 

### DIFF
--- a/templates/timesheet/layout-listing.html.twig
+++ b/templates/timesheet/layout-listing.html.twig
@@ -37,7 +37,7 @@
 }) %}
 {% for field in metaColumns %}
     {% set columns = columns|merge({
-        ('mf_' ~ field.name): {'title': field.label|trans, 'class': 'hidden-xs hidden-sm', 'orderBy': false}
+        ('mf_' ~ field.name): {'title': field.label|trans, 'class': 'hidden-xs hidden-sm mf_' ~	field.name, 'orderBy': false}
     }) %}
 {% endfor %}
 {% if canSeeUsername %}


### PR DESCRIPTION
## Description
Adds css class for custom fields plugin (MetaFieldsBundle) item in timesheet list. 

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [ ] I verified that my code applies to the guidelines (`composer code-check`)
- [ ] I updated the documentation (see [here](https://github.com/kimai/www.kimai.org/tree/master/_documentation))
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
