### PR TITLE
added invoice text field to project and activity

### DIFF
--- a/src/Entity/Activity.php
+++ b/src/Entity/Activity.php
@@ -174,6 +174,12 @@ class Activity implements EntityWithMetaFields, EntityWithBudget
      * )
      */
     private $teams;
+    /**
+     * @var string|null
+     *
+     * @ORM\Column(name="invoice_text", type="text", nullable=true)
+     */
+    private $invoiceText;
 
     public function __construct()
     {
@@ -336,6 +342,16 @@ class Activity implements EntityWithMetaFields, EntityWithBudget
     public function getTeams(): Collection
     {
         return $this->teams;
+    }
+
+    public function getInvoiceText(): ?string
+    {
+        return $this->invoiceText;
+    }
+
+    public function setInvoiceText(?string $invoiceText): void
+    {
+        $this->invoiceText = $invoiceText;
     }
 
     /**

--- a/src/Entity/Project.php
+++ b/src/Entity/Project.php
@@ -246,6 +246,12 @@ class Project implements EntityWithMetaFields, EntityWithBudget
      * )
      */
     private $teams;
+    /**
+     * @var string|null
+     *
+     * @ORM\Column(name="invoice_text", type="text", nullable=true)
+     */
+    private $invoiceText;
 
     public function __construct()
     {
@@ -518,6 +524,16 @@ class Project implements EntityWithMetaFields, EntityWithBudget
         }
 
         return true;
+    }
+
+    public function getInvoiceText(): ?string
+    {
+        return $this->invoiceText;
+    }
+
+    public function setInvoiceText(?string $invoiceText): void
+    {
+        $this->invoiceText = $invoiceText;
     }
 
     /**

--- a/src/Form/ActivityEditForm.php
+++ b/src/Form/ActivityEditForm.php
@@ -60,6 +60,10 @@ class ActivityEditForm extends AbstractType
                 'label' => 'label.description',
                 'required' => false,
             ])
+            ->add('invoiceText', TextareaType::class, [
+                'label' => 'label.invoiceText',
+                'required' => false,
+            ])
         ;
 
         if ($new || !$isGlobal) {

--- a/src/Form/ProjectEditForm.php
+++ b/src/Form/ProjectEditForm.php
@@ -67,6 +67,10 @@ class ProjectEditForm extends AbstractType
                 'label' => 'label.description',
                 'required' => false,
             ])
+            ->add('invoiceText', TextareaType::class, [
+                'label' => 'label.invoiceText',
+                'required' => false,
+            ])
             ->add('orderNumber', TextType::class, [
                 'label' => 'label.orderNumber',
                 'required' => false,

--- a/src/Invoice/Calculator/ActivityInvoiceCalculator.php
+++ b/src/Invoice/Calculator/ActivityInvoiceCalculator.php
@@ -33,7 +33,11 @@ class ActivityInvoiceCalculator extends AbstractSumInvoiceCalculator implements 
             return;
         }
 
-        $invoiceItem->setDescription($entry->getActivity()->getName());
+        if ($entry->getActivity()->getInvoiceText() !== null) {
+            $invoiceItem->setDescription($entry->getActivity()->getInvoiceText());
+        } else {
+            $invoiceItem->setDescription($entry->getActivity()->getName());
+        }
     }
 
     /**

--- a/src/Invoice/Calculator/ProjectInvoiceCalculator.php
+++ b/src/Invoice/Calculator/ProjectInvoiceCalculator.php
@@ -29,8 +29,17 @@ class ProjectInvoiceCalculator extends AbstractSumInvoiceCalculator implements C
 
     protected function mergeSumInvoiceItem(InvoiceItem $invoiceItem, InvoiceItemInterface $entry)
     {
+        if (null === $entry->getActivity()) {
+            return;
+        }
+
         $invoiceItem->setProject($entry->getProject());
-        $invoiceItem->setDescription($entry->getProject()->getName());
+
+        if ($entry->getProject()->getInvoiceText() !== null) {
+            $invoiceItem->setDescription($entry->getProject()->getInvoiceText());
+        } else {
+            $invoiceItem->setDescription($entry->getProject()->getName());
+        }
     }
 
     /**

--- a/src/Migrations/Version20220531145920.php
+++ b/src/Migrations/Version20220531145920.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Kimai time-tracking app.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * @version 1.20.2
+ */
+final class Version20220531145920 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Add invoice text columns to project and activity';
+    }
+
+    public function up(Schema $schema): void
+    {
+        $activities = $schema->getTable('kimai2_activities');
+        $activities->addColumn('invoice_text', 'text', ['notnull' => false, 'default' => null]);
+
+        $projects = $schema->getTable('kimai2_projects');
+        $projects->addColumn('invoice_text', 'text', ['notnull' => false, 'default' => null]);
+    }
+
+    public function down(Schema $schema): void
+    {
+        $activities = $schema->getTable('kimai2_activities');
+        $activities->dropColumn('invoice_text');
+
+        $projects = $schema->getTable('kimai2_projects');
+        $projects->dropColumn('invoice_text');
+    }
+}

