### PR TITLE
fix en_GB format definition

### DIFF
--- a/config/packages/kimai.yaml
+++ b/config/packages/kimai.yaml
@@ -246,7 +246,7 @@ kimai:
             duration: '%%h:%%m h'
         en_GB:
             date_type: 'dd/MM/yyyy'
-            date: 'd-m-Y'
+            date: 'd/m/Y'
             date_time: 'd-m H:i'
         es:
             date_type: 'dd.MM.yyyy'


### PR DESCRIPTION
## Description

Inconsistent format definition did prevent to use dates in date range queries

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I verified that my code applies to the guidelines (`composer code-check`)
- [x] I agree that this code is used in Kimai and will be published under the [MIT license](https://github.com/kevinpapst/kimai2/blob/master/LICENSE)