--- a/templates/activity/edit.html.twig
+++ b/templates/activity/edit.html.twig
@@ -41,6 +41,9 @@
                 </div>
             </div>
             {% endif %}
+            {% if form.invoiceText is defined %}
+                {{ form_row(form.invoiceText) }}
+            {% endif %}
             <div class="row">
                 <div class="col-md-6">
                     {{ form_row(form.visible) }}

--- a/templates/project/edit.html.twig
+++ b/templates/project/edit.html.twig
@@ -52,6 +52,9 @@
                 </div>
             </div>
             {% endif %}
+            {% if form.invoiceText is defined %}
+                {{ form_row(form.invoiceText) }}
+            {% endif %}
             <div class="row">
                 <div class="col-md-6">
                     {{ form_row(form.visible) }}

--- a/tests/Entity/ActivityTest.php
+++ b/tests/Entity/ActivityTest.php
@@ -31,6 +31,7 @@ class ActivityTest extends AbstractEntityTest
         $this->assertNull($sut->getProject());
         $this->assertNull($sut->getName());
         $this->assertNull($sut->getComment());
+        $this->assertNull($sut->getInvoiceText());
         $this->assertTrue($sut->isVisible());
         $this->assertTrue($sut->isBillable());
         $this->assertTrue($sut->isGlobal());
@@ -65,6 +66,9 @@ class ActivityTest extends AbstractEntityTest
 
         $this->assertInstanceOf(Activity::class, $sut->setComment('hello world'));
         $this->assertEquals('hello world', $sut->getComment());
+
+        $sut->setInvoiceText('very long invoice text comment 12324');
+        self::assertEquals('very long invoice text comment 12324', $sut->getInvoiceText());
 
         self::assertFalse($sut->hasColor());
         $sut->setColor('#fffccc');

--- a/tests/Entity/ProjectTest.php
+++ b/tests/Entity/ProjectTest.php
@@ -35,6 +35,7 @@ class ProjectTest extends AbstractEntityTest
         self::assertNull($sut->getStart());
         self::assertNull($sut->getEnd());
         self::assertNull($sut->getComment());
+        self::assertNull($sut->getInvoiceText());
         self::assertTrue($sut->isVisible());
         self::assertTrue($sut->isBillable());
         self::assertNull($sut->getColor());
@@ -85,6 +86,9 @@ class ProjectTest extends AbstractEntityTest
 
         self::assertInstanceOf(Project::class, $sut->setComment('a comment'));
         self::assertEquals('a comment', $sut->getComment());
+
+        $sut->setInvoiceText('very long invoice text comment 12324');
+        self::assertEquals('very long invoice text comment 12324', $sut->getInvoiceText());
 
         self::assertFalse($sut->hasColor());
         $sut->setColor('#fffccc');

--- a/translations/messages.de.xlf
+++ b/translations/messages.de.xlf
@@ -293,6 +293,10 @@
         <source>label.description</source>
         <target>Beschreibung</target>
       </trans-unit>
+      <trans-unit id="sdf4cEApe1" resname="label.invoiceText">
+        <source>label.invoiceText</source>
+        <target>Rechnungstext</target>
+      </trans-unit>
       <trans-unit id="ysOvPSq" resname="label.name">
         <source>label.name</source>
         <target>Name</target>

--- a/translations/messages.en.xlf
+++ b/translations/messages.en.xlf
@@ -293,6 +293,10 @@
         <source>label.description</source>
         <target>Description</target>
       </trans-unit>
+      <trans-unit id="sdf4cEApe1" resname="label.invoiceText">
+        <source>label.invoiceText</source>
+        <target>Invoice text</target>
+      </trans-unit>
       <trans-unit id="ysOvPSq" resname="label.name">
         <source>label.name</source>
         <target>Name</target>


### PR DESCRIPTION
## Description

new DB field which will be used instead of the entity name if the invoice-sum-calculator "project" or "activity" is used.

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
